### PR TITLE
feat: add copilot-setup-steps.yml for Rust backend development

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -68,6 +68,8 @@ jobs:
         cat > .env << EOF
         DATABASE_URL=postgres://treasury_test:test_password@localhost:5433/treasury_test_db
         PORT=3000
+        PIKESPEAK_KEY=${{ secrets.PIKESPEAK_KEY }}
+        FASTNEAR_API_KEY=${{ secrets.FASTNEAR_API_KEY }}
         EOF
 
     - name: Install sqlx-cli


### PR DESCRIPTION
## Summary

- Add `.github/workflows/copilot-setup-steps.yml` to configure GitHub Copilot coding agent environment
- Set up PostgreSQL service container matching existing test database configuration
- Configure Rust toolchain with rustfmt and clippy
- Add cargo caching for faster builds
- Install sqlx-cli and run database migrations

This enables the Copilot coding agent to compile the Rust backend and run tests.

## Test plan

- [ ] Workflow runs automatically on this PR (validates the setup steps work)
- [ ] After merge, assign a task to Copilot requiring `cargo build` in `nt-be`
- [ ] Verify Copilot can run tests successfully

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)