### PR TITLE
docs: add root README and update monitoring interval to seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Treasury26
+
+A comprehensive treasury management platform for NEAR DAOs. Manage members, process payments, create vesting schedules, track balances, and handle multi-signature approvals through Sputnik DAO integration.
+
+## Project Structure
+
+| Directory | Description | Documentation |
+|-----------|-------------|---------------|
+| [nt-be](./nt-be/) | Backend API (Rust/Axum) - Balance tracking, monitoring, CSV export | [README](./nt-be/README.md) |
+| [nt-fe](./nt-fe/) | Frontend (Next.js) - Web interface for treasury management | [README](./nt-fe/README.md) |
+| [contracts](./contracts/) | NEAR smart contracts for bulk payments | [README](./contracts/README.md) |
+| [sandbox](./sandbox/) | Local development environment with Docker | [README](./sandbox/README.md) |
+| [e2e-tests](./e2e-tests/) | End-to-end tests for contract integration | [README](./e2e-tests/bulk-payment/README.md) |
+
+## Quick Links
+
+- **Production Backend**: https://near-treasury-backend.onrender.com
+- **Add Account for Tracking**: See [nt-be/README.md](./nt-be/README.md#1-register-an-account-for-monitoring)
+
+## Features
+
+### Treasury Management
+- Create and configure treasuries with custom policies
+- Member management with role-based permissions (proposer, approver, financial member)
+- Dashboard with total balance overview and USD valuations
+
+### Financial Operations
+- Single and bulk payments in NEAR, NEP-141 tokens, and cross-chain via Intents
+- Token vesting schedules with cliff dates and configurable release
+- Automatic balance tracking and historical charts
+- CSV export of transaction history
+
+### DAO Integration
+- Sputnik DAO proposal creation and management
+- Multi-signature approval workflows
+- Proposal filtering by status, token type, date, and participants
+
+### Balance Monitoring
+- Register accounts for automatic balance tracking
+- Real-time balance change detection across multiple token types
+- Staking rewards tracking
+- Historical balance data with gap-filling
+
+### Smart Contracts
+- Bulk payment processing (up to 100 payments per batch)
+- Storage credit system for batch operations
+- Content-addressed payment lists (SHA-256)
+- Support for NEAR, fungible tokens, and NEAR Intents
+
+## Development
+
+See individual README files for setup instructions:
+
+- Backend: [nt-be/README.md](./nt-be/README.md)
+- Frontend: [nt-fe/README.md](./nt-fe/README.md)
+- Contracts: [contracts/README.md](./contracts/README.md)
+- Local sandbox: [sandbox/README.md](./sandbox/README.md)

--- a/nt-be/README.md
+++ b/nt-be/README.md
@@ -11,6 +11,17 @@ The Balance Change Collection system automatically tracks balance changes for NE
 
 ### 1. Register an Account for Monitoring
 
+**Production** (https://near-treasury-backend.onrender.com):
+```bash
+curl -X POST https://near-treasury-backend.onrender.com/api/monitored-accounts \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account_id": "your-treasury.sputnik-dao.near",
+    "enabled": true
+  }'
+```
+
+**Local development**:
 ```bash
 curl -X POST http://localhost:3000/api/monitored-accounts \
   -H "Content-Type: application/json" \

--- a/nt-be/src/main.rs
+++ b/nt-be/src/main.rs
@@ -29,18 +29,18 @@ async fn main() {
             use near_api::Chain;
             use nt_be::handlers::balance_changes::account_monitor::run_monitor_cycle;
 
-            let interval_minutes = state_clone.env_vars.monitor_interval_minutes;
+            let interval_seconds = state_clone.env_vars.monitor_interval_seconds;
 
-            if interval_minutes == 0 {
-                log::info!("Background monitoring disabled (MONITOR_INTERVAL_MINUTES=0)");
+            if interval_seconds == 0 {
+                log::info!("Background monitoring disabled (MONITOR_INTERVAL_SECONDS=0)");
                 return;
             }
 
-            let interval = Duration::from_secs(interval_minutes * 60);
+            let interval = Duration::from_secs(interval_seconds);
 
             log::info!(
-                "Starting background monitoring service (interval: {} minutes)",
-                interval_minutes
+                "Starting background monitoring service (interval: {} seconds)",
+                interval_seconds
             );
 
             // Wait a bit before first run to let server fully start
@@ -59,7 +59,7 @@ async fn main() {
                     Ok(block) => block.header.height as i64,
                     Err(e) => {
                         log::error!("Failed to get current block height: {}", e);
-                        log::info!("Retrying in {} minutes", interval_minutes);
+                        log::info!("Retrying in {} seconds", interval_seconds);
                         continue;
                     }
                 };
@@ -81,7 +81,7 @@ async fn main() {
                     }
                 }
 
-                log::info!("Next monitoring cycle in {} minutes", interval_minutes);
+                log::info!("Next monitoring cycle in {} seconds", interval_seconds);
             }
         });
     }

--- a/nt-be/src/utils/env.rs
+++ b/nt-be/src/utils/env.rs
@@ -15,7 +15,7 @@ pub struct EnvVars {
     pub signer_id: AccountId,
     pub disable_balance_monitoring: bool,
     pub disable_treasury_creation: bool,
-    pub monitor_interval_minutes: u64,
+    pub monitor_interval_seconds: u64,
     pub telegram_bot_token: Option<String>,
     pub telegram_chat_id: Option<String>,
     pub coingecko_api_key: Option<String>,
@@ -67,10 +67,10 @@ impl Default for EnvVars {
                 .unwrap_or_else(|_| "false".to_string())
                 .parse()
                 .unwrap_or(false),
-            monitor_interval_minutes: std::env::var("MONITOR_INTERVAL_MINUTES")
+            monitor_interval_seconds: std::env::var("MONITOR_INTERVAL_SECONDS")
                 .ok()
                 .and_then(|s| s.parse().ok())
-                .unwrap_or(5),
+                .unwrap_or(30),
             coingecko_api_key: std::env::var("COINGECKO_API_KEY")
                 .ok()
                 .filter(|s| !s.is_empty()),

--- a/nt-be/tests/common/mod.rs
+++ b/nt-be/tests/common/mod.rs
@@ -65,7 +65,7 @@ impl TestServer {
             .args(["run", "--bin", "nt-be"])
             .env("PORT", "3001")
             .env("RUST_LOG", "info")
-            .env("MONITOR_INTERVAL_MINUTES", "0") // Disable background monitoring
+            .env("MONITOR_INTERVAL_SECONDS", "0") // Disable background monitoring
             .env("DATABASE_URL", &db_url) // Override with test database
             .env(
                 "SIGNER_KEY",


### PR DESCRIPTION
## Summary
- Add root README.md with project overview, feature list, and links to component READMEs
- Add production URL example (`https://near-treasury-backend.onrender.com`) for account registration in nt-be README
- Change monitoring interval configuration from minutes to seconds with 30-second default
- Rename `MONITOR_INTERVAL_MINUTES` env var to `MONITOR_INTERVAL_SECONDS`

## Test plan
- [x] Verify root README renders correctly and links work
- [x] Verify nt-be README shows both production and local examples
- [x] Verify backend compiles with `cargo check`
- [x] Verify monitoring starts with 30-second interval by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)