### PR TITLE
fix: remove legacy near:total records

### DIFF
--- a/nt-be/migrations/20260217000001_delete_near_total_records.sql
+++ b/nt-be/migrations/20260217000001_delete_near_total_records.sql
@@ -1,0 +1,7 @@
+-- Remove legacy near:total records.
+-- These were created by migration 20260204000001 which renamed near → near:total.
+-- near:total is a synthetic aggregate (liquid NEAR + staked) that is:
+--   - not queryable via RPC (contains invalid ':' character)
+--   - excluded from all API output
+--   - redundant since near and staking:* are tracked separately
+DELETE FROM balance_changes WHERE token_id = 'near:total';

--- a/nt-be/src/handlers/balance_changes/query_builder.rs
+++ b/nt-be/src/handlers/balance_changes/query_builder.rs
@@ -32,7 +32,6 @@ pub fn build_where_conditions(filters: &BalanceChangeFilters) -> (Vec<String>, u
         "counterparty != 'SNAPSHOT'".to_string(),
         "counterparty != 'STAKING_SNAPSHOT'".to_string(),
         "counterparty != 'NOT_REGISTERED'".to_string(),
-        "token_id != 'near:total'".to_string(), // Exclude internal aggregate token
         // Exclude swap deposit legs - these are shown as part of the swap fulfillment
         format!(
             "id NOT IN (SELECT deposit_balance_change_id FROM detected_swaps WHERE account_id = $1 AND deposit_balance_change_id IS NOT NULL)"
@@ -179,7 +178,7 @@ mod tests {
 
         let (conditions, param_index) = build_where_conditions(&filters);
 
-        assert_eq!(conditions.len(), 6); // Base conditions: account_id, 3x counterparty filters, near:total filter, swap deposit exclusion subquery
+        assert_eq!(conditions.len(), 5); // Base conditions: account_id, 3x counterparty filters, swap deposit exclusion subquery
         assert_eq!(param_index, 2);
     }
 
@@ -199,7 +198,7 @@ mod tests {
 
         let (conditions, param_index) = build_where_conditions(&filters);
 
-        assert_eq!(conditions.len(), 9); // Base (6) + date (1) + token (1) + txn_type (1)
+        assert_eq!(conditions.len(), 8); // Base (5) + date (1) + token (1) + txn_type (1)
         assert_eq!(param_index, 4); // 1 (account_id) + 1 (date) + 1 (tokens) + starts at 2
         assert!(conditions.contains(&"block_time >= $2".to_string()));
         assert!(conditions.iter().any(|c| c.contains("token_id = ANY($3)")));

--- a/nt-be/tests/dirty_monitor_e2e_test.rs
+++ b/nt-be/tests/dirty_monitor_e2e_test.rs
@@ -51,8 +51,7 @@ const BASELINE_BLOCK_TIMESTAMP: i64 = 1_770_076_800_000_000_000;
 
 /// Token snapshots from https://api.trezu.app/api/balance-changes
 /// Balances at or before BASELINE_BLOCK for webassemblymusic-treasury.sputnik-dao.near
-/// Note: `near` is seeded via insert_snapshot_record (needs real on-chain balance),
-///       `near:total` is excluded (computed value, not gap-fillable)
+/// Note: `near` is seeded via insert_snapshot_record (needs real on-chain balance)
 const TREASURY_TOKEN_SNAPSHOTS: &[(&str, &str)] = &[
     (
         "staking:astro-stakers.poolv1.near",
@@ -90,7 +89,7 @@ const TREASURY_TOKEN_SNAPSHOTS: &[(&str, &str)] = &[
 ];
 
 /// Token snapshots for testing-astradao.sputnik-dao.near
-/// Note: `near` and `near:total` excluded (same reason as above)
+/// Note: `near` excluded (same reason as above)
 const STAKING_TOKEN_SNAPSHOTS: &[(&str, &str)] = &[
     ("staking:figment.poolv1.near", "0.100003532026647260349538"),
     (


### PR DESCRIPTION
## Summary
- Adds migration to delete all `near:total` balance_changes records from the database
- Removes the `token_id != 'near:total'` exclusion filter from the query builder (no longer needed)
- Cleans up related test comments

## Context
Migration `20260204000001` renamed `near` → `near:total` to make room for liquid-only NEAR tracking. Since `near` and `staking:*` are now tracked separately, `near:total` is redundant and causes errors in the monitor cycle because `:` is an invalid character in a NEAR account ID — the gap filler attempts RPC calls that always fail.

## Test plan
- [x] Query builder unit tests pass with updated condition counts
- [x] Verify migration runs cleanly on CI
- [ ] Verify monitor cycle no longer logs `near:total` errors

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)