### PR TITLE
fix: add bluetooth permission for Ledger Nano X BLE

### DIFF
--- a/nt-fe/lib/wallet-manifests.ts
+++ b/nt-fe/lib/wallet-manifests.ts
@@ -28,6 +28,7 @@ export const ledgerWalletManifest = {
         storage: true,
         usb: true, // Required for Ledger USB
         hid: true, // Required for WebHID protocol
+        bluetooth: true, // Required for Ledger Nano X Bluetooth
         allowsOpen: [],
     },
 };

--- a/nt-fe/stores/near-store.ts
+++ b/nt-fe/stores/near-store.ts
@@ -32,6 +32,34 @@ import {
     estimateVoteStorage,
 } from "@/lib/sputnik-storage";
 
+/**
+ * Ensures sandboxed iframes get bluetooth permission for Ledger Nano X BLE.
+ * @hot-labs/near-connect doesn't yet include bluetooth in iframe allow attributes,
+ * so we patch it via MutationObserver when iframes are added to the DOM.
+ */
+function ensureBluetoothIframePermission() {
+    if (typeof document === "undefined") return;
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (
+                    node instanceof HTMLIFrameElement &&
+                    node.getAttribute("sandbox")?.includes("allow-scripts")
+                ) {
+                    const allow = node.getAttribute("allow") || "";
+                    if (!allow.includes("bluetooth")) {
+                        node.setAttribute(
+                            "allow",
+                            allow + (allow ? " " : "") + "bluetooth *;",
+                        );
+                    }
+                }
+            }
+        }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+}
+
 // Fallbacks if WASM estimator fails to load
 const FALLBACK_PROPOSAL_STORAGE_BYTES = Big(500);
 const FALLBACK_VOTE_STORAGE_BYTES = Big(100);
@@ -125,6 +153,8 @@ export const useNearStore = create<NearStore>((set, get) => ({
         }
 
         let newConnector = null;
+
+        ensureBluetoothIframePermission();
 
         try {
             newConnector = new NearConnector({


### PR DESCRIPTION
## Summary
- `@hot-labs/near-connect` doesn't include `bluetooth` in the sandboxed iframe's `allow` attribute, causing a Permissions Policy violation when connecting a Ledger Nano X via Bluetooth
- Added a `MutationObserver` in `near-store.ts` that injects `bluetooth *;` into the iframe's `allow` attribute when the library creates it
- Added `bluetooth: true` to the Ledger wallet manifest permissions for future library compatibility

## Test plan
- [ ] Connect Ledger Nano X via Bluetooth — should show "Approve on Ledger" instead of "Connection Failed"
- [ ] Connect Ledger via USB (WebHID) — should still work as before
- [ ] Meteor wallet — should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)