### PR TITLE
fix: prevent chart tooltip from disappearing on auto-refresh

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -1,5 +1,5 @@
 import { TreasuryAsset } from "@/lib/api";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback, useRef } from "react";
 import BalanceChart from "./chart";
 import { Button } from "@/components/button";
 import {
@@ -97,7 +97,13 @@ export default function BalanceWithGraph({
     const { treasuryId } = useTreasury();
     const [selectedToken, setSelectedToken] = useState<string>("all");
     const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>("1W");
+    const [isChartHovered, setIsChartHovered] = useState(false);
     const router = useRouter();
+    const handleChartMouseEnter = useCallback(() => setIsChartHovered(true), []);
+    const handleChartMouseLeave = useCallback(
+        () => setIsChartHovered(false),
+        [],
+    );
     // Group tokens by symbol (to handle same token on different networks)
     const groupedTokens = useMemo(() => {
         const grouped = new Map<string, GroupedToken>();
@@ -201,8 +207,19 @@ export default function BalanceWithGraph({
         return params;
     }, [treasuryId, selectedPeriod, selectedTokenGroup]);
 
+    // Freeze chartParams while hovering so that parent re-renders (from other
+    // queries like useAssets) don't change the query key, which would flip
+    // isLoading to true and unmount the chart — destroying the tooltip.
+    const frozenChartParams = useRef(chartParams);
+    if (!isChartHovered) {
+        frozenChartParams.current = chartParams;
+    }
+
     // Fetch balance chart data with USD values
-    const { data: balanceChartData, isLoading } = useBalanceChart(chartParams);
+    const { data: balanceChartData, isLoading } = useBalanceChart(
+        frozenChartParams.current,
+        { pauseRefetch: isChartHovered },
+    );
 
     // Transform chart data for display
     const chartData = useMemo(() => {
@@ -324,6 +341,14 @@ export default function BalanceWithGraph({
         selectedPeriod,
         totalBalanceUSD,
     ]);
+
+    // Freeze chart data while hovering so tooltip isn't lost when parent
+    // re-renders due to other queries (e.g. token balance) refetching.
+    const frozenChartData = useRef(chartData);
+    if (!isChartHovered) {
+        frozenChartData.current = chartData;
+    }
+    const displayChartData = frozenChartData.current;
 
     if (isLoadingTokens) {
         return (
@@ -547,8 +572,10 @@ export default function BalanceWithGraph({
                 </div>
             ) : (
                 <BalanceChart
-                    data={chartData.data}
+                    data={displayChartData.data}
                     symbol={selectedTokenGroup?.symbol}
+                    onMouseEnter={handleChartMouseEnter}
+                    onMouseLeave={handleChartMouseLeave}
                 />
             )}
         </PageCard>

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/chart.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/chart.tsx
@@ -20,6 +20,8 @@ interface ChartDataPoint {
 interface BalanceChartProps {
     data?: ChartDataPoint[];
     symbol?: string;
+    onMouseEnter?: () => void;
+    onMouseLeave?: () => void;
 }
 
 const chartConfig = {
@@ -33,7 +35,12 @@ const chartConfig = {
     },
 } satisfies ChartConfig;
 
-export default function BalanceChart({ data = [], symbol }: BalanceChartProps) {
+export default function BalanceChart({
+    data = [],
+    symbol,
+    onMouseEnter,
+    onMouseLeave,
+}: BalanceChartProps) {
     if (data.length === 0) {
         return (
             <div className="h-[180px]">
@@ -63,7 +70,12 @@ export default function BalanceChart({ data = [], symbol }: BalanceChartProps) {
     const tickInterval = calculateInterval(data.length);
 
     return (
-        <ChartContainer config={chartConfig} className="h-56">
+        <ChartContainer
+            config={chartConfig}
+            className="h-56"
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+        >
             <AreaChart data={data}>
                 <defs>
                     <linearGradient

--- a/nt-fe/e2e/chart-tooltip-hover.spec.ts
+++ b/nt-fe/e2e/chart-tooltip-hover.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect, Page, Route } from "@playwright/test";
+import FINAL_ASSETS from "./fixtures/assets.json";
+
+const TREASURY_ID = "webassemblymusic-treasury.sputnik-dao.near";
+const DASHBOARD_URL = `/${TREASURY_ID}`;
+const BACKEND_URL =
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_BACKEND_API_BASE ||
+    "http://localhost:8080";
+
+test.use({ locale: "en-US" });
+
+test.beforeAll(async () => {
+    const res = await fetch(`${BACKEND_URL}/api/treasury/create`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            name: "WebAssembly Music Treasury",
+            accountId: TREASURY_ID,
+            paymentThreshold: 1,
+            governors: ["test.near"],
+            financiers: ["test.near"],
+            requestors: ["test.near"],
+        }),
+    });
+    if (res.ok) {
+        console.log(`Created DAO ${TREASURY_ID} in sandbox`);
+    } else {
+        console.log(
+            `DAO creation returned ${res.status} (may already exist)`,
+        );
+    }
+});
+
+const MONITORED_ACCOUNTS_RESPONSE = {
+    accountId: TREASURY_ID,
+    enabled: true,
+    lastSyncedAt: "2026-02-18T10:00:00Z",
+    createdAt: "2026-01-27T16:47:58.759890Z",
+    updatedAt: "2026-02-18T10:00:00Z",
+    exportCredits: 5,
+    batchPaymentCredits: 10,
+    planType: "plus",
+    creditsResetAt: "2026-03-01T00:00:00Z",
+    dirtyAt: "2026-02-18T10:00:00Z",
+    isNewRegistration: false,
+};
+
+/**
+ * Set up mocks that simulate real-world conditions:
+ * - Assets endpoint returns slightly different balances on each refetch
+ *   (simulating price/balance fluctuations every 5s)
+ * - This causes parent re-renders that change totalBalanceUSD and tokens,
+ *   which was the root cause of the tooltip disappearing.
+ */
+async function setupMocks(page: Page) {
+    let chartFetchCount = 0;
+    let assetsFetchCount = 0;
+
+    await page.route("**/api/monitored-accounts", async (route: Route) => {
+        const method = route.request().method();
+        if (method === "POST") {
+            await route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify(MONITORED_ACCOUNTS_RESPONSE),
+            });
+        } else if (method === "OPTIONS") {
+            await route.fulfill({ status: 200 });
+        } else {
+            await route.continue();
+        }
+    });
+
+    // Return slightly different NEAR balance on each fetch to simulate
+    // real-world balance fluctuations from useAssets refetchInterval.
+    await page.route("**/api/user/assets*", async (route: Route) => {
+        assetsFetchCount++;
+        const assets = JSON.parse(JSON.stringify(FINAL_ASSETS));
+        // Find the standard NEAR token and tweak its balance
+        const nearToken = assets.find(
+            (a: any) => a.id === "near" && a.residency === "Near",
+        );
+        if (nearToken?.balance?.Standard) {
+            const base = BigInt(nearToken.balance.Standard.total);
+            // Add a small increment on each fetch (0.001 NEAR per fetch)
+            const increment =
+                BigInt(assetsFetchCount) * BigInt("1000000000000000000000");
+            nearToken.balance.Standard.total = (base + increment).toString();
+        }
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(assets),
+        });
+    });
+
+    await page.route("**/api/balance-history/chart*", async (route: Route) => {
+        chartFetchCount++;
+        const response: Record<string, any[]> = {
+            all: [
+                {
+                    timestamp: "2026-02-11T00:00:00Z",
+                    balance: "1000",
+                    valueUsd: 5000,
+                },
+                {
+                    timestamp: "2026-02-12T00:00:00Z",
+                    balance: "1010",
+                    valueUsd: 5100,
+                },
+                {
+                    timestamp: "2026-02-13T00:00:00Z",
+                    balance: "1020",
+                    valueUsd: 5200,
+                },
+                {
+                    timestamp: "2026-02-14T00:00:00Z",
+                    balance: "1030",
+                    valueUsd: 5300,
+                },
+                {
+                    timestamp: "2026-02-15T00:00:00Z",
+                    balance: "1040",
+                    valueUsd: 5400,
+                },
+                {
+                    timestamp: "2026-02-16T00:00:00Z",
+                    balance: "1050",
+                    valueUsd: 5500,
+                },
+                {
+                    timestamp: "2026-02-17T00:00:00Z",
+                    balance: "1060",
+                    valueUsd: 5600,
+                },
+            ],
+        };
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(response),
+        });
+    });
+
+    await page.route("**/api/recent-activity*", async (route: Route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({ data: [], total: 0 }),
+        });
+    });
+
+    return {
+        getChartFetchCount: () => chartFetchCount,
+        getAssetsFetchCount: () => assetsFetchCount,
+    };
+}
+
+test("chart tooltip remains visible while hovering during refetch interval", async ({
+    page,
+}) => {
+    test.setTimeout(60_000);
+
+    const { getChartFetchCount, getAssetsFetchCount } =
+        await setupMocks(page);
+
+    await page.goto(DASHBOARD_URL);
+
+    const chartContainer = page.locator("[data-slot='chart']").first();
+
+    // Wait for chart SVG to render
+    await chartContainer
+        .locator("svg")
+        .first()
+        .waitFor({ state: "visible", timeout: 15_000 });
+
+    // Let initial refetches happen before we start hovering
+    await page.waitForTimeout(2_000);
+    const fetchCountBeforeHover = getChartFetchCount();
+    const assetsFetchBeforeHover = getAssetsFetchCount();
+
+    // Hover over the chart to trigger tooltip
+    const box = await chartContainer.boundingBox();
+    expect(box).toBeTruthy();
+    await page.mouse.move(
+        box!.x + box!.width * 0.5,
+        box!.y + box!.height * 0.5,
+    );
+
+    // Wait for tooltip to appear
+    const tooltip = chartContainer.locator(".recharts-tooltip-wrapper");
+    await expect(tooltip).toBeVisible({ timeout: 5_000 });
+
+    // Wait longer than the 5-second refetch interval while still hovering.
+    // During this time, useAssets refetches with changing data, which causes
+    // parent re-renders with new totalBalanceUSD — the original cause of
+    // tooltip disappearing.
+    await page.waitForTimeout(8_000);
+
+    // Verify that assets DID refetch during hover (confirming the test
+    // exercises the real-world scenario of parent re-renders).
+    const assetsFetchAfterHover = getAssetsFetchCount();
+    expect(assetsFetchAfterHover).toBeGreaterThan(assetsFetchBeforeHover);
+
+    // Tooltip should still be visible — this is the core assertion.
+    await expect(tooltip).toBeVisible();
+
+    // Verify that no additional chart fetches occurred while hovering
+    const fetchCountAfterHover = getChartFetchCount();
+    expect(fetchCountAfterHover).toBe(fetchCountBeforeHover);
+
+    // Move mouse away from chart
+    await page.mouse.move(0, 0);
+
+    // After un-hovering, refetch should resume — wait for at least one more fetch
+    await expect
+        .poll(() => getChartFetchCount(), { timeout: 10_000 })
+        .toBeGreaterThan(fetchCountAfterHover);
+});

--- a/nt-fe/hooks/use-treasury-queries.ts
+++ b/nt-fe/hooks/use-treasury-queries.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import {
     getUserTreasuries,
     getTreasuryConfig,
@@ -69,7 +69,10 @@ export function useTreasuryConfig(
  * Fetches historical balance snapshots at specified intervals
  * Supports filtering by specific tokens or all tokens
  */
-export function useBalanceChart(params: BalanceChartRequest | null) {
+export function useBalanceChart(
+    params: BalanceChartRequest | null,
+    options?: { pauseRefetch?: boolean },
+) {
     return useQuery({
         queryKey: [
             "balanceChart",
@@ -82,7 +85,8 @@ export function useBalanceChart(params: BalanceChartRequest | null) {
         queryFn: () => getBalanceChart(params!),
         enabled: !!params?.accountId,
         staleTime: 1000 * 5, // 5 seconds (balance chart changes frequently)
-        refetchInterval: 1000 * 5, // Refetch every 5 seconds
+        refetchInterval: options?.pauseRefetch ? false : 1000 * 5, // Pause refetch on hover to preserve tooltip
+        placeholderData: keepPreviousData, // Show previous data while fetching new query key to avoid loading flicker
     });
 }
 


### PR DESCRIPTION
## Summary

- Freezes `chartParams` and `chartData` via `useRef` while the user hovers over the balance chart, preventing the tooltip from being destroyed by parent re-renders caused by `useAssets` refetching every 5 seconds
- Adds `placeholderData: keepPreviousData` to `useBalanceChart` as a safety net against loading state flicker on query key changes
- Pauses `refetchInterval` on `useBalanceChart` during hover

**Root cause:** `useAssets` refetches every 5s → new `tokens` prop → `groupedTokens` recalculates → `selectedTokenGroup` gets a new object reference → `chartParams` recalculates with a new `endTime` → query key changes → `isLoading` flips to `true` → chart unmounts (replaced by skeleton) → tooltip state destroyed.

## Test plan

- [x] Hover over the balance chart with a specific token selected (e.g. NEAR) — tooltip should remain visible indefinitely while hovering
- [x] After moving mouse away, chart should resume refetching normally
- [x] Playwright e2e test (`e2e/chart-tooltip-hover.spec.ts`) simulates changing asset data on each refetch and verifies tooltip survives

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)