### PR TITLE
fix: check list approval status before calling payout_batch

### DIFF
--- a/nt-be/src/handlers/bulkpayment/worker.rs
+++ b/nt-be/src/handlers/bulkpayment/worker.rs
@@ -30,7 +30,10 @@ impl PaymentListStatus {
             PaymentListStatus::Simple(s) if s == "Approved"
         ) || matches!(
             self,
-            PaymentListStatus::Enum { Approved: Some(_), .. }
+            PaymentListStatus::Enum {
+                Approved: Some(_),
+                ..
+            }
         )
     }
 
@@ -40,7 +43,10 @@ impl PaymentListStatus {
             PaymentListStatus::Simple(s) if s == "Pending"
         ) || matches!(
             self,
-            PaymentListStatus::Enum { Pending: Some(_), .. }
+            PaymentListStatus::Enum {
+                Pending: Some(_),
+                ..
+            }
         )
     }
 }
@@ -156,9 +162,7 @@ pub async fn query_and_process_pending_lists(
                 log::error!("Failed to process batch for list {}: {}", list_id, err_str);
 
                 // Remove list from tracking if it's not found or completed
-                if err_str.contains("not found")
-                    || err_str.contains("No pending payments")
-                {
+                if err_str.contains("not found") || err_str.contains("No pending payments") {
                     log::info!("Removing list {} from worker queue", list_id);
                     completed_lists.push(list_id.clone());
                 }


### PR DESCRIPTION
## Summary
- The bulk payment worker was calling `payout_batch` for every list in its queue without checking if the list was approved, causing many failed transactions for pending/rejected lists
- Added a `view_list` call (free read-only RPC) before `payout_batch` to check list status: only approved lists proceed, pending lists are skipped, and rejected/not-found lists are removed from the queue
- Removed the spurious `caller_id` parameter from the `payout_batch` call (the contract method only takes `list_id`)

## Test plan
- [ ] Verify `cargo check` passes (confirmed locally, single expected warning for unused `Rejected` field)
- [ ] Deploy and observe that pending (unapproved) lists no longer produce failed transactions
- [ ] Confirm approved lists still process correctly via `payout_batch`
- [ ] Confirm rejected/not-found lists are correctly removed from the worker queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)