### PR TITLE
fix: resolve bulk payment tx hash via receipt tracing

### DIFF
--- a/nt-be/src/handlers/bulkpayment/transactions.rs
+++ b/nt-be/src/handlers/bulkpayment/transactions.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use crate::{
     AppState,
     handlers::balance_changes::transfer_hints::tx_resolver::resolve_receipt_to_transaction,
+    handlers::balance_changes::utils::with_transport_retry,
     utils::cache::{CacheKey, CacheTier},
     utils::jsonrpc::create_rpc_client,
 };
@@ -363,17 +364,17 @@ async fn lookup_transaction_hash(
     let parsed_contract: near_primitives::types::AccountId = contract_id.parse()?;
 
     // Find receipt IDs from account changes on the contract at this block
-    let changes_response = client
-        .call(
-            methods::EXPERIMENTAL_changes::RpcStateChangesInBlockByTypeRequest {
-                block_reference: BlockReference::BlockId(BlockId::Height(block_height)),
-                state_changes_request:
-                    near_primitives::views::StateChangesRequestView::AccountChanges {
-                        account_ids: vec![parsed_contract],
-                    },
-            },
-        )
-        .await?;
+    let changes_response = with_transport_retry("lookup_tx_hash_changes", || {
+        let req = methods::EXPERIMENTAL_changes::RpcStateChangesInBlockByTypeRequest {
+            block_reference: BlockReference::BlockId(BlockId::Height(block_height)),
+            state_changes_request:
+                near_primitives::views::StateChangesRequestView::AccountChanges {
+                    account_ids: vec![parsed_contract.clone()],
+                },
+        };
+        client.call(req)
+    })
+    .await?;
 
     // Check for TransactionProcessing first — if the transaction was sent
     // directly to the contract, the tx hash is immediately available.


### PR DESCRIPTION
## Summary
- Fixed bulk payment transaction hash lookup failing with "No transaction found in block" error
- The `block_height` stored by the contract is where the **receipt** executed, not where the originating **transaction** was included — these can be different blocks on NEAR
- Replaced chunk-scanning approach with the existing `resolve_receipt_to_transaction` infrastructure that uses `EXPERIMENTAL_changes` and `EXPERIMENTAL_tx_status` to properly trace receipts back to their originating transaction

## Test plan
- [x] Verified locally: `/api/bulk-payment/list/b2e7a99a6b2e78a41c707a0a59400e91695b3c491c22e1b0365d8b0c4e64b996/transaction/megha19.near` now returns `{"success":true,"transactionHash":"6GA6TzTPaGSkbbowgVuL3SH7KKaYcz79ZWetdCLjBgMc","blockHeight":186247356}`
- [ ] Verify other bulk payment transaction lookups still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)