### PR TITLE
Exclude zero-change records from balance change queries

### DIFF
--- a/nt-be/src/handlers/balance_changes/query_builder.rs
+++ b/nt-be/src/handlers/balance_changes/query_builder.rs
@@ -41,6 +41,8 @@ pub fn build_where_conditions(filters: &BalanceChangeFilters) -> (Vec<String>, u
         "counterparty != 'SNAPSHOT'".to_string(),
         "counterparty != 'STAKING_SNAPSHOT'".to_string(),
         "counterparty != 'NOT_REGISTERED'".to_string(),
+        // Exclude zero-change records (internal gap-filler bookkeeping)
+        "(amount != 0 OR balance_before != balance_after)".to_string(),
         "(action_kind IS NULL OR action_kind != 'CreateAccount')".to_string(),
         RELAYER_WHERE_CONDITION.to_string(),
         // Exclude swap deposit legs - these are shown as part of the swap fulfillment
@@ -195,7 +197,7 @@ mod tests {
 
         let (conditions, param_index) = build_where_conditions(&filters);
 
-        assert_eq!(conditions.len(), 7); // Base conditions: account_id, SNAPSHOT, STAKING_SNAPSHOT, NOT_REGISTERED, CreateAccount, relayer, swap deposit exclusion
+        assert_eq!(conditions.len(), 8); // Base conditions: account_id, SNAPSHOT, STAKING_SNAPSHOT, NOT_REGISTERED, zero-change, CreateAccount, relayer, swap deposit exclusion
         assert_eq!(param_index, 2);
     }
 
@@ -216,7 +218,7 @@ mod tests {
 
         let (conditions, param_index) = build_where_conditions(&filters);
 
-        assert_eq!(conditions.len(), 10); // Base (7) + date (1) + token (1) + txn_type (1)
+        assert_eq!(conditions.len(), 11); // Base (8) + date (1) + token (1) + txn_type (1)
         assert_eq!(param_index, 4); // 1 (account_id) + 1 (date) + 1 (tokens) + starts at 2
         assert!(conditions.contains(&"block_time >= $2".to_string()));
         assert!(conditions.iter().any(|c| c.contains("token_id = ANY($3)")));


### PR DESCRIPTION
## Summary
This change filters out zero-change balance records from balance change queries by adding a condition that excludes records where both the amount is zero AND the balance hasn't changed. These records are internal gap-filler bookkeeping entries that should not be exposed to users.

## Key Changes
- Added a new WHERE condition `(amount != 0 OR balance_before != balance_after)` to filter out zero-change records
- Updated test assertions to reflect the new condition count (7 → 8 base conditions)
- Updated composite filter test to account for the additional base condition (10 → 11 total conditions)

## Implementation Details
The new condition uses an OR logic to ensure records are included if either:
- The amount is non-zero, OR
- The balance actually changed (balance_before differs from balance_after)

This effectively excludes internal bookkeeping entries that have zero amount and no balance change, while preserving legitimate balance change records.

https://claude.ai/code/session_01NY66fG1wGDQbYfBsisRh8T