### PR TITLE
fix: reinsert NEAR dust filter for recent activity

### DIFF
--- a/nt-be/src/handlers/balance_changes/history.rs
+++ b/nt-be/src/handlers/balance_changes/history.rs
@@ -1520,7 +1520,7 @@ pub async fn get_recent_activity(
         transaction_types: transaction_types_for_query.clone(),
         min_amount: None,
         max_amount: None,
-        exclude_near_dust: false,
+        exclude_near_dust: true,
     };
 
     // Count query
@@ -1572,7 +1572,7 @@ pub async fn get_recent_activity(
         max_amount: None,
         include_metadata: Some(true),
         include_prices: Some(true),
-        exclude_near_dust: false,
+        exclude_near_dust: true,
     };
 
     let enriched_changes = get_balance_changes_internal(&state, &balance_query)


### PR DESCRIPTION
## Summary
- Re-enables filtering of tiny NEAR balance changes (< 0.01 NEAR) from the recent activity view
- Gas refunds, storage deposit refunds, and other micro-transactions were creating noise in the activity history
- The raw balance-changes API (`/api/balance-changes`) is **not affected** — it continues to return all records for accounting/export purposes

## What changed
- Set `exclude_near_dust: true` in both places in `get_recent_activity` ([history.rs:1523](nt-be/src/handlers/balance_changes/history.rs#L1523), [history.rs:1575](nt-be/src/handlers/balance_changes/history.rs#L1575))
- This adds `NOT (token_id = 'near' AND ABS(amount) < 0.01)` to the SQL WHERE clause for recent activity queries only

## Test plan
- [ ] Verify recent activity no longer shows NEAR micro-transactions (gas refunds < 0.01 NEAR)
- [ ] Verify legitimate NEAR transactions (>= 0.01 NEAR) still appear
- [ ] Verify balance-changes API still returns all records including dust

🤖 Generated with [Claude Code](https://claude.com/claude-code)