### PR TITLE
fix: Fixed signAndSendTransaction params to align with NEAR Connect types

### DIFF
--- a/nt-fe/src/ledger-wallet/index.js
+++ b/nt-fe/src/ledger-wallet/index.js
@@ -1913,10 +1913,11 @@ class LedgerWallet {
      */
     async signAndSendTransactions(params) {
         const results = [];
+        const { transactions, ...transactionParams } = params;
 
         for (const tx of params.transactions) {
             const result = await this.signAndSendTransaction({
-                ...params,
+                ...transactionParams,
                 receiverId: tx.receiverId,
                 actions: tx.actions,
             });


### PR DESCRIPTION
I have not tested it yet from the browser, but I observed the issue in iOS / Android ports.

https://github.com/azbang/near-connect/blob/e2e4a9bc175ee52083191ddb171df52e888cbef1/src/types/index.ts#L66-L71

https://github.com/azbang/near-connect/blob/e2e4a9bc175ee52083191ddb171df52e888cbef1/src/InjectedWallet.ts#L50