### PR TITLE
fix: always show pending counter, hide on mobile when tab is selected

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/requests/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/requests/page.tsx
@@ -291,9 +291,7 @@ export default function RequestsPage() {
             value: "InProgress",
             label: "Pending",
             trigger:
-                !!pendingCount &&
-                pendingCount > 0 &&
-                currentTab !== "InProgress" ? (
+                !!pendingCount && pendingCount > 0 ? (
                     <NumberBadge number={pendingCount} variant="secondary" />
                 ) : undefined,
         },

--- a/nt-fe/components/responsive-tabs.tsx
+++ b/nt-fe/components/responsive-tabs.tsx
@@ -73,7 +73,6 @@ export function ResponsiveTabs({
                         <SelectTrigger className="border-0 h-auto gap-1.5 font-medium text-sm focus:ring-0 w-auto">
                             <span className="flex items-center gap-1.5">
                                 {currentLabel}
-                                {currentTrigger}
                             </span>
                         </SelectTrigger>
                         <SelectContent align="start">
@@ -81,7 +80,7 @@ export function ResponsiveTabs({
                                 <SelectItem key={tab.value} value={tab.value}>
                                     <span className="flex items-center gap-1.5">
                                         {tab.selectLabel ?? tab.label}
-                                        {tab.trigger}
+                                        {tab.value !== value && tab.trigger}
                                     </span>
                                 </SelectItem>
                             ))}


### PR DESCRIPTION
- Remove `currentTab !== "InProgress"` condition so the pending badge
  is visible at all times on desktop, including when the Pending tab
  is active
- On mobile (Select dropdown), hide the trigger badge for the currently
  selected item to avoid overlapping with the checkmark icon

https://claude.ai/code/session_01HQC8sLFWkwtmRhLncpjZXy