### PR TITLE
Improve balance chart loading state handling

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -273,7 +273,7 @@ export default function BalanceWithGraph({
     }
 
     // Fetch balance chart data with USD values
-    const { data: balanceChartData, isLoading } = useBalanceChart(
+    const { data: balanceChartData, isLoading, isFetching } = useBalanceChart(
         frozenChartParams.current,
     );
 
@@ -794,7 +794,7 @@ export default function BalanceWithGraph({
                     </SelectContent>
                 </Select>
             </div>
-            {isLoading ? (
+            {isLoading || (isFetching && chartData.data.length === 0) ? (
                 <div className="h-56 w-full space-y-3 p-4">
                     <Skeleton className="h-50 w-full" />
                 </div>


### PR DESCRIPTION
## Summary
Enhanced the loading state logic in the balance chart component to better handle data fetching scenarios and improve user experience during chart updates.

## Key Changes
- Added `isFetching` state from the `useBalanceChart` hook to track ongoing data requests
- Updated the loading condition to show the skeleton loader when either:
  - Initial data is loading (`isLoading`), OR
  - Data is being fetched AND the chart currently has no data (`isFetching && chartData.data.length === 0`)

## Implementation Details
This change prevents the skeleton loader from appearing during subsequent data refreshes when chart data already exists, while still showing it during initial load or when the chart is empty. This provides a smoother user experience by avoiding unnecessary UI flashing when the chart is being updated with new data.

https://claude.ai/code/session_01UTCXhkNEbWbhSupzMzc8He