### PR TITLE
fix: exclude lockup tokens from treasury selector balance display

### DIFF
--- a/nt-fe/components/treasury-info.tsx
+++ b/nt-fe/components/treasury-info.tsx
@@ -34,10 +34,13 @@ export function TreasuryBalance({
     const { data, isLoading } = useAssets(daoId);
     if (isLoading)
         return <Skeleton className={skeletonClassName ?? "h-4 w-16"} />;
-    if (data?.totalBalanceUSD === undefined) return null;
+    if (!data?.tokens) return null;
+    const balanceExcludingLockup = data.tokens
+        .filter((t) => t.residency !== "Lockup")
+        .reduce((sum, t) => sum + t.balanceUSD, 0);
     return (
         <span className={cn("text-sm text-muted-foreground", className)}>
-            {formatCurrency(Number(data.totalBalanceUSD))}
+            {formatCurrency(balanceExcludingLockup)}
         </span>
     );
 }


### PR DESCRIPTION
Aligns TreasuryBalance component with balance-with-graph page behavior
by filtering out tokens with residency === "Lockup" before summing USD values.

https://claude.ai/code/session_01M2AZHj1mrJ6w61guhiwdhT