### PR TITLE
Hide Address Book from guest treasury navigation

### DIFF
--- a/nt-fe/components/sidebar.tsx
+++ b/nt-fe/components/sidebar.tsx
@@ -324,32 +324,36 @@ export function Sidebar({ onClose }: SidebarProps) {
                             onContactClick={() => setSupportModalOpen(true)}
                         />
                     )}
-                    {bottomNavLinks.filter((link) => !(link.memberRequired && isGuestTreasury)).map((link) => {
-                        const href = treasuryId
-                            ? `/${treasuryId}${link.path ? `/${link.path}` : ""}`
-                            : `/${link.path ? `/${link.path}` : ""}`;
-                        const isActive = pathname === href;
+                    {bottomNavLinks
+                        .filter(
+                            (link) => !(link.memberRequired && isGuestTreasury),
+                        )
+                        .map((link) => {
+                            const href = treasuryId
+                                ? `/${treasuryId}${link.path ? `/${link.path}` : ""}`
+                                : `/${link.path ? `/${link.path}` : ""}`;
+                            const isActive = pathname === href;
 
-                        return (
-                            <NavLink
-                                id={link.id}
-                                key={link.path}
-                                isActive={isActive}
-                                icon={link.icon}
-                                label={link.label}
-                                showLabels={!isReduced}
-                                endAdornment={
-                                    link.showNewPill ? (
-                                        <NEW enabled={!isReduced} />
-                                    ) : undefined
-                                }
-                                onClick={() => {
-                                    router.push(href);
-                                    if (isMobile) onClose();
-                                }}
-                            />
-                        );
-                    })}
+                            return (
+                                <NavLink
+                                    id={link.id}
+                                    key={link.path}
+                                    isActive={isActive}
+                                    icon={link.icon}
+                                    label={link.label}
+                                    showLabels={!isReduced}
+                                    endAdornment={
+                                        link.showNewPill ? (
+                                            <NEW enabled={!isReduced} />
+                                        ) : undefined
+                                    }
+                                    onClick={() => {
+                                        router.push(href);
+                                        if (isMobile) onClose();
+                                    }}
+                                />
+                            );
+                        })}
 
                     <NavLink
                         id="help-support-link"


### PR DESCRIPTION
## Summary
This change restricts access to the Address Book navigation link for guest users in treasury sidebars by adding a membership requirement check.

## Key Changes
- Added `memberRequired` property to the bottom navigation link type definition to support conditional link visibility
- Marked the Address Book link as requiring membership (`memberRequired: true`)
- Updated the sidebar navigation rendering to filter out links that require membership when viewing a guest treasury (`isGuestTreasury`)

## Implementation Details
The Address Book link is now hidden from the sidebar navigation when `isGuestTreasury` is true, preventing guest users from accessing this feature. The filtering logic uses a simple conditional check: `!(link.memberRequired && isGuestTreasury)`, which allows links without the `memberRequired` flag or links when the user is not a guest to remain visible.

https://claude.ai/code/session_01DZycQ3tPVbf9RQddwGLMVa