### PR TITLE
fix: address book bugs and disable stats generation option

### DIFF
--- a/nt-be/src/main.rs
+++ b/nt-be/src/main.rs
@@ -239,7 +239,7 @@ async fn main() {
     }
 
     // Spawn public dashboard daily refresh service
-    {
+    if !state.env_vars.disable_stats_generation {
         let state_clone = state.clone();
         tokio::spawn(async move {
             nt_be::services::run_public_dashboard_refresh_service(state_clone).await;

--- a/nt-be/src/utils/env.rs
+++ b/nt-be/src/utils/env.rs
@@ -15,6 +15,7 @@ pub struct EnvVars {
     pub bulk_payment_signer: SecretKey,
     pub disable_balance_monitoring: bool,
     pub disable_treasury_creation: bool,
+    pub disable_stats_generation: bool,
     pub monitor_interval_seconds: u64,
     pub telegram_bot_token: Option<String>,
     pub telegram_chat_id: Option<String>,
@@ -83,6 +84,10 @@ impl Default for EnvVars {
                 .parse()
                 .unwrap_or(false),
             disable_treasury_creation: std::env::var("DISABLE_TREASURY_CREATION")
+                .unwrap_or_else(|_| "false".to_string())
+                .parse()
+                .unwrap_or(false),
+            disable_stats_generation: std::env::var("DISABLE_STATS_GENERATION")
                 .unwrap_or_else(|_| "false".to_string())
                 .parse()
                 .unwrap_or(false),

--- a/nt-fe/app/(treasury)/[treasuryId]/address-book/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/address-book/page.tsx
@@ -318,6 +318,11 @@ function RecipientsView({
             setBulkDeleteCount(0);
         } else if (entryToDelete) {
             await deleteEntries.mutateAsync([entryToDelete.id]);
+            setSelectedIds((prev) => {
+                const next = new Set(prev);
+                next.delete(entryToDelete.id);
+                return next;
+            });
             setEntryToDelete(null);
         }
     }

--- a/nt-fe/features/address-book/components/review-recipients.tsx
+++ b/nt-fe/features/address-book/components/review-recipients.tsx
@@ -54,20 +54,21 @@ export function ReviewRecipients({
             ),
         [existingEntries],
     );
-    const duplicateIndexes = useMemo(
-        () =>
-            recipients.reduce<number[]>((duplicates, recipient, index) => {
-                if (
-                    recipient?.address &&
-                    existingAddresses.has(normalizeAddress(recipient.address))
-                ) {
-                    duplicates.push(index);
-                }
-
-                return duplicates;
-            }, []),
-        [existingAddresses, recipients],
-    );
+    const duplicateIndexes = useMemo(() => {
+        const seen = new Set<string>();
+        const duplicates: number[] = [];
+        for (let index = 0; index < recipients.length; index++) {
+            const address = recipients[index]?.address;
+            if (!address) continue;
+            const normalized = normalizeAddress(address);
+            if (existingAddresses.has(normalized) || seen.has(normalized)) {
+                duplicates.push(index);
+            } else {
+                seen.add(normalized);
+            }
+        }
+        return duplicates;
+    }, [existingAddresses, recipients]);
     const duplicateIndexSet = useMemo(
         () => new Set(duplicateIndexes),
         [duplicateIndexes],

--- a/nt-fe/features/proposals/components/expanded-view/change-policy-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/change-policy-expanded.tsx
@@ -129,7 +129,7 @@ function getMemberItems(
                         <Pill
                             key={role}
                             title={formatRoleName(role)}
-                            variant="card"
+                            variant="secondary"
                         />
                     ))}
                 </div>


### PR DESCRIPTION
## Summary

- **Address book selection cleanup**: After deleting a single entry, its ID is now removed from `selectedIds` to prevent stale selection state
- **Duplicate detection fix in bulk import**: `duplicateIndexes` now also checks for duplicates *within* the import batch (not just against existing entries), preventing multiple identical rows from being silently accepted
- **Backend: `DISABLE_STATS_GENERATION` env flag**: New `disable_stats_generation` env var gates the public dashboard refresh service, allowing it to be disabled without code changes (e.g. in prod environments where stats generation is unwanted)
- **UI: Pill variant fix in change-policy view**: Changed `variant="card"` → `variant="secondary"` for role pills in the change-policy expanded view

## Test plan

- [ ] Delete a single address book entry and verify it's deselected in the UI
- [ ] Bulk import recipients with duplicate addresses and confirm both rows are flagged
- [ ] Set `DISABLE_STATS_GENERATION=true` in backend env and verify the dashboard refresh service does not spawn
- [ ] Review role pills in change-policy expanded view render correctly with `secondary` variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)