### PR TITLE
fix: remove incorrect setIsAddressValid(false) from handleRemove

### DIFF
--- a/nt-fe/features/address-book/components/add-recipient-form.tsx
+++ b/nt-fe/features/address-book/components/add-recipient-form.tsx
@@ -358,7 +358,6 @@ export function AddRecipientInput({
         const nextLength = fields.length - 1;
         const nextActive = activeIndex > index ? activeIndex - 1 : activeIndex;
         setActiveIndex(Math.max(0, Math.min(nextActive, nextLength - 1)));
-        setIsAddressValid(false);
     };
 
     return (


### PR DESCRIPTION
When removing a non-active committed entry, the active entry's address
validity was incorrectly reset to false, disabling action buttons even
though the active entry remained valid. Index-shift cases are already
handled by the form key change triggering AccountInput remount with
validateOnMount.

https://claude.ai/code/session_01VMSu9H3YpCwvxwyf71okSf