### PR TITLE
test: stabilize start-page e2e scenarios and add waitlist coverage

### DIFF
--- a/nt-fe/e2e/start-page.spec.ts
+++ b/nt-fe/e2e/start-page.spec.ts
@@ -36,7 +36,10 @@ async function setupStartPageMocks(
             });
         }
 
-        if (url.includes("/api/user/treasuries") || url.includes("/user/treasuries")) {
+        if (
+            url.includes("/api/user/treasuries") ||
+            url.includes("/user/treasuries")
+        ) {
             return route.fulfill({
                 status: 200,
                 contentType: "application/json",


### PR DESCRIPTION
## Summary
- Stabilized `nt-fe/e2e/start-page.spec.ts` to reduce flakiness in start-page checks.
- Improved mock handling and synchronization for redirect scenarios.
- Added coverage for signed-in users with no treasuries when creation is disabled (waitlist flow).
- Updated `nt-fe/e2e/README.md` test structure to reflect current E2E specs.

## Why
- Start-page E2E checks were intermittently failing and causing unstable signal.
- This improves confidence in a critical entry flow (`/`) and protects onboarding routing behavior.

## Test plan
- [x] `npm run test:e2e -- e2e/start-page.spec.ts --workers=1`
- [x] `npm run test:e2e:headed -- e2e/start-page.spec.ts --workers=1`
- [x] Verified scenarios:
  - signed out -> Connect Wallet visible
  - signed in + no treasuries -> redirects to `/app/new`
  - signed in + has treasury -> redirects to `/{daoId}`
  - signed in + no treasuries + creation disabled -> waitlist UI shown

## Notes
- Scope is E2E tests/docs only.
- No production business logic changes.