### PR TITLE
fix: compute FT lockup unlock metrics in backend for active schedule

### DIFF
--- a/nt-be/src/handlers/user/assets.rs
+++ b/nt-be/src/handlers/user/assets.rs
@@ -97,9 +97,12 @@ pub enum TokenResidency {
 #[serde(rename_all = "camelCase")]
 pub struct FtLockupSchedule {
     pub start_timestamp: Option<u64>,
-    pub session_interval: Option<u64>,
-    pub session_num: Option<u32>,
-    pub last_claim_session: Option<u32>,
+    pub round_interval: Option<u64>,
+    pub rounds_total: Option<u32>,
+    pub rounds_completed: Option<u32>,
+    pub total_amount: Option<String>,
+    pub unlocked_amount: Option<String>,
+    pub locked_amount: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -700,6 +703,29 @@ pub async fn compute_user_assets(
             .saturating_sub(position.claimed_amount)
             .saturating_sub(position.unclaimed_amount);
 
+        let rounds_total = position.session_num.unwrap_or(0);
+        let rounds_completed = position.last_claim_session.unwrap_or(0).min(rounds_total);
+
+        // Display metrics for FT lockup details:
+        // show cumulative unlocked for the active schedule, including already-claimed rounds.
+        let (display_total_raw, display_unlocked_raw, display_locked_raw) =
+            if let Some(release_per_session) = position.release_per_session {
+                if rounds_total > 0 {
+                    let round_total_raw = release_per_session.saturating_mul(rounds_total as u128);
+                    let claimed_by_rounds_raw =
+                        release_per_session.saturating_mul(rounds_completed as u128);
+                    let unlocked_cumulative_raw =
+                        claimed_by_rounds_raw.saturating_add(position.unclaimed_amount);
+                    let unlocked_clamped_raw = unlocked_cumulative_raw.min(round_total_raw);
+                    let locked_round_raw = round_total_raw.saturating_sub(unlocked_clamped_raw);
+                    (round_total_raw, unlocked_clamped_raw, locked_round_raw)
+                } else {
+                    (total_raw, position.unclaimed_amount, locked_raw)
+                }
+            } else {
+                (total_raw, position.unclaimed_amount, locked_raw)
+            };
+
         all_simplified_tokens.push((
             SimplifiedToken {
                 id: unified_id,
@@ -707,9 +733,12 @@ pub async fn compute_user_assets(
                 lockup_instance_id: Some(position.instance_id),
                 ft_lockup_schedule: Some(FtLockupSchedule {
                     start_timestamp: position.start_timestamp,
-                    session_interval: position.session_interval,
-                    session_num: position.session_num,
-                    last_claim_session: position.last_claim_session,
+                    round_interval: position.session_interval,
+                    rounds_total: Some(rounds_total),
+                    rounds_completed: Some(rounds_completed),
+                    total_amount: Some(display_total_raw.to_string()),
+                    unlocked_amount: Some(display_unlocked_raw.to_string()),
+                    locked_amount: Some(display_locked_raw.to_string()),
                 }),
                 decimals: token_meta.decimals,
                 balance: Balance::Standard {

--- a/nt-be/src/handlers/user/ft_lockups.rs
+++ b/nt-be/src/handlers/user/ft_lockups.rs
@@ -9,7 +9,10 @@ use crate::{
     AppState,
     utils::{
         cache::{CacheKey, CacheTier},
-        serde::{opt_u32_from_string_or_number, opt_u64_from_string_or_number},
+        serde::{
+            opt_u32_from_string_or_number, opt_u64_from_string_or_number,
+            opt_u128_string_from_string_or_number,
+        },
     },
 };
 
@@ -31,6 +34,8 @@ pub(crate) struct FtLockupAccountData {
     pub session_num: Option<u32>,
     #[serde(default, deserialize_with = "opt_u32_from_string_or_number")]
     pub last_claim_session: Option<u32>,
+    #[serde(default, deserialize_with = "opt_u128_string_from_string_or_number")]
+    pub release_per_session: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -44,6 +49,7 @@ pub(crate) struct FtLockupPosition {
     pub session_interval: Option<u64>,
     pub session_num: Option<u32>,
     pub last_claim_session: Option<u32>,
+    pub release_per_session: Option<u128>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -472,6 +478,10 @@ pub(crate) async fn fetch_ft_lockup_positions(
             session_interval: account_data.session_interval,
             session_num: account_data.session_num,
             last_claim_session: account_data.last_claim_session,
+            release_per_session: account_data
+                .release_per_session
+                .as_deref()
+                .map(parse_u128_amount),
         });
     }
 

--- a/nt-be/src/services/ft_lockup_scheduler.rs
+++ b/nt-be/src/services/ft_lockup_scheduler.rs
@@ -625,6 +625,7 @@ mod tests {
             session_interval: Some(100),
             session_num: Some(10),
             last_claim_session: Some(2),
+            release_per_session: None,
         };
         let next_claim_at = compute_next_claim_at(now, &data).expect("next claim should exist");
         let now_ts = now.timestamp();
@@ -645,6 +646,7 @@ mod tests {
             session_interval: Some(100),
             session_num: Some(10),
             last_claim_session: Some(0),
+            release_per_session: None,
         };
 
         let now = Utc::now();

--- a/nt-be/src/utils/serde.rs
+++ b/nt-be/src/utils/serde.rs
@@ -99,3 +99,72 @@ where
         .map(|v| u32::try_from(v).map_err(|_| de::Error::custom("number is out of u32 range")))
         .transpose()
 }
+
+/// Deserialize an optional u128-like value and store as string.
+/// Accepts null, string, or integer and returns decimal string form.
+pub fn opt_u128_string_from_string_or_number<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StringOrU128Visitor;
+
+    impl<'de> de::Visitor<'de> for StringOrU128Visitor {
+        type Value = Option<String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("null, string, or integer")
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_some<D2>(self, deserializer: D2) -> Result<Self::Value, D2::Error>
+        where
+            D2: Deserializer<'de>,
+        {
+            opt_u128_string_from_string_or_number(deserializer)
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Some(value.to_string()))
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if value < 0 {
+                return Err(de::Error::custom("expected non-negative integer"));
+            }
+            Ok(Some(value.to_string()))
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            value
+                .parse::<u128>()
+                .map(|v| Some(v.to_string()))
+                .map_err(de::Error::custom)
+        }
+    }
+
+    deserializer.deserialize_any(StringOrU128Visitor)
+}

--- a/nt-fe/components/lockup-details-modal.tsx
+++ b/nt-fe/components/lockup-details-modal.tsx
@@ -91,35 +91,35 @@ function formatReleaseInterval(seconds?: number): string {
 
 function calculateNextFtUnlockDate(
     startTimestamp?: number,
-    sessionInterval?: number,
-    sessionNum?: number,
+    roundInterval?: number,
+    roundsTotal?: number,
 ): string {
     if (
         !startTimestamp ||
         Number.isNaN(startTimestamp) ||
-        !sessionInterval ||
-        Number.isNaN(sessionInterval) ||
-        sessionInterval <= 0
+        !roundInterval ||
+        Number.isNaN(roundInterval) ||
+        roundInterval <= 0
     ) {
         return "N/A";
     }
 
-    const totalSessions = sessionNum ?? 0;
+    const totalRounds = roundsTotal ?? 0;
     const nowSeconds = Math.floor(Date.now() / 1000);
-    let nextUnlock = startTimestamp + sessionInterval;
+    let nextUnlock = startTimestamp + roundInterval;
     let releaseIndex = 1;
 
     while (
         nextUnlock <= nowSeconds &&
-        (totalSessions <= 0 || releaseIndex < totalSessions)
+        (totalRounds <= 0 || releaseIndex < totalRounds)
     ) {
-        nextUnlock += sessionInterval;
+        nextUnlock += roundInterval;
         releaseIndex += 1;
     }
 
     if (
-        totalSessions > 0 &&
-        releaseIndex >= totalSessions &&
+        totalRounds > 0 &&
+        releaseIndex >= totalRounds &&
         nextUnlock <= nowSeconds
     ) {
         return "Completed";
@@ -159,18 +159,24 @@ export function LockupDetailsModal({
     let summaryTotal = Big(0);
 
     if (isFtLockup && asset.balance.type === "Standard") {
-        total = Big(
-            formatBalance(asset.balance.total, asset.decimals, asset.decimals),
-        );
-        summaryTotal = total;
-        locked = Big(
-            formatBalance(asset.balance.locked, asset.decimals, asset.decimals),
-        );
-        unlocked = total.sub(locked);
-        progressPct = total.gt(0) ? unlocked.div(total).mul(100).toNumber() : 0;
+        const totalRaw =
+            asset.ftLockupSchedule?.totalAmount ??
+            asset.balance.total.toFixed(0);
+        const unlockedRaw = asset.ftLockupSchedule?.unlockedAmount ?? "0";
+        const lockedRaw =
+            asset.ftLockupSchedule?.lockedAmount ??
+            asset.balance.locked.toFixed(0);
+        const roundsDone = asset.ftLockupSchedule?.roundsCompleted ?? 0;
+        const roundsTotal = asset.ftLockupSchedule?.roundsTotal ?? 0;
 
-        const roundsDone = asset.ftLockupSchedule?.lastClaimSession ?? 0;
-        const roundsTotal = asset.ftLockupSchedule?.sessionNum ?? 0;
+        total = Big(formatBalance(totalRaw, asset.decimals, asset.decimals));
+        unlocked = Big(
+            formatBalance(unlockedRaw, asset.decimals, asset.decimals),
+        );
+        locked = Big(formatBalance(lockedRaw, asset.decimals, asset.decimals));
+        summaryTotal = total;
+
+        progressPct = total.gt(0) ? unlocked.div(total).mul(100).toNumber() : 0;
         progressLabel =
             roundsTotal > 0
                 ? `${roundsDone}/${roundsTotal} Rounds`
@@ -223,12 +229,12 @@ export function LockupDetailsModal({
 
     const totalUsd = summaryTotal.mul(asset.price).toNumber();
 
-    const roundsTotal = asset.ftLockupSchedule?.sessionNum ?? 0;
+    const roundsTotal = asset.ftLockupSchedule?.roundsTotal ?? 0;
 
     const nextUnlockDate = calculateNextFtUnlockDate(
         asset.ftLockupSchedule?.startTimestamp,
-        asset.ftLockupSchedule?.sessionInterval,
-        asset.ftLockupSchedule?.sessionNum,
+        asset.ftLockupSchedule?.roundInterval,
+        asset.ftLockupSchedule?.roundsTotal,
     );
 
     const nearStartDate = formatDateFromNanoseconds(
@@ -411,7 +417,7 @@ export function LockupDetailsModal({
                                     <span>
                                         {formatReleaseInterval(
                                             asset.ftLockupSchedule
-                                                ?.sessionInterval,
+                                                ?.roundInterval,
                                         )}
                                     </span>
                                 </div>

--- a/nt-fe/lib/api.ts
+++ b/nt-fe/lib/api.ts
@@ -78,9 +78,12 @@ export type TokenResidency = "Near" | "Ft" | "Intents" | "Lockup" | "Staked";
 
 export interface FtLockupSchedule {
     startTimestamp?: number;
-    sessionInterval?: number;
-    sessionNum?: number;
-    lastClaimSession?: number;
+    roundInterval?: number;
+    roundsTotal?: number;
+    roundsCompleted?: number;
+    totalAmount?: string;
+    unlockedAmount?: string;
+    lockedAmount?: string;
 }
 
 export interface TreasuryAsset {


### PR DESCRIPTION
- Move FT lockup display calculations from frontend to backend and return UI-ready fields in `ftLockupSchedule`: `totalAmount`, `unlockedAmount`, `lockedAmount`, `roundsCompleted`, `roundsTotal`.
- Ensure `Unlocked` reflects cumulative unlocked value for the active schedule (`claimed rounds + currently unclaimed`), so `1/N Rounds` never appears with `Unlocked = 0`, and behavior remains correct when the same lockup instance is reused for subsequent lockup cycles.
- Renamed sessions to rounds
