### PR TITLE
fix: improve mobile modal scrolling and spacing consistency

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/page.tsx
@@ -38,7 +38,7 @@ export default function AppPage() {
         >
             <div className="flex flex-col lg:flex-row gap-5">
                 <div className="flex flex-col gap-5 lg:w-3/5 w-full">
-                    <div className="lg:hidden">
+                    <div className="lg:hidden empty:hidden">
                         <CreateBanner />
                     </div>
                     <OnboardingProgress

--- a/nt-fe/components/assets-table.tsx
+++ b/nt-fe/components/assets-table.tsx
@@ -1639,7 +1639,7 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                 }
                             }}
                         >
-                            <SelectTrigger className="h-auto w-auto border-0 bg-transparent p-0 text-sm font-medium text-foreground shadow-none hover:bg-transparent focus-visible:ring-0 [&_svg]:text-foreground! [&_svg]:opacity-100">
+                            <SelectTrigger className="h-auto w-auto border-0 bg-transparent px-2 py-1 text-sm font-medium text-foreground shadow-none hover:bg-transparent focus-visible:ring-0 [&_svg]:text-foreground! [&_svg]:opacity-100">
                                 <SelectValue />
                             </SelectTrigger>
                             <SelectContent align="start" className="min-w-56">

--- a/nt-fe/components/lockup-details-modal.tsx
+++ b/nt-fe/components/lockup-details-modal.tsx
@@ -275,7 +275,7 @@ export function LockupDetailsModal({
 
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
-            <DialogContent className="sm:max-w-[560px]">
+            <DialogContent className="sm:max-w-[560px] overflow-hidden">
                 <DialogHeader>
                     <div className="flex items-center gap-1">
                         {onBack ? (
@@ -295,219 +295,225 @@ export function LockupDetailsModal({
                     </div>
                 </DialogHeader>
 
-                <div className="space-y-6">
-                    {isNearLockup ? (
-                        <div className="overflow-hidden rounded-xl border border-border/70">
-                            <div className="p-[3px]">
-                                {allocatedAmountSummary}
-                            </div>
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                    <div className="space-y-6">
+                        {isNearLockup ? (
+                            <div className="overflow-hidden rounded-xl border border-border/70">
+                                <div className="p-[3px]">
+                                    {allocatedAmountSummary}
+                                </div>
 
-                            {reservedStorage.gt(0) ? (
-                                <div className="flex items-center justify-between px-2 py-2 text-sm">
-                                    <div className="flex items-center gap-1.5 text-muted-foreground">
-                                        Reserved For Storage{" "}
-                                        <Tooltip content="NEAR reserved by the lockup account to pay storage costs.">
-                                            <Info className="size-3.5" />
-                                        </Tooltip>
+                                {reservedStorage.gt(0) ? (
+                                    <div className="flex items-center justify-between px-2 py-2 text-sm">
+                                        <div className="flex items-center gap-1.5 text-muted-foreground">
+                                            Reserved For Storage{" "}
+                                            <Tooltip content="NEAR reserved by the lockup account to pay storage costs.">
+                                                <Info className="size-3.5" />
+                                            </Tooltip>
+                                        </div>
+                                        <span className="text-foreground">
+                                            {reservedStorage.toFixed(2)}{" "}
+                                            {asset.symbol}
+                                        </span>
                                     </div>
-                                    <span className="text-foreground">
-                                        {reservedStorage.toFixed(2)}{" "}
-                                        {asset.symbol}
-                                    </span>
-                                </div>
-                            ) : null}
-                        </div>
-                    ) : (
-                        allocatedAmountSummary
-                    )}
-                    {hasLockupStakingNotice ? (
-                        <div className="rounded-xl bg-muted/60 px-4 py-3 text-sm flex items-start gap-2">
-                            <Info className="size-4 mt-0.5 shrink-0" />
-                            <p className="text-foreground">
-                                {isFullLockupStaked
-                                    ? `All ${lockupStakedDisplay} ${asset.symbol} from your lockup is earning right now.`
-                                    : `Part of your lockup (${lockupStakedDisplay} ${asset.symbol}) is earning right now.`}{" "}
-                                To use unlocked tokens, stop earning first and
-                                withdraw them.
-                            </p>
-                        </div>
-                    ) : null}
-                    {showTokenBreakdown ? (
-                        <div className="space-y-2 text-sm">
-                            <p className="font-semibold">Token Breakdown</p>
-                            <div className="space-y-2">
-                                <div className="flex items-center justify-between">
-                                    <p className="text-muted-foreground">
-                                        Allocated Amount
-                                    </p>
-                                    <p className="font-medium">
-                                        {allocatedFromContract.toFixed(2)}{" "}
-                                        {asset.symbol}
-                                    </p>
-                                </div>
-                                <div className="flex items-center justify-between">
-                                    <p className="text-muted-foreground">
-                                        Earned
-                                    </p>
-                                    <p className="text-general-success-foreground font-medium">
-                                        +{earnedFromStaking.toFixed(2)}{" "}
-                                        {asset.symbol}
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    ) : null}
-
-                    <div className="space-y-2 text-sm">
-                        <div className="flex items-center justify-between ">
-                            <p className="font-semibold">Progress</p>
-                            <p>{progressLabel}</p>
-                        </div>
-                        <div className="h-1.5 rounded-full bg-muted overflow-hidden">
-                            <div
-                                className="h-full rounded-full bg-foreground"
-                                style={{
-                                    width: `${Math.min(Math.max(progressPct, 0), 100)}%`,
-                                }}
-                            />
-                        </div>
-                        <div className="flex items-center justify-between">
-                            <div>
-                                <p className="text-muted-foreground">
-                                    Unlocked
-                                </p>
-                                <p className="text-general-success-foreground font-medium">
-                                    {unlocked.toFixed(2)} {asset.symbol}
-                                </p>
-                            </div>
-                            <div className="text-right">
-                                <p className="text-muted-foreground">Locked</p>
-                                <p className="font-medium">
-                                    {locked.toFixed(2)} {asset.symbol}
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="space-y-2 text-sm">
-                        <p className="font-semibold">Schedule</p>
-                        {isFtLockup ? (
-                            <div className="space-y-2">
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">
-                                        Start Date
-                                    </span>
-                                    <span>
-                                        {formatDateFromSeconds(
-                                            asset.ftLockupSchedule
-                                                ?.startTimestamp,
-                                        )}
-                                    </span>
-                                </div>
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">
-                                        Rounds
-                                    </span>
-                                    <span>{roundsTotal || "N/A"}</span>
-                                </div>
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">
-                                        Release Interval
-                                    </span>
-                                    <span>
-                                        {formatReleaseInterval(
-                                            asset.ftLockupSchedule
-                                                ?.roundInterval,
-                                        )}
-                                    </span>
-                                </div>
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">
-                                        Next Unlock Date
-                                    </span>
-                                    <span>{nextUnlockDate}</span>
-                                </div>
+                                ) : null}
                             </div>
                         ) : (
-                            <div className="space-y-2">
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">
-                                        Start Date
-                                    </span>
-                                    <span>{nearStartDate}</span>
-                                </div>
-                                <div className="flex justify-between">
-                                    <span className="text-muted-foreground">
-                                        End Date
-                                    </span>
-                                    <span>{nearEndDate}</span>
+                            allocatedAmountSummary
+                        )}
+                        {hasLockupStakingNotice ? (
+                            <div className="rounded-xl bg-muted/60 px-4 py-3 text-sm flex items-start gap-2">
+                                <Info className="size-4 mt-0.5 shrink-0" />
+                                <p className="text-foreground">
+                                    {isFullLockupStaked
+                                        ? `All ${lockupStakedDisplay} ${asset.symbol} from your lockup is earning right now.`
+                                        : `Part of your lockup (${lockupStakedDisplay} ${asset.symbol}) is earning right now.`}{" "}
+                                    To use unlocked tokens, stop earning first
+                                    and withdraw them.
+                                </p>
+                            </div>
+                        ) : null}
+                        {showTokenBreakdown ? (
+                            <div className="space-y-2 text-sm">
+                                <p className="font-semibold">Token Breakdown</p>
+                                <div className="space-y-2">
+                                    <div className="flex items-center justify-between">
+                                        <p className="text-muted-foreground">
+                                            Allocated Amount
+                                        </p>
+                                        <p className="font-medium">
+                                            {allocatedFromContract.toFixed(2)}{" "}
+                                            {asset.symbol}
+                                        </p>
+                                    </div>
+                                    <div className="flex items-center justify-between">
+                                        <p className="text-muted-foreground">
+                                            Earned
+                                        </p>
+                                        <p className="text-general-success-foreground font-medium">
+                                            +{earnedFromStaking.toFixed(2)}{" "}
+                                            {asset.symbol}
+                                        </p>
+                                    </div>
                                 </div>
                             </div>
-                        )}
-                    </div>
+                        ) : null}
 
-                    <Collapsible
-                        open={guideOpen}
-                        onOpenChange={setGuideOpen}
-                        className="overflow-hidden lockup-grant-box"
-                    >
-                        <CollapsibleTrigger asChild>
-                            <button
-                                type="button"
-                                className="w-full flex items-center justify-between px-3 py-2.5 text-sm font-medium cursor-pointer"
-                            >
-                                <span className="flex items-center gap-2">
-                                    <BadgeDollarSign className="size-4 text-muted-foreground" />
-                                    How your grant works
-                                </span>
-                                {guideOpen ? (
-                                    <ChevronUp className="size-4 text-muted-foreground" />
-                                ) : (
-                                    <ChevronDown className="size-4 text-muted-foreground" />
-                                )}
-                            </button>
-                        </CollapsibleTrigger>
-                        <CollapsibleContent className="px-3 pb-3 text-xs text-muted-foreground">
+                        <div className="space-y-2 text-sm">
+                            <div className="flex items-center justify-between ">
+                                <p className="font-semibold">Progress</p>
+                                <p>{progressLabel}</p>
+                            </div>
+                            <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                                <div
+                                    className="h-full rounded-full bg-foreground"
+                                    style={{
+                                        width: `${Math.min(Math.max(progressPct, 0), 100)}%`,
+                                    }}
+                                />
+                            </div>
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <p className="text-muted-foreground">
+                                        Unlocked
+                                    </p>
+                                    <p className="text-general-success-foreground font-medium">
+                                        {unlocked.toFixed(2)} {asset.symbol}
+                                    </p>
+                                </div>
+                                <div className="text-right">
+                                    <p className="text-muted-foreground">
+                                        Locked
+                                    </p>
+                                    <p className="font-medium">
+                                        {locked.toFixed(2)} {asset.symbol}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="space-y-2 text-sm">
+                            <p className="font-semibold">Schedule</p>
                             {isFtLockup ? (
-                                <ol className="list-decimal pl-4 space-y-1">
-                                    <li>
-                                        You receive a grant for a specific
-                                        period of time. Instead of getting the
-                                        full amount at once, the assets become
-                                        available in parts over time.
-                                    </li>
-                                    <li>
-                                        When the date for the next release
-                                        arrives, that portion of tokens is
-                                        automatically unlocked and moved to your
-                                        treasury balance.
-                                    </li>
-                                    <li>
-                                        Once they appear in your balance, you
-                                        can immediately use them for payments,
-                                        transfers, or other transactions.
-                                    </li>
-                                </ol>
+                                <div className="space-y-2">
+                                    <div className="flex justify-between">
+                                        <span className="text-muted-foreground">
+                                            Start Date
+                                        </span>
+                                        <span>
+                                            {formatDateFromSeconds(
+                                                asset.ftLockupSchedule
+                                                    ?.startTimestamp,
+                                            )}
+                                        </span>
+                                    </div>
+                                    <div className="flex justify-between">
+                                        <span className="text-muted-foreground">
+                                            Rounds
+                                        </span>
+                                        <span>{roundsTotal || "N/A"}</span>
+                                    </div>
+                                    <div className="flex justify-between">
+                                        <span className="text-muted-foreground">
+                                            Release Interval
+                                        </span>
+                                        <span>
+                                            {formatReleaseInterval(
+                                                asset.ftLockupSchedule
+                                                    ?.roundInterval,
+                                            )}
+                                        </span>
+                                    </div>
+                                    <div className="flex justify-between">
+                                        <span className="text-muted-foreground">
+                                            Next Unlock Date
+                                        </span>
+                                        <span>{nextUnlockDate}</span>
+                                    </div>
+                                </div>
                             ) : (
-                                <ol className="list-decimal pl-4 space-y-1">
-                                    <li>
-                                        You receive a grant for a set period of
-                                        time with a defined start and end date.
-                                    </li>
-                                    <li>
-                                        As tokens unlock, they automatically
-                                        become available in your treasury
-                                        balance.
-                                    </li>
-                                    <li>
-                                        You can use the unlocked tokens
-                                        immediately for payments, transfers, or
-                                        other transactions.
-                                    </li>
-                                </ol>
+                                <div className="space-y-2">
+                                    <div className="flex justify-between">
+                                        <span className="text-muted-foreground">
+                                            Start Date
+                                        </span>
+                                        <span>{nearStartDate}</span>
+                                    </div>
+                                    <div className="flex justify-between">
+                                        <span className="text-muted-foreground">
+                                            End Date
+                                        </span>
+                                        <span>{nearEndDate}</span>
+                                    </div>
+                                </div>
                             )}
-                        </CollapsibleContent>
-                    </Collapsible>
+                        </div>
+
+                        <Collapsible
+                            open={guideOpen}
+                            onOpenChange={setGuideOpen}
+                            className="overflow-hidden lockup-grant-box"
+                        >
+                            <CollapsibleTrigger asChild>
+                                <button
+                                    type="button"
+                                    className="w-full flex items-center justify-between px-3 py-2.5 text-sm font-medium cursor-pointer"
+                                >
+                                    <span className="flex items-center gap-2">
+                                        <BadgeDollarSign className="size-4 text-muted-foreground" />
+                                        How your grant works
+                                    </span>
+                                    {guideOpen ? (
+                                        <ChevronUp className="size-4 text-muted-foreground" />
+                                    ) : (
+                                        <ChevronDown className="size-4 text-muted-foreground" />
+                                    )}
+                                </button>
+                            </CollapsibleTrigger>
+                            <CollapsibleContent className="px-3 pb-3 text-xs text-muted-foreground">
+                                {isFtLockup ? (
+                                    <ol className="list-decimal pl-4 space-y-1">
+                                        <li>
+                                            You receive a grant for a specific
+                                            period of time. Instead of getting
+                                            the full amount at once, the assets
+                                            become available in parts over time.
+                                        </li>
+                                        <li>
+                                            When the date for the next release
+                                            arrives, that portion of tokens is
+                                            automatically unlocked and moved to
+                                            your treasury balance.
+                                        </li>
+                                        <li>
+                                            Once they appear in your balance,
+                                            you can immediately use them for
+                                            payments, transfers, or other
+                                            transactions.
+                                        </li>
+                                    </ol>
+                                ) : (
+                                    <ol className="list-decimal pl-4 space-y-1">
+                                        <li>
+                                            You receive a grant for a set period
+                                            of time with a defined start and end
+                                            date.
+                                        </li>
+                                        <li>
+                                            As tokens unlock, they automatically
+                                            become available in your treasury
+                                            balance.
+                                        </li>
+                                        <li>
+                                            You can use the unlocked tokens
+                                            immediately for payments, transfers,
+                                            or other transactions.
+                                        </li>
+                                    </ol>
+                                )}
+                            </CollapsibleContent>
+                        </Collapsible>
+                    </div>
                 </div>
             </DialogContent>
         </Dialog>

--- a/nt-fe/components/modal.tsx
+++ b/nt-fe/components/modal.tsx
@@ -113,7 +113,7 @@ function DialogHeader({
         <BaseDialogHeader
             {...props}
             className={cn(
-                "border-b border-border px-3 pb-3.5 -mx-3 flex flex-row items-center justify-between text-center gap-4",
+                "border-b border-border px-3 pb-3.5 -mx-3 flex flex-row items-center justify-between text-center gap-4 sticky top-0 z-10 bg-card sm:static",
                 className,
             )}
         >

--- a/nt-fe/components/page-component-layout.tsx
+++ b/nt-fe/components/page-component-layout.tsx
@@ -110,8 +110,10 @@ export function PageComponentLayout({
             </header>
 
             <main className="flex-1 overflow-y-auto bg-page-bg p-4">
-                <SystemStatusBanner className="lg:hidden" />
-                {children}
+                <div className="flex flex-col gap-3">
+                    <SystemStatusBanner className="lg:hidden" />
+                    {children}
+                </div>
             </main>
         </div>
     );


### PR DESCRIPTION
- Added consistent mobile spacing below the system maintenance banner.
- Fixed phantom spacing on dashboard mobile when create banner is not rendered by hiding empty wrapper.
- Improved mobile dropdown trigger spacing in assets table by adding internal padding.
- Fixed lockup/staking modal mobile scrolling by making modal body the dedicated scroll region.
- Made shared modal headers sticky on small screens so titles stay visible while only content scrolls.
