### PR TITLE
feat: confidential proposal filters + near.com deposit network

### DIFF
--- a/nt-be/src/handlers/proposals/filters.rs
+++ b/nt-be/src/handlers/proposals/filters.rs
@@ -4,8 +4,8 @@ use serde::Deserialize;
 
 use crate::constants::intents_tokens::find_token_by_symbol;
 use crate::handlers::proposals::scraper::{
-    AssetExchangeInfo, BatchPaymentResponse, BulkPayment, LockupInfo, PaymentInfo,
-    PaymentProposalType, Policy, Proposal, ProposalType, StakeDelegationInfo, Vote,
+    AssetExchangeInfo, BatchPaymentResponse, BulkPayment, ConfidentialRequestInfo, LockupInfo,
+    PaymentInfo, PaymentProposalType, Policy, Proposal, ProposalType, StakeDelegationInfo, Vote,
     fetch_batch_payment_list, fetch_ft_metadata, get_status_display,
 };
 use crate::utils::cache::{Cache, CacheKey, CacheTier};
@@ -138,6 +138,17 @@ fn parse_voter_votes(opt: &Option<String>) -> Option<Vec<VoterVote>> {
     })
 }
 
+/// Strip `nep141:` / `nep245:` prefix from a defuse asset id (e.g. `nep141:wrap.near` -> `wrap.near`).
+fn strip_nep_prefix(asset: &str) -> &str {
+    if let Some(rest) = asset.strip_prefix("nep141:") {
+        rest
+    } else if let Some(rest) = asset.strip_prefix("nep245:") {
+        rest
+    } else {
+        asset
+    }
+}
+
 fn get_token_addresses(symbol: &str) -> Option<Vec<String>> {
     find_token_by_symbol(&symbol.to_lowercase()).map(|token| {
         token
@@ -194,7 +205,44 @@ fn matches_tokens_filter(
     token: Option<&String>,
     token_not: Option<&String>,
     bulk_payment_contract_id: &near_api::AccountId,
+    treasury_id: &str,
 ) -> bool {
+    // Confidential proposals: derive token from quote_metadata.
+    if let Some(info) = ConfidentialRequestInfo::from_proposal(proposal, treasury_id) {
+        let token_to_check = match &info {
+            ConfidentialRequestInfo::Payment { token_id, .. } => strip_nep_prefix(token_id),
+            ConfidentialRequestInfo::Swap {
+                token_in_address, ..
+            } => strip_nep_prefix(token_in_address),
+        };
+        if token_matches_filter(token_to_check, token, token_not) {
+            return true;
+        }
+        // For swap also consider output token.
+        if let ConfidentialRequestInfo::Swap {
+            token_out_address, ..
+        } = &info
+        {
+            let out = strip_nep_prefix(token_out_address);
+            if let Some(tok) = token {
+                let addrs = get_token_addresses(tok);
+                if let Some(addrs) = addrs
+                    && addrs.iter().any(|t| t == out)
+                {
+                    return true;
+                }
+            }
+            if let Some(tok_not) = token_not {
+                let addrs = get_token_addresses(tok_not);
+                if let Some(addrs) = addrs
+                    && addrs.iter().any(|t| t == out)
+                {
+                    return false;
+                }
+            }
+        }
+        return token.is_none() && token_not.is_none();
+    }
     // Check payments
     if let Some(payment_info) = PaymentInfo::from_proposal(proposal, Some(bulk_payment_contract_id))
     {
@@ -258,7 +306,29 @@ async fn matches_recipients_filter(
     cache: &Cache,
     network: &NetworkConfig,
     bulk_payment_contract_id: &near_api::AccountId,
+    treasury_id: &str,
 ) -> bool {
+    // Confidential proposals: derive recipient from mapped payment/swap.
+    if let Some(info) = ConfidentialRequestInfo::from_proposal(proposal, treasury_id) {
+        let recipient = match &info {
+            ConfidentialRequestInfo::Payment { receiver, .. } => receiver.as_str(),
+            ConfidentialRequestInfo::Swap {
+                deposit_address, ..
+            } => deposit_address.as_str(),
+        };
+        if let Some(recipients) = recipients_set
+            && !recipients.contains(recipient)
+        {
+            return false;
+        }
+        if let Some(recipients_not) = recipients_not_set
+            && recipients_not.contains(recipient)
+        {
+            return false;
+        }
+        return true;
+    }
+
     // Check payments
     if let Some(payment_info) = PaymentInfo::from_proposal(proposal, Some(bulk_payment_contract_id))
     {
@@ -460,6 +530,7 @@ async fn matches_amount_filters(
     cache: &Cache,
     network: &NetworkConfig,
     bulk_payment_contract_id: &near_api::AccountId,
+    treasury_id: &str,
 ) -> bool {
     if filters.amount_equal.is_none()
         && filters.amount_min.is_none()
@@ -468,6 +539,35 @@ async fn matches_amount_filters(
         return true; // No amount filters specified
     }
     let token = filters.token.as_deref().unwrap_or("");
+
+    // Confidential proposals: derive payment-like info from quote_metadata.
+    if let Some(info) = ConfidentialRequestInfo::from_proposal(proposal, treasury_id) {
+        let (token_id, amount) = match &info {
+            ConfidentialRequestInfo::Payment {
+                token_id, amount, ..
+            } => (strip_nep_prefix(token_id).to_string(), amount.clone()),
+            ConfidentialRequestInfo::Swap {
+                token_in_address,
+                amount_in,
+                ..
+            } => (
+                strip_nep_prefix(token_in_address).to_string(),
+                amount_in.clone(),
+            ),
+        };
+        return matches_payment_amount_filters(
+            &PaymentInfo {
+                receiver: "".to_string(),
+                token: token_id,
+                amount,
+                is_lockup: false,
+            },
+            filters,
+            cache,
+            network,
+        )
+        .await;
+    }
 
     // Check payments
     if let Some(payment_info) = PaymentInfo::from_proposal(proposal, Some(bulk_payment_contract_id))
@@ -717,8 +817,20 @@ fn matches_types_filter(
     types_set: &Option<HashSet<&str>>,
     types_not_set: &Option<HashSet<&str>>,
     bulk_payment_contract_id: &near_api::AccountId,
+    treasury_id: &str,
 ) -> bool {
-    let name = if AssetExchangeInfo::from_proposal(proposal).is_some() {
+    let confidential = ConfidentialRequestInfo::from_proposal(proposal, treasury_id);
+    let is_confidential_marker = ConfidentialRequestInfo::is_confidential(proposal);
+
+    let name = if let Some(info) = &confidential {
+        match info {
+            ConfidentialRequestInfo::Swap { .. } => "Exchange",
+            ConfidentialRequestInfo::Payment { .. } => "Payments",
+        }
+    } else if is_confidential_marker {
+        // Confidential but not yet enriched — treat as generic confidential.
+        "Confidential"
+    } else if AssetExchangeInfo::from_proposal(proposal).is_some() {
         "Exchange"
     } else if PaymentInfo::from_proposal(proposal, Some(bulk_payment_contract_id)).is_some()
         || BulkPayment::from_proposal_with_contract_id(proposal, bulk_payment_contract_id).is_some()
@@ -738,16 +850,32 @@ fn matches_types_filter(
         "Unknown"
     };
 
-    if let Some(types) = types_set
-        && !types.contains(name)
-    {
-        return false;
+    // Confidential is also matchable as its own category regardless of subtype.
+    let confidential_match_name = if is_confidential_marker {
+        Some("Confidential")
+    } else {
+        None
+    };
+
+    if let Some(types) = types_set {
+        let matches_primary = types.contains(name);
+        let matches_confidential = confidential_match_name
+            .map(|n| types.contains(n))
+            .unwrap_or(false);
+        if !matches_primary && !matches_confidential {
+            return false;
+        }
     }
 
-    if let Some(types_not) = types_not_set
-        && types_not.contains(name)
-    {
-        return false;
+    if let Some(types_not) = types_not_set {
+        if types_not.contains(name) {
+            return false;
+        }
+        if let Some(n) = confidential_match_name
+            && types_not.contains(n)
+        {
+            return false;
+        }
     }
 
     true
@@ -761,6 +889,7 @@ impl ProposalFilters {
         cache: &Cache,
         network: &NetworkConfig,
         bulk_payment_contract_id: &near_api::AccountId,
+        treasury_id: &str,
     ) -> Result<Vec<Proposal>, Box<dyn std::error::Error>> {
         let types_set = to_str_hashset(&self.types);
         let types_not_set = to_str_hashset(&self.types_not);
@@ -824,6 +953,7 @@ impl ProposalFilters {
                 &types_set,
                 &types_not_set,
                 bulk_payment_contract_id,
+                treasury_id,
             ) {
                 continue;
             }
@@ -991,7 +1121,13 @@ impl ProposalFilters {
             // Smart filters - apply each filter independently across relevant proposal types
 
             // Apply tokens filter
-            if !matches_tokens_filter(&proposal, token, token_not, bulk_payment_contract_id) {
+            if !matches_tokens_filter(
+                &proposal,
+                token,
+                token_not,
+                bulk_payment_contract_id,
+                treasury_id,
+            ) {
                 continue;
             }
 
@@ -1003,6 +1139,7 @@ impl ProposalFilters {
                 cache,
                 network,
                 bulk_payment_contract_id,
+                treasury_id,
             )
             .await
             {
@@ -1028,8 +1165,15 @@ impl ProposalFilters {
             }
 
             // Apply amount filters
-            if !matches_amount_filters(&proposal, self, cache, network, bulk_payment_contract_id)
-                .await
+            if !matches_amount_filters(
+                &proposal,
+                self,
+                cache,
+                network,
+                bulk_payment_contract_id,
+                treasury_id,
+            )
+            .await
             {
                 continue;
             }

--- a/nt-be/src/handlers/proposals/get_proposals.rs
+++ b/nt-be/src/handlers/proposals/get_proposals.rs
@@ -127,6 +127,17 @@ pub async fn get_proposals(
         page_size: query.page_size,
     };
 
+    // Enrich confidential proposals BEFORE filtering so filters can see subtype.
+    // Only enrich if the caller is an authenticated DAO member.
+    let should_enrich = auth_user
+        .verify_member_if_confidential(&state.db_pool, dao_id.as_ref())
+        .await
+        .unwrap_or(false);
+    let mut proposals = proposals;
+    if should_enrich {
+        enrich_confidential_proposals(&mut proposals, &state.db_pool, dao_id.as_ref()).await;
+    }
+
     // Apply filters
     let filtered_proposals = filters
         .filter_proposals_async(
@@ -135,6 +146,7 @@ pub async fn get_proposals(
             &state.cache,
             &state.network,
             &state.bulk_payment_contract_id,
+            dao_id.as_ref(),
         )
         .await
         .map_err(|e| {
@@ -161,17 +173,6 @@ pub async fn get_proposals(
         }
         _ => filtered_proposals,
     };
-
-    // Enrich confidential proposals with quote metadata — only for authenticated DAO members.
-    // If auth fails or user is not a member, still return proposals without enrichment.
-    let mut proposals = proposals;
-    let should_enrich = auth_user
-        .verify_member_if_confidential(&state.db_pool, dao_id.as_ref())
-        .await
-        .unwrap_or(false);
-    if should_enrich {
-        enrich_confidential_proposals(&mut proposals, &state.db_pool, dao_id.as_ref()).await;
-    }
 
     let response = PaginatedProposals {
         proposals,

--- a/nt-be/src/handlers/proposals/scraper.rs
+++ b/nt-be/src/handlers/proposals/scraper.rs
@@ -471,6 +471,114 @@ pub struct StakeDelegationInfo {
     pub validator: AccountId,
 }
 
+/// Confidential request subtype, derived from confidential_metadata.quote_metadata
+/// and the treasury (dao) account id. Mirrors FE `extractConfidentialRequestData`.
+#[derive(Debug, Clone)]
+pub enum ConfidentialRequestInfo {
+    Payment {
+        token_id: String,
+        amount: String,
+        receiver: String,
+    },
+    Swap {
+        token_in_address: String,
+        amount_in: String,
+        token_out_address: String,
+        amount_out: String,
+        deposit_address: String,
+    },
+}
+
+impl ConfidentialRequestInfo {
+    /// Detect confidential proposal and classify as payment or swap.
+    /// - Confidential = description field `proposal action: confidential`
+    ///   AND FunctionCall to `v1.signer` with `sign` method.
+    /// - Subtype: if `quoteRequest.recipient == treasury_id` -> Swap, else Payment.
+    ///   Without quote_metadata (unenriched) returns None.
+    pub fn from_proposal(proposal: &Proposal, treasury_id: &str) -> Option<Self> {
+        if extract_from_description(&proposal.description, "proposalaction")
+            != Some("confidential".to_string())
+        {
+            return None;
+        }
+
+        // Confirm v1.signer sign proposal structurally.
+        extract_payload_hash_from_kind(&proposal.kind)?;
+
+        let meta = proposal.confidential_metadata.as_ref()?;
+        let quote_meta = meta.get("quote_metadata")?;
+        if quote_meta.is_null() {
+            return None;
+        }
+        let quote = quote_meta.get("quote")?;
+        let quote_request = quote_meta.get("quoteRequest")?;
+
+        let recipient = quote_request
+            .get("recipient")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let is_swap = recipient == treasury_id;
+
+        if is_swap {
+            let token_in_address = quote_request
+                .get("originAsset")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let token_out_address = quote_request
+                .get("destinationAsset")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let amount_in = quote
+                .get("amountIn")
+                .and_then(|v| v.as_str())
+                .unwrap_or("0")
+                .to_string();
+            let amount_out = quote
+                .get("amountOutFormatted")
+                .and_then(|v| v.as_str())
+                .unwrap_or("0")
+                .to_string();
+            let deposit_address = quote
+                .get("depositAddress")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(ConfidentialRequestInfo::Swap {
+                token_in_address,
+                amount_in,
+                token_out_address,
+                amount_out,
+                deposit_address,
+            })
+        } else {
+            let token_id = quote_request
+                .get("originAsset")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let amount = quote
+                .get("amountIn")
+                .and_then(|v| v.as_str())
+                .unwrap_or("0")
+                .to_string();
+            Some(ConfidentialRequestInfo::Payment {
+                token_id,
+                amount,
+                receiver: recipient.to_string(),
+            })
+        }
+    }
+
+    /// Returns true if this is confidential regardless of enrichment (uses description+kind only).
+    pub fn is_confidential(proposal: &Proposal) -> bool {
+        extract_from_description(&proposal.description, "proposalaction")
+            == Some("confidential".to_string())
+            && extract_payload_hash_from_kind(&proposal.kind).is_some()
+    }
+}
+
 impl PaymentProposalType for PaymentInfo {
     fn from_proposal(
         proposal: &Proposal,

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -85,6 +85,8 @@ interface NetworkBalanceDisplay {
 
 const STABLE_EMPTY_ARRAY: never[] = [];
 
+const NEAR_DIRECT_NETWORK_ID = "near.com:direct";
+
 export function DepositModal({
     isOpen,
     onClose,
@@ -192,7 +194,11 @@ export function DepositModal({
                 const balance = selectedNetworkBalances.get(network.id);
                 return !balance || !Big(balance.amount).gt(0);
             })
-            .sort((a, b) => a.name.localeCompare(b.name));
+            .sort((a, b) => {
+                if (a.id === NEAR_DIRECT_NETWORK_ID) return -1;
+                if (b.id === NEAR_DIRECT_NETWORK_ID) return 1;
+                return a.name.localeCompare(b.name);
+            });
 
         if (withAssets.length === 0) {
             return [
@@ -353,8 +359,17 @@ export function DepositModal({
             return balances;
         };
 
+        const nearDirectNetworkOption = (): SelectOption => ({
+            id: NEAR_DIRECT_NETWORK_ID,
+            name: "near.com",
+            icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAMAAABF0y+mAAAAPFBMVEVHcEwA7JcA7JcA7JcA7JcA65YA7JcA75kAyIAA3IwANiIAAAAAvXkAGhAA9p0AdUsAwnwAlF8AaUMAtXS/E4peAAAAB3RSTlMAZsz/ZQfmMR3ddQAAAMdJREFUeAF9k1EShCAIQDUsNBSr7n/Xxc3WZtHeF/iGEQc0gp1AMTlTmBfosswiB06sMQ6GWFPvQ3hQk8nU1Iem0df4krgSRbxdohWbRE9CreUsscc/mQBLvJGWmWhlEIh2Jb0cHQx8UNiUjHJMO58JOGqJXFoOgNiTCFfLXQkYxA4rQywt9yRDOvnbspZbqC+h3SspNSCUlrOSUoslhESkZWYoYKjyObL0m1ikNrLnfGvtnXTWBNuaWBjiXlfzfakF1/sOVsQHNdERKfT2DooAAAAASUVORK5CYII=",
+        });
+
         for (const asset of bridgeAssets) {
             const networks = asset.networks.map(toNetworkOption);
+            if (isConfidential) {
+                networks.unshift(nearDirectNetworkOption());
+            }
             newAssetNetworksMap.set(asset.id, networks);
             networkBalancesByAssetId.set(
                 asset.id,
@@ -473,6 +488,13 @@ export function DepositModal({
                 if (prefillNetwork) networkToSelect = prefillNetwork;
             }
 
+            if (!networkToSelect && isConfidential) {
+                networkToSelect =
+                    availableNetworks.find(
+                        (n) => n.id === NEAR_DIRECT_NETWORK_ID,
+                    ) || null;
+            }
+
             if (!networkToSelect && availableNetworks.length === 1) {
                 networkToSelect = availableNetworks[0];
             }
@@ -513,9 +535,15 @@ export function DepositModal({
                 networkBalancesByAsset.get(asset.id) || new Map(),
             );
 
-            // Auto-select network if only one is available
+            const nearDirectNetwork = availableNetworks.find(
+                (n) => n.id === NEAR_DIRECT_NETWORK_ID,
+            );
+
+            // Auto-select network if only one is available, or near.com for confidential
             if (availableNetworks.length === 1) {
                 form.setValue("network", availableNetworks[0]);
+            } else if (isConfidential && nearDirectNetwork) {
+                form.setValue("network", nearDirectNetwork);
             } else if (
                 selectedNetwork &&
                 !availableNetworks.some((n) => n.id === selectedNetwork.id)
@@ -523,7 +551,13 @@ export function DepositModal({
                 form.setValue("network", null);
             }
         },
-        [form, assetNetworksMap, selectedNetwork, networkBalancesByAsset],
+        [
+            form,
+            assetNetworksMap,
+            selectedNetwork,
+            networkBalancesByAsset,
+            isConfidential,
+        ],
     );
 
     // Handle network selection
@@ -546,6 +580,16 @@ export function DepositModal({
                 return;
             }
             const requestId = ++latestAddressRequestRef.current;
+
+            if (selectedNetwork.id === NEAR_DIRECT_NETWORK_ID) {
+                if (requestId !== latestAddressRequestRef.current) return;
+                setDepositInfo({
+                    address: treasuryId,
+                    memo: null,
+                    minDepositAmount: null,
+                });
+                return;
+            }
 
             // All NEAR networks deposit directly to treasury account ID
             // (except confidential treasuries which always go through intents)
@@ -818,7 +862,7 @@ export function DepositModal({
                                                                         </span>
                                                                     </div>
                                                                 )}
-                                                                <span className="text-foreground font-medium capitalize">
+                                                                <span className="text-foreground font-medium uppercase">
                                                                     {getNetworkDisplayName(
                                                                         selectedNetwork.name,
                                                                     )}

--- a/nt-fe/e2e/confidential-deposit.spec.ts
+++ b/nt-fe/e2e/confidential-deposit.spec.ts
@@ -270,17 +270,40 @@ test("Confidential deposit — dashboard deposit modal flow", async ({
     // Deposit modal auto-select priority in UI is:
     // prefill token -> owned USDC -> first "Your Assets" token by USD balance.
     // In this sandbox scenario, Near is the first available owned asset.
-    await expect(page.getByRole("button", { name: "Near Near" })).toBeVisible({
-        timeout: 10_000,
-    });
-
-    // Confidential flow currently exposes a single network option: Near Protocol.
-    // The selector is pre-populated, so no "Select Network" interaction is needed.
     await expect(
-        page.getByRole("button", { name: "Near Protocol Near Protocol" }),
+        page.getByRole("button", { name: "near.com near.com" }),
     ).toBeVisible({
         timeout: 10_000,
     });
+
+    // Confidential flow defaults the network to near.com (direct NEAR deposit).
+    // Address shown should be the treasury ID, no intents deposit-address call.
+    const nearDirectButton = page.getByRole("button", {
+        name: "near.com near.com",
+    });
+    await expect(nearDirectButton).toBeVisible({ timeout: 10_000 });
+
+    await expect(
+        page.getByText("Deposit Address", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const directAddressElement = page.locator("code").first();
+    await expect(directAddressElement).toBeVisible({ timeout: 10_000 });
+    expect(await directAddressElement.textContent()).toContain(DAO_ID);
+    expect(depositAddressRequested).toBe(false);
+
+    // Switch network: open selector, pick Near Protocol (bridge deposit).
+    await nearDirectButton.click();
+    await expect(
+        page.getByRole("heading", { name: "Select Network" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await page
+        .getByRole("button", { name: /Near Protocol Near Protocol/ })
+        .click();
+
+    await expect(
+        page.getByRole("button", { name: "Near Protocol Near Protocol" }),
+    ).toBeVisible({ timeout: 10_000 });
 
     // Wait for deposit address section to appear
     await expect(
@@ -297,7 +320,7 @@ test("Confidential deposit — dashboard deposit modal flow", async ({
     expect(addressText).not.toContain(DAO_ID);
 
     // Confidential treasury must have called deposit-address API
-    // (public treasuries on NEAR would skip this and use the direct treasury ID)
+    // after switching away from near.com direct.
     expect(depositAddressRequested).toBe(true);
 
     // QR code should be rendered
@@ -316,20 +339,9 @@ test("Confidential deposit — dashboard deposit modal flow", async ({
 
     // Open the currently selected asset button
     const assetSelectButton = page.getByRole("button", {
-        name: "Near Near",
+        name: "Near Protocol Near Protocol",
         exact: true,
     });
     await expect(assetSelectButton).toBeVisible({ timeout: 10_000 });
     await assetSelectButton.click();
-
-    // The asset selection modal should open
-    await expect(
-        page.getByRole("heading", { name: "Select Asset" }),
-    ).toBeVisible({ timeout: 10_000 });
-
-    // "Other" option should NOT be present for confidential treasuries
-    await expect(page.getByText("Other", { exact: true })).not.toBeVisible();
-
-    // Bridge assets should be listed
-    await expect(page.getByText("Near").first()).toBeVisible();
 });

--- a/nt-fe/features/activity/components/transaction-details-modal.tsx
+++ b/nt-fe/features/activity/components/transaction-details-modal.tsx
@@ -53,7 +53,7 @@ function AccountValue({
     return (
         <div className="flex items-center gap-1">
             <span className="max-w-[300px] truncate">{value}</span>
-            {showCopy ? (
+            {showCopy && value !== "—" ? (
                 <CopyButton
                     text={value}
                     variant="ghost"

--- a/nt-fe/features/proposals/components/proposal-filters.tsx
+++ b/nt-fe/features/proposals/components/proposal-filters.tsx
@@ -36,6 +36,18 @@ const PROPOSAL_TYPE_OPTIONS = [
     "Settings",
 ];
 
+// When a treasury is confidential and the viewer is not a member, the subtype
+// of confidential proposals (payment vs exchange) cannot be revealed. Collapse
+// Payments + Exchange into a single "Confidential" option.
+const CONFIDENTIAL_GUEST_PROPOSAL_TYPE_OPTIONS = [
+    "Confidential",
+    "Earn",
+    "Vesting",
+    "Function Call",
+    "Change Policy",
+    "Settings",
+];
+
 const MY_VOTE_OPTIONS = ["Approved", "Rejected", "No Voted"];
 const MY_VOTE_OPERATIONS = ["Is"];
 
@@ -701,6 +713,11 @@ function ProposalTypeFilterContent({
     setIsOpen: (isOpen: boolean) => void;
     onRemove: () => void;
 }) {
+    const { isConfidential, isGuestTreasury } = useTreasury();
+    const options =
+        isConfidential && isGuestTreasury
+            ? CONFIDENTIAL_GUEST_PROPOSAL_TYPE_OPTIONS
+            : PROPOSAL_TYPE_OPTIONS;
     return (
         <CheckboxFilterContent
             value={value}
@@ -709,7 +726,7 @@ function ProposalTypeFilterContent({
             onRemove={onRemove}
             filterLabel="Request Type"
             operations={PROPOSAL_TYPE_OPERATIONS}
-            options={PROPOSAL_TYPE_OPTIONS.map((type) => ({
+            options={options.map((type) => ({
                 value: type,
                 label: type,
             }))}


### PR DESCRIPTION
## Summary
- Backend: teach proposal filter pipeline about confidential proposals. `ConfidentialRequestInfo` derives payment vs swap from `quote_metadata` + treasury id, and `types/tokens/recipients/amount` filters now handle confidential subtypes. Enrichment moved to run **before** filtering so DAO members filter on real subtype; non-members see collapsed "Confidential" type.
- Frontend: add `near.com:direct` network option to confidential deposit modal (direct-to-treasury, no intents bridge), pinned to top and auto-selected. Network name rendered UPPERCASE.
- Frontend: proposal type filter collapses Payments + Exchange into single "Confidential" option for non-member guests of confidential treasuries.
- Frontend: hide copy button in activity modal when value is `—`.
