### PR TITLE
feat(nt-fe): add 9 locales — DE, FR, VI, ZH, TR, ID, PT, JA, KO

### DIFF
--- a/nt-fe/components/language-switcher.tsx
+++ b/nt-fe/components/language-switcher.tsx
@@ -30,6 +30,22 @@ const labelKeyByLocale: Record<Locale, string> = {
     ko: "korean",
 };
 
+const flagByLocale: Record<Locale, string> = {
+    en: "🇬🇧",
+    es: "🇪🇸",
+    uk: "🇺🇦",
+    he: "🇮🇱",
+    de: "🇩🇪",
+    fr: "🇫🇷",
+    vi: "🇻🇳",
+    zh: "🇨🇳",
+    tr: "🇹🇷",
+    id: "🇮🇩",
+    pt: "🇧🇷",
+    ja: "🇯🇵",
+    ko: "🇰🇷",
+};
+
 interface LanguageSwitcherProps {
     align?: "start" | "end" | "center";
     className?: string;
@@ -83,7 +99,12 @@ export function LanguageSwitcher({
                         onSelect={() => handleSelect(code)}
                         className="flex items-center justify-between gap-2"
                     >
-                        <span>{t(labelKeyByLocale[code])}</span>
+                        <span className="flex items-center gap-2">
+                            <span aria-hidden="true" className="text-base">
+                                {flagByLocale[code]}
+                            </span>
+                            <span>{t(labelKeyByLocale[code])}</span>
+                        </span>
                         {code === locale && <Check className="h-4 w-4" />}
                     </DropdownMenuItem>
                 ))}

--- a/nt-fe/components/language-switcher.tsx
+++ b/nt-fe/components/language-switcher.tsx
@@ -19,6 +19,15 @@ const labelKeyByLocale: Record<Locale, string> = {
     es: "spanish",
     uk: "ukrainian",
     he: "hebrew",
+    de: "german",
+    fr: "french",
+    vi: "vietnamese",
+    zh: "chinese",
+    tr: "turkish",
+    id: "indonesian",
+    pt: "portuguese",
+    ja: "japanese",
+    ko: "korean",
 };
 
 interface LanguageSwitcherProps {

--- a/nt-fe/components/language-switcher.tsx
+++ b/nt-fe/components/language-switcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Languages } from "lucide-react";
+import { Check, Globe } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { useTransition } from "react";
@@ -89,7 +89,7 @@ export function LanguageSwitcher({
                         className,
                     )}
                 >
-                    <Languages className="h-5 w-5" />
+                    <Globe className="h-5 w-5" />
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align={align} className="min-w-[160px]">

--- a/nt-fe/components/ui/datepicker.tsx
+++ b/nt-fe/components/ui/datepicker.tsx
@@ -37,6 +37,15 @@ import { enUS } from "date-fns/locale/en-US";
 import { es } from "date-fns/locale/es";
 import { uk } from "date-fns/locale/uk";
 import { he } from "date-fns/locale/he";
+import { de } from "date-fns/locale/de";
+import { fr } from "date-fns/locale/fr";
+import { vi } from "date-fns/locale/vi";
+import { zhCN } from "date-fns/locale/zh-CN";
+import { tr } from "date-fns/locale/tr";
+import { id } from "date-fns/locale/id";
+import { pt } from "date-fns/locale/pt";
+import { ja } from "date-fns/locale/ja";
+import { ko } from "date-fns/locale/ko";
 import type { Locale } from "date-fns";
 
 const DATE_FNS_LOCALES: Record<string, Locale> = {
@@ -44,6 +53,15 @@ const DATE_FNS_LOCALES: Record<string, Locale> = {
     es,
     uk,
     he,
+    de,
+    fr,
+    vi,
+    zh: zhCN,
+    tr,
+    id,
+    pt,
+    ja,
+    ko,
 };
 
 import { Button, buttonVariants } from "@/components/ui/button";

--- a/nt-fe/i18n/config.ts
+++ b/nt-fe/i18n/config.ts
@@ -1,4 +1,18 @@
-export const locales = ["en", "es", "uk", "he"] as const;
+export const locales = [
+    "en",
+    "es",
+    "uk",
+    "he",
+    "de",
+    "fr",
+    "vi",
+    "zh",
+    "tr",
+    "id",
+    "pt",
+    "ja",
+    "ko",
+] as const;
 export type Locale = (typeof locales)[number];
 
 export const defaultLocale: Locale = "en";
@@ -8,6 +22,15 @@ export const localeNames: Record<Locale, string> = {
     es: "Español",
     uk: "Українська",
     he: "עברית",
+    de: "Deutsch",
+    fr: "Français",
+    vi: "Tiếng Việt",
+    zh: "中文",
+    tr: "Türkçe",
+    id: "Bahasa Indonesia",
+    pt: "Português",
+    ja: "日本語",
+    ko: "한국어",
 };
 
 /** Right-to-left locales. */

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -1,0 +1,2101 @@
+{
+    "common": {
+        "loading": "Wird geladen...",
+        "notAvailable": "k. A.",
+        "connecting": "Wird verbunden...",
+        "save": "Speichern",
+        "cancel": "Abbrechen",
+        "submit": "Absenden",
+        "close": "Schließen",
+        "back": "Zurück",
+        "seeDemo": "Trezu-Demo ansehen",
+        "search": "Suche",
+        "filter": "Filter",
+        "filterActive": "Filter (aktiv)",
+        "export": "Exportieren",
+        "exporting": "Wird exportiert",
+        "import": "Importieren",
+        "remove": "Entfernen",
+        "removing": "Wird entfernt...",
+        "edit": "Bearbeiten",
+        "continue": "Weiter",
+        "select": "Auswählen",
+        "all": "Alle",
+        "none": "Keine",
+        "retry": "Erneut versuchen",
+        "tryAgain": "Bitte erneut versuchen.",
+        "confirm": "Bestätigen",
+        "next": "Weiter",
+        "previous": "Zurück",
+        "yes": "Ja",
+        "no": "Nein",
+        "approve": "Genehmigen",
+        "reject": "Ablehnen",
+        "copy": "Kopieren",
+        "copied": "Kopiert",
+        "viewAll": "Alle anzeigen",
+        "viewDetails": "Details anzeigen",
+        "noResults": "Keine Ergebnisse gefunden",
+        "add": "Hinzufügen"
+    },
+    "languageSwitcher": {
+        "label": "Sprache",
+        "select": "Sprache auswählen",
+        "english": "English",
+        "spanish": "Español",
+        "ukrainian": "Українська",
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
+    },
+    "header": {
+        "toggleSidebar": "Seitenleiste umschalten",
+        "toggleTheme": "Design umschalten"
+    },
+    "nav": {
+        "dashboard": "Dashboard",
+        "requests": "Anfragen",
+        "payments": "Zahlungen",
+        "exchange": "Tauschen",
+        "addressBook": "Adressbuch",
+        "members": "Mitglieder",
+        "settings": "Einstellungen",
+        "helpSupport": "Hilfe & Support",
+        "saveGuestTreasury": "Diese Gast-Treasury in Ihrer Treasury-Liste speichern."
+    },
+    "signIn": {
+        "connect": "Verbinden",
+        "connectWallet": "Wallet verbinden",
+        "wallet": "Wallet",
+        "termsOfService": "Nutzungsbedingungen",
+        "privacyPolicy": "Datenschutzerklärung",
+        "disconnect": "Trennen"
+    },
+    "auth": {
+        "noWallet": "Verbinden Sie Ihre Wallet",
+        "noPermission": "Sie haben keine Berechtigung, diese Aktion auszuführen",
+        "noVote": "Sie haben über diesen Vorschlag bereits abgestimmt",
+        "noSponsoredTransactions": "Keine gesponserten Transaktionen mehr verfügbar"
+    },
+    "landing": {
+        "welcome": "Willkommen bei Trezu",
+        "chooseOption": "Wählen Sie unten eine Option, um zu starten.",
+        "newUserTitle": "Ich bin neu bei Trezu",
+        "newUserDescription": "Ich habe von Trezu gehört, habe aber noch keine Treasury.",
+        "existingUserTitle": "Ich nutze Trezu bereits",
+        "existingUserDescription": "Ich habe ein Konto und verwalte eine Treasury.",
+        "gradientTagline": "Cross-Chain-Multisig-Sicherheit für die Verwaltung digitaler Vermögenswerte",
+        "waitlistTitle": "Tragen Sie sich auf die Trezu-Warteliste ein",
+        "waitlistSubmittedTitle": "Sie sind auf der Liste 🎉",
+        "waitlistSubmittedDescription": "Vielen Dank! Wir benachrichtigen Sie, sobald die Treasury-Erstellung verfügbar ist.",
+        "waitlistDescription": "Wir haben das heutige Treasury-Limit erreicht. Kein Problem - versuchen Sie es später erneut oder hinterlassen Sie Ihre Kontaktdaten für die Warteliste. Wir melden uns, sobald ein Platz frei wird.",
+        "waitlistInputPlaceholder": "E-Mail-Adresse oder Telegram (z. B. @username)",
+        "waitlistPrivacyNote": "Wir verwenden diese Daten ausschließlich zur Benachrichtigung",
+        "waitlistSubmit": "Auf die Warteliste setzen",
+        "waitlistSubmitFailed": "Übermittlung fehlgeschlagen. Bitte erneut versuchen.",
+        "welcomeAlt": "Willkommen"
+    },
+    "blocked": {
+        "title": "Dienst in Ihrem Land nicht verfügbar",
+        "description": "Aufgrund von Einschränkungen ist dieser Dienst in Ihrer Region derzeit nicht verfügbar."
+    },
+    "notFound": {
+        "title": "Hoppla, diese Seite ist nicht mehr verfügbar...",
+        "description": "Es scheint, dass Sie einem nicht mehr funktionierenden Link gefolgt sind. Gehen Sie zurück oder kehren Sie zum Dashboard zurück.",
+        "backToDashboard": "Zurück zum Dashboard"
+    },
+    "treasuryInfo": {
+        "logoAlt": "Treasury-Logo"
+    },
+    "dateInput": {
+        "placeholder": "tt.mm.jjjj"
+    },
+    "thresholdSlider": {
+        "warningSingleMember": "Ein Schwellenwert von 1 von {memberCount} bedeutet, dass jedes einzelne Mitglied Transaktionen ausführen kann. Dies verringert die Sicherheit.",
+        "infoBalanced": "Ein Schwellenwert von {currentThreshold} von {memberCount} bietet ein gutes Gleichgewicht zwischen Sicherheit und operativer Flexibilität."
+    },
+    "intentsFee": {
+        "amountTooLowForFee": "{prefix}Betrag zu niedrig für Netzwerkgebühr ({fee} {symbol}). Fügen Sie mindestens {addMore} {symbol} hinzu."
+    },
+    "metadata": {
+        "treasuryTitle": "Dashboard | Trezu",
+        "landingTitle": "Trezu | Cross-Chain Treasury Management",
+        "description": "Verwalten Sie das Kapital Ihres Teams in wenigen Minuten über ein einziges Dashboard, ohne jemals Ihre Schlüssel aus der Hand zu geben.",
+        "ogTitle": "Trezu | Eine Multisig. Jede Krypto. Volle Kontrolle."
+    },
+    "pages": {
+        "dashboard": {
+            "title": "Dashboard",
+            "description": "Übersicht über Ihre Treasury-Vermögenswerte und -Aktivitäten",
+            "descriptionLong": "Verwalten Sie Ihre Treasury-Vermögenswerte und verfolgen Sie Aktivitäten"
+        },
+        "activity": {
+            "title": "Letzte Transaktionen",
+            "descriptionDetails": "Details zur Anfrage",
+            "descriptionList": "Letzte Transaktionen über alle Vermögenswerte hinweg"
+        },
+        "requests": {
+            "title": "Anfragen",
+            "description": "Alle ausstehenden Multisig-Anfragen anzeigen und verwalten",
+            "detailDescription": "Details zur Anfrage",
+            "detailTitle": "Anfrage Nr. {id}"
+        },
+        "members": {
+            "title": "Mitglieder",
+            "description": "Teammitglieder und Berechtigungen verwalten"
+        },
+        "settings": {
+            "title": "Einstellungen",
+            "description": "Passen Sie Ihre App-Einstellungen an"
+        },
+        "addressBook": {
+            "title": "Adressbuch",
+            "description": "Verwalten Sie Ihre gespeicherten Empfänger"
+        },
+        "payments": {
+            "title": "Zahlungen",
+            "description": "Senden und empfangen Sie Mittel sicher"
+        },
+        "exchange": {
+            "title": "Tauschen",
+            "description": "Tauschen Sie Ihre Token sicher und effizient"
+        },
+        "vesting": {
+            "title": "Vesting",
+            "description": "Erstellen Sie Vesting-Pläne schnell und mühelos"
+        },
+        "earn": {
+            "title": "Erträge",
+            "description": "Erträge auf Ihre Vermögenswerte erzielen",
+            "placeholder": "Erkunden Sie Ertragsmöglichkeiten und Staking-Belohnungen."
+        },
+        "createTreasury": {
+            "title": "Treasury erstellen",
+            "description": "Richten Sie eine neue Multisig-Treasury für Ihr Team ein"
+        },
+        "manageTreasuries": {
+            "title": "Treasuries verwalten",
+            "description": "Steuern Sie, welche Treasuries in Ihrem Konto erscheinen"
+        },
+        "stats": {
+            "title": "Statistiken",
+            "description": "Echtzeit-Vermögenswerte unter Verwaltung über alle Sputnik-DAO-Treasuries hinweg."
+        },
+        "telegram": {
+            "title": "Treasury verbinden",
+            "description": "Verknüpfen Sie Ihre Treasuries mit einem Telegram-Chat",
+            "metaTitle": "Trezu — Telegram verbinden",
+            "metaDescription": "Verbinden Sie Ihre Trezu-Treasury mit einem Telegram-Chat"
+        },
+        "wallet": {
+            "title": "Trezu Wallet",
+            "description": "Treasury-Vorschläge über Trezu signieren"
+        }
+    },
+    "depositModal": {
+        "validation": {
+            "selectAsset": "Bitte wählen Sie einen Vermögenswert aus",
+            "selectNetwork": "Bitte wählen Sie ein Netzwerk aus"
+        },
+        "sections": {
+            "supportedNetworks": "Unterstützte Netzwerke",
+            "networksWithAssets": "Netzwerke mit Vermögenswerten",
+            "yourAssets": "Ihre Vermögenswerte",
+            "otherAssets": "Andere Vermögenswerte"
+        },
+        "errors": {
+            "addressUnavailable": "Einzahlungsadresse für den ausgewählten Vermögenswert und das Netzwerk konnte nicht abgerufen werden.",
+            "fetchFailed": "Abrufen der Einzahlungsadresse fehlgeschlagen. Bitte erneut versuchen."
+        },
+        "title": "Einzahlen",
+        "subtitle": "Wählen Sie Vermögenswert und Netzwerk, um die Einzahlungsadresse anzuzeigen",
+        "assetLabel": "Vermögenswert",
+        "networkLabel": "Netzwerk",
+        "selectAsset": "Vermögenswert auswählen",
+        "selectNetwork": "Netzwerk auswählen",
+        "otherAssetName": "Andere",
+        "otherNetworkInfo": "Sie können jedes Token einzahlen, das nicht in den Vermögenswerten aufgeführt ist, jedoch nur über das NEAR-Netzwerk.",
+        "depositAddressHeading": "Einzahlungsadresse",
+        "depositAddressSubtitle": "Überprüfen Sie Ihre Einzahlungsadresse stets sorgfältig.",
+        "addressLabel": "Adresse",
+        "addressCopied": "Adresse in die Zwischenablage kopiert",
+        "memoLabel": "Memo",
+        "memoCopied": "Memo in die Zwischenablage kopiert",
+        "memoWarning": "Sie <bold>müssen</bold> das Memo angeben, wenn Sie Mittel an diese Adresse senden. Ein Versand ohne Memo kann zum dauerhaften Verlust der Mittel führen.",
+        "onlyDeposit": "Zahlen Sie nur <symbolTag>{symbol}</symbolTag> aus dem <networkTag>{network}</networkTag>-Netzwerk ein. Wir empfehlen, mit einer kleinen Testtransaktion zu beginnen, um sicherzustellen, dass alles korrekt funktioniert, bevor Sie den vollen Betrag senden.",
+        "minimumDeposit": "Mindesteinzahlung: <amountTag>{amount} {symbol}</amountTag>",
+        "searchByName": "Nach Namen suchen"
+    },
+    "assetDetails": {
+        "coinPrice": "Coin-Preis",
+        "weight": "Gewicht",
+        "source": "Quelle",
+        "send": "Senden",
+        "exchange": "Tauschen",
+        "comingSoon": "Demnächst verfügbar",
+        "vesting": "Vesting",
+        "vestedPercent": "{percent}% gevestet",
+        "frozen": "Eingefroren",
+        "frozenTooltip": "Eingefrorene Token sind gesperrt und können nicht verwendet werden. Sie könnten gesperrt sein, weil sie für Speicher verwendet werden, gestaked sind oder noch nicht gevestet wurden.",
+        "vested": "Gevestet"
+    },
+    "dashboard": {
+        "overview": "Übersicht über Ihre Treasury-Vermögenswerte und -Aktivitäten",
+        "assets": "Vermögenswerte",
+        "balance": "Guthaben",
+        "totalBalance": "Gesamtguthaben",
+        "deposit": "Einzahlen",
+        "addAssets": "Vermögenswerte hinzufügen",
+        "hidden": "Ausgeblendet",
+        "confidentialHidden": "Guthaben für vertrauliche Treasuries ausgeblendet",
+        "recentActivity": "Letzte Aktivität",
+        "viewAllTransactions": "Alle Transaktionen anzeigen"
+    },
+    "activity": {
+        "filters": {
+            "createdDate": "Erstellungsdatum",
+            "token": "Token",
+            "from": "Von",
+            "to": "An"
+        },
+        "tabs": {
+            "all": "Alle",
+            "sent": "Gesendet",
+            "received": "Empfangen",
+            "stakingRewards": "Staking-Belohnungen",
+            "exchange": "Tauschen"
+        },
+        "searchPlaceholder": "Nach Transaktions-Hash suchen",
+        "searchPlaceholderShort": "Transaktions-Hash",
+        "fromPool": "von {pool}",
+        "table": {
+            "type": "TYP",
+            "transaction": "TRANSAKTION",
+            "from": "VON",
+            "to": "AN",
+            "transactionHash": "TRANSAKTIONS-HASH",
+            "hashTooltip": "Eindeutige Kennung (Hash) dieser Transaktion"
+        },
+        "empty": {
+            "title": "Keine Transaktionen gefunden",
+            "description": "Ihre Transaktionen erscheinen hier, sobald sie ausgeführt werden"
+        },
+        "emptyDashboard": {
+            "title": "Noch nichts anzuzeigen",
+            "description": "Ihre Transaktionen und Aktionen erscheinen hier, sobald sie ausgeführt werden"
+        },
+        "recentTitle": "Letzte Transaktionen",
+        "details": {
+            "title": "Transaktionsdetails",
+            "copyAddress": "Adresse kopieren",
+            "addressCopied": "Adresse in die Zwischenablage kopiert",
+            "sell": "Verkaufen",
+            "receive": "Empfangen",
+            "pending": "Ausstehend",
+            "type": "Typ",
+            "date": "Datum",
+            "from": "Von",
+            "to": "An",
+            "method": "Methode",
+            "contract": "Vertrag",
+            "transaction": "Transaktion"
+        }
+    },
+    "export": {
+        "types": {
+            "csv": ".CSV",
+            "json": ".JSON",
+            "xlsx": ".XLSX"
+        },
+        "transactionTypes": {
+            "all": "Alle Typen",
+            "sent": "Gesendet",
+            "received": "Empfangen",
+            "stakingRewards": "Staking-Belohnungen"
+        },
+        "validation": {
+            "invalidEmail": "Bitte geben Sie eine gültige E-Mail-Adresse ein"
+        },
+        "columns": {
+            "submissionTime": "Einreichungszeit",
+            "dateRange": "Datumsbereich",
+            "generatedBy": "Erstellt von",
+            "status": "Status"
+        },
+        "status": {
+            "generating": "Wird erstellt",
+            "expired": "Abgelaufen",
+            "failed": "Fehlgeschlagen"
+        },
+        "noPermission": "Sie haben keine Berechtigung, die Datei herunterzuladen.",
+        "download": "Herunterladen",
+        "heading": "Letzte Transaktionen exportieren",
+        "teamOnly": "Die Erstellung und der Download von Exporten sind nur für Teammitglieder verfügbar.",
+        "creditsUsed": "Sie haben alle Ihre Credits aufgebraucht",
+        "exportsUsed": "Sie haben alle Ihre Exporte aufgebraucht",
+        "upgradePrompt": "Upgraden Sie Ihren Tarif, um mehr zu erhalten und weiterzumachen",
+        "resetPrompt": "Upgraden Sie Ihren Tarif für mehr Zugriff oder warten Sie, bis Ihre Limits nächsten Monat zurückgesetzt werden.",
+        "tabs": {
+            "generate": "Export erstellen",
+            "history": "Verlauf"
+        },
+        "fields": {
+            "documentType": "Dokumenttyp",
+            "timeRange": "Zeitraum",
+            "selectDateRange": "Datumsbereich auswählen",
+            "asset": "Vermögenswert",
+            "allAssets": "Alle Vermögenswerte",
+            "transactionType": "Transaktionstyp"
+        },
+        "buttons": {
+            "noPermissionExport": "Sie haben keine Berechtigung zum Exportieren",
+            "quotaExhausted": "Sie haben Ihr gesamtes Kontingent aufgebraucht",
+            "exporting": "Wird exportiert...",
+            "export": "Exportieren"
+        },
+        "empty": {
+            "title": "Noch keine Exporte",
+            "description": "Ihre exportierten Dateien des letzten Monats erscheinen hier, sobald sie erstellt werden."
+        },
+        "requirements": {
+            "heading": "Export-Anforderungen",
+            "canExportFrom": "Sie können Daten exportieren aus:",
+            "availability": "Exportierte Dateien stehen 48 Stunden zum Download zur Verfügung."
+        },
+        "quota": {
+            "heading": "Export-Kontingent",
+            "unlimited": "Unbegrenzt",
+            "perMonth": "{count} / Monat",
+            "flexibilityPrompt": "Suchen Sie mehr Flexibilität?",
+            "contactUs": "Kontaktieren Sie uns"
+        }
+    },
+    "requests": {
+        "filters": {
+            "proposalTypes": {
+                "Payments": "Zahlungen",
+                "Exchange": "Tauschen",
+                "Earn": "Erträge",
+                "Vesting": "Vesting",
+                "Function Call": "Funktionsaufruf",
+                "Change Policy": "Richtlinie ändern",
+                "Settings": "Einstellungen",
+                "Confidential": "Vertraulich"
+            },
+            "voteStatus": {
+                "Approved": "Genehmigt",
+                "Rejected": "Abgelehnt",
+                "No Voted": "Nicht abgestimmt"
+            },
+            "requestsType": "Anfragetyp",
+            "createdDate": "Erstellungsdatum",
+            "recipient": "Empfänger",
+            "token": "Token",
+            "requester": "Antragsteller",
+            "approver": "Genehmiger",
+            "myVoteStatus": "Mein Abstimmungsstatus",
+            "all": "ALLE",
+            "amount": "Betrag",
+            "from": "Von",
+            "to": "An",
+            "min": "Min.",
+            "max": "Max.",
+            "invalidDate": "Ungültiges Datum",
+            "operationIsNot": " ist nicht",
+            "operationBefore": " vor",
+            "operationAfter": " nach",
+            "operationContains": " enthält",
+            "searchByAddress": "Nach Adresse suchen",
+            "loadingMembers": "Mitglieder werden geladen...",
+            "noMembersFound": "Keine Mitglieder gefunden. Drücken Sie Eingabe, um \"{query}\" hinzuzufügen",
+            "noMembersAvailable": "Keine Mitglieder verfügbar",
+            "reset": "Zurücksetzen",
+            "clear": "Löschen",
+            "addFilter": "Filter hinzufügen"
+        },
+        "tabs": {
+            "all": "Alle",
+            "pending": "Ausstehend",
+            "executed": "Ausgeführt",
+            "rejected": "Abgelehnt",
+            "expired": "Abgelaufen",
+            "failed": "Fehlgeschlagen"
+        },
+        "searchPlaceholder": "Anfrage nach Name oder ID suchen",
+        "searchPlaceholderShort": "Nach Name oder ID suchen",
+        "errorLoading": "Fehler beim Laden der Vorschläge. Bitte erneut versuchen.",
+        "empty": {
+            "title": "Erstellen Sie Ihre erste Anfrage",
+            "description": "Anfragen für Zahlungen, Tausche und andere Aktionen erscheinen hier, sobald sie erstellt werden.",
+            "send": "Senden",
+            "exchange": "Tauschen"
+        },
+        "actions": {
+            "approve": "Genehmigen",
+            "reject": "Ablehnen",
+            "deposit": "Einzahlen",
+            "viewRequest": "Anfrage anzeigen"
+        },
+        "table": {
+            "selectAll": "Alle auswählen",
+            "selectRow": "Zeile auswählen",
+            "request": "Anfrage",
+            "transaction": "Transaktion",
+            "requester": "Antragsteller",
+            "voting": "Abstimmung",
+            "votingTooltip": "Die erste Zahl zeigt erhaltene Genehmigungen. Die zweite Zahl zeigt zur Ausführung erforderliche Genehmigungen.",
+            "status": "Status",
+            "notPending": "Vorschlag ist nicht ausstehend.",
+            "noPermissionVote": "Sie haben keine Berechtigung, über diese Anfrage abzustimmen.",
+            "alreadyVoted": "Sie haben über diese Anfrage bereits abgestimmt.",
+            "noResults": "Keine Anfragen entsprechen Ihren Filtern.",
+            "allCaughtUp": "Alles erledigt!",
+            "noPending": "Es gibt keine ausstehenden Anfragen.",
+            "send": "Senden",
+            "exchange": "Tauschen",
+            "requestsSelected": "{count, plural, one {# Anfrage ausgewählt} other {# Anfragen ausgewählt}}",
+            "bulkApproveDisabled": "Diese Anfrage kann nicht genehmigt werden, da das Treasury-Guthaben unzureichend ist."
+        },
+        "pending": {
+            "title": "Ausstehende Anfragen",
+            "viewAll": "Alle anzeigen",
+            "emptyTitle": "Alles erledigt!",
+            "emptyDescription": "Es gibt keine ausstehenden Anfragen."
+        }
+    },
+    "proposals": {
+        "status": {
+            "pending": "Ausstehend",
+            "approved": "Genehmigt",
+            "rejected": "Abgelehnt",
+            "executed": "Ausgeführt",
+            "expired": "Abgelaufen",
+            "failed": "Fehlgeschlagen",
+            "removed": "Entfernt",
+            "inProgress": "In Bearbeitung"
+        },
+        "statusTooltip": {
+            "pending": "Diese Anfrage ist noch ausstehend und hat die zur Ausführung erforderliche Anzahl an Stimmen noch nicht erreicht.",
+            "executed": "Ausgeführt, nachdem {approved} von {required} Mitgliedern die Anfrage genehmigt haben.",
+            "rejected": "Abgelehnt, nachdem {rejected} von {required} Mitgliedern für die Ablehnung der Anfrage gestimmt haben.",
+            "expired": "Abgelaufen, da nicht genügend Stimmen zur Ausführung erhalten wurden.",
+            "failed": "Die Anfrage konnte nicht abgeschlossen werden. Transaktionsdetails finden Sie <link>hier</link>.",
+            "failedPlain": "Die Anfrage konnte nicht abgeschlossen werden. Transaktionsdetails finden Sie hier."
+        },
+        "votes": {
+            "approved": "Genehmigt",
+            "rejected": "Abgelehnt",
+            "pending": "Ausstehend"
+        },
+        "voteModal": {
+            "confirmTitle": "Bestätigen Sie Ihre Abstimmung",
+            "removeTitle": "Anfrage entfernen",
+            "bulkBody": "Sie sind dabei, mehrere Anfragen zu {action}. Nach dem Absenden kann diese Entscheidung nicht mehr geändert werden.",
+            "singleBody": "Sie sind dabei, diese Anfrage zu {action}. Nach der Bestätigung kann diese Aktion nicht rückgängig gemacht werden.",
+            "actionApprove": "genehmigen",
+            "actionReject": "ablehnen",
+            "actionRemove": "entfernen",
+            "insufficientBalance": "Anfragen <highlight>{ids}</highlight> können wegen unzureichenden Guthabens nicht genehmigt werden. Ihre Genehmigung gilt nur für die verbleibenden Anfragen.",
+            "remove": "Entfernen",
+            "confirm": "Bestätigen"
+        },
+        "expanded": {
+            "recipient": "Empfänger",
+            "amount": "Betrag",
+            "networkFee": "Netzwerkgebühr",
+            "notes": "Notizen",
+            "sent": "Gesendet",
+            "received": "Empfangen",
+            "priceDifference": "Preisunterschied",
+            "priceDifferenceTooltip": "Unterschied zwischen dem Angebotskurs und dem aktuellen Marktkurs. Positive Werte bedeuten einen besseren Kurs als der Markt.",
+            "slippageTolerance": "Slippage-Toleranz",
+            "estimatedTime": "Geschätzte Zeit",
+            "seconds": "{count} Sekunden",
+            "description": "Beschreibung",
+            "methodName": "Methodenname",
+            "args": "Args",
+            "deposit": "Einzahlen",
+            "gas": "Gas",
+            "totalDeposit": "Einzahlung gesamt",
+            "totalGas": "Gas gesamt",
+            "receiverId": "Empfänger-ID",
+            "contractId": "Vertrags-ID",
+            "actionsCount": "{count, plural, one {# Aktion} other {# Aktionen}}",
+            "functionCallsCount": "{count, plural, one {# Funktionsaufruf} other {# Funktionsaufrufe}}",
+            "showLess": "Weniger anzeigen",
+            "showMore": "Mehr anzeigen",
+            "stakingPool": "Staking-Pool",
+            "validator": "Validator",
+            "action": "Aktion",
+            "stake": "Staken",
+            "unstake": "Unstaken",
+            "withdraw": "Abheben",
+            "lockupOwner": "Lockup-Inhaber",
+            "lockupDuration": "Lockup-Dauer",
+            "cliff": "Cliff",
+            "releaseDuration": "Freigabedauer",
+            "vestingSchedule": "Vesting-Plan",
+            "cancellable": "Kündbar",
+            "allowEarn": "Staking erlauben",
+            "yes": "Ja",
+            "no": "Nein",
+            "notSet": "Nicht festgelegt",
+            "from": "Von",
+            "to": "An",
+            "paymentsCount": "{count, plural, one {# Zahlung} other {# Zahlungen}}",
+            "sourceWallet": "Quell-Wallet",
+            "allNear": "Alles NEAR",
+            "startDate": "Startdatum",
+            "endDate": "Enddatum",
+            "cliffDate": "Cliff-Datum",
+            "allowCancellation": "Kündigung erlauben",
+            "allowStaking": "Staking erlauben",
+            "loadingHistorical": "Historische Konfiguration wird geladen...",
+            "name": "Name",
+            "purpose": "Zweck",
+            "logo": "Logo",
+            "logoAlt": "Logo",
+            "primaryColor": "Primärfarbe",
+            "noChangesCurrent": "Keine Änderungen in der Konfiguration im Vergleich zum aktuellen Stand erkannt.",
+            "noChangesHistorical": "Keine Änderungen in der Konfiguration im Vergleich zum historischen Stand erkannt.",
+            "method": "Methode",
+            "arguments": "Argumente",
+            "contract": "Vertrag",
+            "actionNumber": "Aktion {number}",
+            "actions": "Aktionen",
+            "collapseAll": "Alle einklappen",
+            "expandAll": "Alle ausklappen",
+            "send": "Senden",
+            "receive": "Empfangen",
+            "rate": "Kurs",
+            "priceSlippageLimit": "Preis-Slippage-Limit",
+            "slippageTooltip": "Dies ist das für diese Anfrage festgelegte Slippage-Limit. Wenn sich der Marktkurs während der Ausführung über diesen Schwellenwert hinaus ändert, schlägt die Anfrage automatisch fehl.",
+            "estimatedTimeTooltip": "Geschätzte Zeit für die Ausführung des Tauschs nach Bestätigung der Einzahlungstransaktion.",
+            "minReceive": "Min. Erhalt",
+            "minimumReceived": "Mindestens erhalten",
+            "minReceiveTooltip": "Dies ist der Mindestbetrag, den Sie aus diesem Tausch erhalten, basierend auf dem für die Anfrage festgelegten Slippage-Limit.",
+            "depositAddress": "Einzahlungsadresse",
+            "depositAddressTooltip": "Die 1Click-Einzahlungsadresse, an die Token für die Cross-Chain-Tausch-Ausführung gesendet werden.",
+            "quoteSignature": "Angebotssignatur",
+            "quoteSignatureTooltip": "Die kryptografische Signatur der 1Click-API, die dieses Angebot validiert.",
+            "quoteDeadline": "1-Click-Angebotsfrist",
+            "quoteDeadlineTooltip": "Zeitpunkt, zu dem die Einzahlungsadresse inaktiv wird und Mittel verloren gehen können.",
+            "status": "Status",
+            "transactionLink": "Transaktionslink",
+            "viewTransaction": "Transaktion anzeigen",
+            "recipientNumber": "Empfänger {number}",
+            "oopsTitle": "Hoppla! Etwas ist schiefgelaufen",
+            "oopsDescription": "Wir konnten keine Daten zum Anzeigen finden.",
+            "totalAmount": "Gesamtbetrag",
+            "recipients": "Empfänger",
+            "recipientsCount": "{count, plural, one {# Empfänger} other {# Empfänger}}",
+            "unsupportedProposal": "Nicht unterstützter Vorschlagstyp",
+            "requestDetails": "Anfragedetails",
+            "linkCopied": "Link in die Zwischenablage kopiert",
+            "copyLink": "Link kopieren",
+            "openRequestPage": "Anfrageseite öffnen",
+            "deleteRequest": "Anfrage löschen",
+            "unknownRecipients": "Unbekannte Empfänger",
+            "loadingConfig": "Konfiguration wird geladen...",
+            "historicalData": "Historische Daten...",
+            "generalUpdate": "Allgemeine Aktualisierung",
+            "detailsUnavailable": "Details nicht verfügbar",
+            "changesCount": "{count, plural, one {# Änderung} other {# Änderungen}}",
+            "policyUpdate": "Richtlinien-Aktualisierung",
+            "noChangesDetected": "Keine Änderungen erkannt",
+            "loadingPolicy": "Richtlinie wird geladen...",
+            "roleChanges": "Rollenänderungen",
+            "policyParameters": "Richtlinienparameter",
+            "defaultVotePolicy": "Standardabstimmungsrichtlinie",
+            "policyRoleChanges": "Richtlinien- & Rollenänderungen",
+            "membersAdded": "{count, plural, one {# Mitglied hinzugefügt} other {# Mitglieder hinzugefügt}}",
+            "membersRemoved": "{count, plural, one {# Mitglied entfernt} other {# Mitglieder entfernt}}",
+            "membersUpdated": "{count, plural, one {# Mitglied aktualisiert} other {# Mitglieder aktualisiert}}",
+            "rolesModified": "{count, plural, one {# Rolle geändert} other {# Rollen geändert}}",
+            "parametersChanged": "{count, plural, one {# Parameter geändert} other {# Parameter geändert}}",
+            "defaultVotePolicyPart": "Standardabstimmungsrichtlinie",
+            "onReceiver": "auf {receiver}",
+            "toPrefix": "An:",
+            "validatorPrefix": "Validator:",
+            "validatorSubtitle": "Validator: {address}",
+            "impactTitle": "Auswirkung der Änderung der Abstimmungsdauer",
+            "impactBody": "Sie sind dabei, die Abstimmungsdauer zu aktualisieren. Dies wirkt sich auf die folgenden bestehenden Anfragen aus.",
+            "activeRequestsBullet": "{count, plural, one {# Anfrage bleibt nach dieser Änderung mit aktualisierten Ablaufdaten zur Abstimmung aktiv.} other {# Anfragen bleiben nach dieser Änderung mit aktualisierten Ablaufdaten zur Abstimmung aktiv.}}",
+            "expiringRequestsBullet": "{count, plural, one {# Anfrage wird unter der neuen Abstimmungsdauer als \"Abgelaufen\" markiert.} other {# Anfragen werden unter der neuen Abstimmungsdauer als \"Abgelaufen\" markiert.}}",
+            "remainActiveHeading": "Anfragen, die mit neuem Ablaufdatum zur Abstimmung aktiv bleiben",
+            "willExpireHeading": "Anfragen, die als \"Abgelaufen\" markiert werden",
+            "tableRequest": "Anfrage",
+            "tableTransaction": "Transaktion",
+            "tableNewExpiry": "Neuer Ablauf",
+            "expireInDays": "{count, plural, one {Läuft in # Tag ab} other {Läuft in # Tagen ab}}",
+            "today": "Heute",
+            "uponApproval": "Bei Genehmigung",
+            "yesContinue": "Ja, weiter",
+            "transactionCreated": "Transaktion erstellt",
+            "voting": "Abstimmung",
+            "approvalsReceived": "{received}/{required} Genehmigungen erhalten",
+            "expiresAt": "Läuft ab am",
+            "expiredAt": "Abgelaufen am",
+            "exchangingTokens": "Token werden getauscht",
+            "exchangingTokensBody": "Diese Anfrage wurde vom Team genehmigt. Der Token-Tausch ist nun in Bearbeitung und kann einige Zeit in Anspruch nehmen.",
+            "requestFailed": "Anfrage fehlgeschlagen",
+            "requestFailedBody": "Das Team hat diese Anfrage genehmigt, sie ist jedoch aufgrund von Kursschwankungen fehlgeschlagen. Bitte erstellen Sie eine neue Anfrage und versuchen Sie es erneut.",
+            "votingPeriod24h": "Abstimmungszeitraum: 24 Stunden",
+            "votingPeriod24hBody": "Diese Tauschanfrage hat eine Abstimmungsdauer von 24 Stunden. Genehmigen Sie diese Anfrage innerhalb dieser Zeit, andernfalls läuft sie ab.",
+            "reject": "Ablehnen",
+            "approve": "Genehmigen"
+        },
+        "insufficientBalance": {
+            "noAsset": "Diese Anfrage kann nicht genehmigt werden, da das erforderliche Token in der Treasury nicht verfügbar ist.",
+            "bond": "Diese Anfrage kann nicht genehmigt werden, da die Treasury unzureichendes <token>{symbol}</token>-Guthaben hat. Fügen Sie <token>{amount} {symbol}</token> hinzu, um die Vorschlagskaution zu decken.",
+            "continue": "Diese Anfrage kann nicht genehmigt werden, da die Treasury unzureichendes <token>{symbol}</token>-Guthaben hat. Fügen Sie <token>{amount} {symbol}</token> hinzu, um fortzufahren.",
+            "modalTitle": "Unzureichendes NEAR-Guthaben",
+            "modalBodyVote": "Sie haben nicht genügend NEAR-Token in Ihrer Wallet, um diese Stimme abzugeben. Für die Abstimmung ist ein Mindestguthaben von <amount>{required} NEAR</amount> erforderlich. Bitte fügen Sie NEAR zu Ihrer Wallet hinzu und versuchen Sie es erneut.",
+            "modalBodyProposal": "Sie haben nicht genügend NEAR-Token in Ihrer Wallet, um diese Anfrage zu erstellen. Für das Erstellen einer Anfrage ist ein Mindestguthaben von <amount>{required} NEAR</amount> erforderlich. Bitte fügen Sie NEAR zu Ihrer Wallet hinzu und versuchen Sie es erneut.",
+            "gotIt": "Verstanden"
+        }
+    },
+    "members": {
+        "title": "Mitglieder",
+        "description": "Teammitglieder und Berechtigungen verwalten",
+        "permissions": "Berechtigungen",
+        "member": "Mitglied",
+        "activeMembers": "Aktive Mitglieder",
+        "noActiveMembers": "Keine aktiven Mitglieder gefunden.",
+        "addNewMember": "Neues Mitglied hinzufügen",
+        "membersSelected": "{count, plural, =0 {keine Mitglieder} one {# Mitglied} other {# Mitglieder}} ausgewählt",
+        "remove": "Entfernen",
+        "edit": "Bearbeiten",
+        "requestorOnlyTooltip": "Sie können diesem Mitglied nur die Antragsteller-Rolle zuweisen, da es für die Erstellung von Zahlungsanfragen aus NEARN verantwortlich ist.",
+        "memberModal": {
+            "editRoles": "Rollen bearbeiten",
+            "addNewMember": "Neues Mitglied hinzufügen",
+            "validatingAddresses": "Adressen werden validiert...",
+            "creatingProposal": "Vorschlag wird erstellt...",
+            "reviewRequest": "Anfrage prüfen",
+            "noChanges": "An den Mitgliederrollen wurden keine Änderungen vorgenommen"
+        },
+        "previewModal": {
+            "title": "Überprüfen Sie Ihre Anfrage",
+            "youAreEditing": "Sie bearbeiten",
+            "youAreAdding": "Sie fügen hinzu",
+            "membersCount": "{count, plural, one {# Mitglied} other {# Mitglieder}}",
+            "newMembersCount": "{count, plural, one {# neues Mitglied} other {# neue Mitglieder}}",
+            "updatedMembers": "Aktualisierte Mitglieder",
+            "newMembers": "Neue Mitglieder",
+            "creatingProposal": "Vorschlag wird erstellt...",
+            "confirmSubmit": "Anfrage bestätigen und absenden"
+        },
+        "removeDialog": {
+            "title": "Anfrage entfernen",
+            "nearnBody": "Nach Genehmigung wird {account} dauerhaft aus der Treasury entfernt und alle zugehörigen Berechtigungen werden widerrufen. Nach der Entfernung kann dieses Konto keine Anfragen mehr aus NEARN erstellen.",
+            "genericBody": "Nach Genehmigung wird durch diese Aktion <bold>{accounts}</bold> dauerhaft aus der Treasury entfernt und alle zugewiesenen Berechtigungen werden widerrufen.",
+            "creatingProposal": "Vorschlag wird erstellt..."
+        },
+        "validation": {
+            "accountIdRequired": "Konto-ID ist erforderlich",
+            "invalidNearAddress": "Ungültige NEAR-Adresse.",
+            "atLeastOneRole": "Mindestens eine Rolle muss ausgewählt sein",
+            "atLeastOneMember": "Mindestens ein Mitglied ist erforderlich",
+            "alreadyAdded": "Dieses Mitglied wurde oben bereits hinzugefügt",
+            "alreadyInTreasury": "Dieses Mitglied existiert bereits in der Treasury",
+            "cannotRemoveRoleAfter": "Sie können die {role}-Rolle diesem Mitglied nicht entziehen. Nach all Ihren Änderungen wäre es die einzige Person mit dieser Rolle.",
+            "cannotRemoveRoleAfterGov": "Sie können die {role}-Rolle diesem Mitglied nicht entziehen. Nach all Ihren Änderungen wäre es das einzige Mitglied mit der Rolle {role}, und ohne diese Rolle können Sie keine Teammitglieder verwalten oder die Abstimmung konfigurieren."
+        },
+        "policy": {
+            "addMembers": "Richtlinie aktualisieren - Neue Mitglieder hinzufügen",
+            "addMembersSuccess": "Anfrage für neues Mitglied erfolgreich erstellt",
+            "editMember": "Richtlinie aktualisieren - Mitgliederberechtigungen bearbeiten",
+            "editMembers": "Richtlinie aktualisieren - Mehrere Mitglieder bearbeiten",
+            "editMemberSuccess": "Anfrage zur Aktualisierung der Mitgliederrollen erfolgreich erstellt",
+            "editMembersSuccess": "Sammelanfrage zur Aktualisierung der Mitgliederrollen erfolgreich erstellt",
+            "removeMember": "Richtlinie aktualisieren - Mitglied entfernen",
+            "removeMembers": "Richtlinie aktualisieren - Mitglieder entfernen",
+            "removeMemberSuccess": "Anfrage zur Mitgliederentfernung erfolgreich erstellt"
+        }
+    },
+    "settings": {
+        "tabs": {
+            "general": "Allgemein",
+            "voting": "Abstimmung",
+            "preferences": "Präferenzen",
+            "integrations": "Integrationen"
+        },
+        "general": {
+            "validation": {
+                "displayNameRequired": "Anzeigename ist erforderlich",
+                "displayNameMax": "Anzeigename muss weniger als 100 Zeichen umfassen"
+            },
+            "proposalDescriptionTitle": "Konfiguration aktualisieren - Design & Logo",
+            "proposalSubmitted": "Anfrage zur Aktualisierung der Konfiguration übermittelt",
+            "treasuryNotFound": "Treasury nicht gefunden",
+            "treasuryName": "Treasury-Name",
+            "treasuryNameDescription": "Der Name Ihrer Treasury. Er wird in der gesamten App angezeigt.",
+            "displayName": "Anzeigename",
+            "displayNamePlaceholder": "Anzeigenamen eingeben",
+            "accountName": "Kontoname",
+            "logo": "Logo",
+            "logoDescription": "Laden Sie ein Logo für Ihre Treasury hoch. Empfohlen sind SVG, PNG oder JPG (256x256 px).",
+            "treasuryLogoAlt": "Treasury-Logo",
+            "uploading": "Wird hochgeladen...",
+            "uploadLogo": "Logo hochladen",
+            "removeLogo": "Logo entfernen",
+            "logoUploaded": "Logo erfolgreich hochgeladen",
+            "uploadError": "Beim Hochladen des Bildes ist ein Fehler aufgetreten. Bitte erneut versuchen.",
+            "invalidLogo": "Ungültiges Logo. Bitte laden Sie eine PNG-, JPG- oder SVG-Datei hoch, die genau 256x256 px groß ist",
+            "invalidImage": "Ungültige Bilddatei. Bitte laden Sie ein gültiges Bild hoch.",
+            "fileReadError": "Fehler beim Lesen der Datei. Bitte erneut versuchen.",
+            "primaryColor": "Primärfarbe",
+            "primaryColorDescription": "Legen Sie die Primärfarbe für die Oberflächenelemente Ihrer Treasury fest. Diese Farbe wird sowohl im hellen als auch im dunklen Modus verwendet, achten Sie daher beim Wählen neutraler Töne auf den Kontrast.",
+            "selectColorLabel": "Farbe {color} auswählen"
+        },
+        "voting": {
+            "validation": {
+                "required": "Abstimmungsdauer ist erforderlich",
+                "validNumber": "Abstimmungsdauer muss eine gültige Zahl sein",
+                "min": "Abstimmungsdauer muss mindestens 1 Tag betragen",
+                "max": "Abstimmungsdauer muss weniger als 1000 Tage betragen",
+                "whole": "Abstimmungsdauer muss eine ganze Anzahl Tage sein"
+            },
+            "missingData": "Erforderliche Daten fehlen",
+            "thresholdProposalTitle": "Richtlinie aktualisieren - Abstimmungsschwellenwerte",
+            "thresholdProposalSummary": "{account} hat beantragt, den Abstimmungsschwellenwert von {oldValue} auf {newValue} zu ändern.",
+            "thresholdSubmitted": "Anfrage zur Aktualisierung des Abstimmungsschwellenwerts übermittelt",
+            "createProposalFailed": "Erstellung des Vorschlags fehlgeschlagen",
+            "durationProposalTitle": "Richtlinie aktualisieren - Abstimmungsdauer",
+            "durationProposalSummary": "{account} hat beantragt, die Abstimmungsdauer von {oldValue} auf {newValue} zu ändern.",
+            "durationSubmitted": "Anfrage erfolgreich erstellt",
+            "pendingTitle": "Aktive Anfrage zum Abstimmungsschwellenwert",
+            "pendingBody": "Um Konflikte zu vermeiden, müssen Sie die bestehenden ausstehenden Anfragen abschließen oder lösen, bevor Sie fortfahren. Diese Anfragen sind derzeit aktiv und müssen zuerst genehmigt oder abgelehnt werden.",
+            "viewRequest": "Anfrage anzeigen",
+            "thresholdHeading": "Abstimmungsschwellenwert",
+            "thresholdDescriptionApprovers": "Legen Sie fest, wie viele Stimmen zur Genehmigung von Zahlungs- und teambezogenen Anfragen erforderlich sind. Konfigurieren Sie die Schwellenwerte für Genehmiger und Governance separat.",
+            "thresholdDescriptionGeneric": "Legen Sie fest, wie viele Stimmen zur Genehmigung von Anfragen erforderlich sind. Konfigurieren Sie Schwellenwerte für jede Rolle basierend auf deren Verantwortlichkeiten.",
+            "membersWhoCanVote": "Mitglieder, die abstimmen können",
+            "votesRequired": "Stimmen sind zur Genehmigung von Anfragen erforderlich",
+            "durationHeading": "Abstimmungsdauer",
+            "durationDescription": "Die Zeit (in Tagen), die ein Vorschlag zur Abstimmung offen bleibt. Wird die Abstimmung nicht innerhalb dieses Zeitraums abgeschlossen, läuft die Entscheidung ab.",
+            "durationApprovers": " Diese Dauer gilt gleichermaßen für Governance- und Genehmiger-Rollen.",
+            "durationGeneric": " Diese Dauer ist für alle Treasury-Rollen einheitlich.",
+            "days": "Tage"
+        },
+        "preferences": {
+            "timeZone": "Zeitzone",
+            "timeZoneDescription": "Stellen Sie Ihre lokale Zeitzone für die korrekte Datums- und Zeitanzeige ein.",
+            "timeFormat": "Zeitformat",
+            "hour12": "12-Stunden (1:00 PM)",
+            "hour24": "24-Stunden (13:00)",
+            "autoTimezone": "Zeitzone automatisch anhand Ihres Standorts festlegen",
+            "timezone": "Zeitzone",
+            "loadingTimezones": "Zeitzonen werden geladen...",
+            "selectTimezone": "Zeitzone auswählen",
+            "searchTimezones": "Zeitzonen suchen...",
+            "noTimezones": "Keine Zeitzonen gefunden",
+            "save": "Speichern",
+            "savedToast": "Präferenzen erfolgreich gespeichert",
+            "saveFailed": "Speichern der Präferenzen fehlgeschlagen",
+            "loadFailed": "Laden der Zeitzonen fehlgeschlagen"
+        }
+    },
+    "addressBook": {
+        "emptyTitle": "Fügen Sie Ihren ersten Empfänger hinzu",
+        "emptyDescription": "Speichern Sie häufig verwendete Adressen für schnellere, fehlerfreie Auszahlungen. Ihre Kontakte bleiben privat und sind nur für Ihr Team sichtbar.",
+        "import": "Importieren",
+        "addRecipient": "Empfänger hinzufügen",
+        "recipientsHeading": "Empfänger",
+        "recipientsSelected": "{count, plural, =0 {keine Empfänger} one {# Empfänger} other {# Empfänger}} ausgewählt",
+        "sectionHeading": "Empfänger",
+        "privacyNote": "Gespeicherte Adressen sind privat und nur für Ihr Team sichtbar.",
+        "searchPlaceholder": "Empfänger nach Namen suchen",
+        "searchPlaceholderShort": "Suche",
+        "review": {
+            "header": "Details prüfen",
+            "youAreAdding": "Sie fügen hinzu",
+            "newRecipients": "{count, plural, one {# neuen Empfänger} other {# neue Empfänger}}",
+            "onNetworks": "auf {count, plural, one {# Netzwerk} other {# Netzwerken}}",
+            "recipients": "Empfänger",
+            "allDuplicates": "Alle importierten Empfänger existieren bereits in Ihrem Adressbuch. Gehen Sie zurück, um eine andere Liste hochzuladen, oder entfernen Sie Duplikate aus dieser Prüfung.",
+            "someDuplicates": "{duplicates} doppelte Empfänger von {total} Empfängern insgesamt. Fortfahren, um nur die neuen Empfänger zu importieren.",
+            "duplicated": "Dupliziert",
+            "notePlaceholder": "Fügen Sie eine Notiz hinzu, um diesen Empfänger zu identifizieren (z. B. Auftragnehmer-Zahlung, Vesting-Verteilung).",
+            "skipDuplicates": "Duplikate überspringen und nur neue importieren.",
+            "allDuplicatesTooltip": "Alle importierten Empfänger sind bereits in Ihrem Adressbuch, sodass es nichts Neues zu importieren gibt.",
+            "duplicateActionTooltip": "Aktivieren Sie das Überspringen von Duplikaten oder entfernen Sie doppelte Empfänger, um fortzufahren.",
+            "adding": "Wird hinzugefügt…",
+            "nothingNew": "Nichts Neues zu importieren",
+            "addRecipientsButton": "{count, plural, one {Empfänger hinzufügen} other {Empfänger hinzufügen}}"
+        },
+        "removeDialog": {
+            "title": "Empfänger entfernen",
+            "bulk": "Hierdurch werden <bold>{count, plural, one {# Empfänger} other {# Empfänger}}</bold> aus Ihrem Adressbuch entfernt. Sie können sie jederzeit wieder hinzufügen.",
+            "single": "Hierdurch wird <bold>{name}</bold> aus Ihrem Adressbuch entfernt. Sie können diesen Empfänger jederzeit wieder hinzufügen."
+        },
+        "importFlow": {
+            "title": "Empfänger importieren",
+            "description": "Laden Sie eine Liste von Empfängeradressen in Ihr Adressbuch hoch.",
+            "foundSummary": "{count, plural, one {# Empfänger} other {# Empfänger}} auf {networkCount, plural, one {# Netzwerk} other {# Netzwerken}} gefunden",
+            "uploadPrompt": "Empfängerdaten hochladen oder einfügen",
+            "fixErrors": "Fehler beheben, um fortzufahren",
+            "continueReview": "Weiter zur Prüfung"
+        },
+        "form": {
+            "editRecipient": "Empfänger bearbeiten",
+            "addRecipient": "Empfänger hinzufügen",
+            "import": "Importieren",
+            "recipientName": "Empfängername",
+            "namePlaceholder": "Alice",
+            "recipientAddress": "Empfängeradresse",
+            "network": "Netzwerk",
+            "networkInfo": "Mit dieser Adresse kompatible Netzwerke",
+            "enterAddressFirst": "Geben Sie zuerst die Empfängeradresse ein",
+            "selectNetwork": "Netzwerk auswählen",
+            "selectNetworksTitle": "Netzwerke auswählen",
+            "searchNetworksPlaceholder": "Netzwerke suchen…",
+            "done": "Fertig",
+            "edit": "Bearbeiten",
+            "remove": "Entfernen",
+            "incomplete": "Unvollständig",
+            "addAnother": "Weiteren Empfänger hinzufügen",
+            "fillAllTooltip": "Sie müssen alle Felder ausfüllen, um einen Empfänger hinzuzufügen.",
+            "reviewDetails": "Details prüfen",
+            "reviewTooltip": "Alle Empfänger müssen vollständig sein, bevor die Prüfung erfolgen kann.",
+            "invalidAddress": "Ungültige Adresse",
+            "noCompatibleNetworks": "Keine kompatiblen Netzwerke für diese Adresse"
+        },
+        "parsing": {
+            "rowPrefix": "Zeile {row}: {message}",
+            "missingName": "Fehlender Empfängername. Bitte fügen Sie einen Namen hinzu.",
+            "missingAddress": "Fehlende Empfängeradresse. Bitte fügen Sie eine Wallet-Adresse hinzu.",
+            "invalidAddressFormat": "Die Adresse \"{address}\" ist kein gültiges Format für ein unterstütztes Netzwerk.",
+            "unknownNetwork": "Unbekanntes Netzwerk \"{network}\". Unterstützte Netzwerke: {available}.",
+            "incompatibleNetwork": "Die Adresse \"{address}\" ist nicht mit {network} kompatibel. Kompatible Netzwerke: {compatible}.",
+            "noDataFound": "Keine Daten gefunden. Bitte fügen Sie Empfänger in diesem Format hinzu: Name, Address, Network, Note",
+            "headerColumnsNotFound": "Wir haben eine Kopfzeile erkannt, aber konnten die Spalten 'Name' und 'Address' nicht finden. Bitte verwenden Sie diese Spaltennamen oder entfernen Sie die Kopfzeile.",
+            "failedToParseCsv": "CSV-Daten konnten nicht geparst werden"
+        }
+    },
+    "payments": {
+        "validation": {
+            "recipientMin": "Empfänger sollte mindestens 2 Zeichen umfassen",
+            "recipientMax": "Empfänger muss weniger als 128 Zeichen umfassen",
+            "amountPositive": "Betrag muss größer als 0 sein",
+            "recipientTokenSame": "Empfänger- und Token-Adresse dürfen nicht identisch sein"
+        },
+        "newPayment": "Neue Zahlung",
+        "reviewYourPayment": "Überprüfen Sie Ihre Zahlung",
+        "reviewButton": "Zahlung prüfen",
+        "reviewButtonDisabled": "Betrag und Adresse eingeben",
+        "comingSoon": "Demnächst verfügbar",
+        "bulkPayments": "Sammelzahlungen",
+        "summaryRecipients": "an {count, plural, one {# Empfänger} other {# Empfänger}}",
+        "networkFee": "Netzwerkgebühr",
+        "networkFeeInfo": "Informationen zur Netzwerkgebühr",
+        "commentPlaceholder": "Kommentar hinzufügen (optional)...",
+        "preparingRoute": "1Click-Transferroute wird vorbereitet...",
+        "confirmSubmit": "Anfrage bestätigen und absenden",
+        "useDifferentAddress": "Andere Adresse verwenden",
+        "failed1ClickQuote": "Erstellung des 1Click-Transfer-Angebots fehlgeschlagen",
+        "paymentSubmitted": "Anfrage zum Senden der Zahlung übermittelt"
+    },
+    "bulkPayment": {
+        "comingSoonToast": "Sammelzahlungen kommen demnächst!",
+        "submittingList": "Sammelzahlungsliste wird übermittelt",
+        "submittingProposal": "Vorschlag wird übermittelt",
+        "proposalSubmitted": "Sammelzahlungsvorschlag übermittelt",
+        "submitListFailed": "Übermittlung der Zahlungsliste fehlgeschlagen",
+        "submitFailed": "Übermittlung der Sammelzahlung fehlgeschlagen",
+        "upload": {
+            "pleaseUploadCsv": "Bitte laden Sie eine CSV-Datei hoch",
+            "fileSizeLimit": "Dateigröße muss kleiner als 1,5 MB sein",
+            "headerTitle": "Sammelzahlungsanfragen",
+            "headerSubtitle": "Bezahlen Sie mehrere Empfänger mit einem einzigen Vorschlag.",
+            "creditsUsed": "Sie haben alle Ihre Credits aufgebraucht",
+            "bulkPaymentsUsed": "Sie haben alle Ihre Sammelzahlungen aufgebraucht",
+            "upgradeTrial": "Upgraden Sie Ihren Tarif, um mehr zu erhalten und weiterzumachen",
+            "upgradePaid": "Upgraden Sie Ihren Tarif für mehr Zugriff oder warten Sie, bis Ihre Limits nächsten Monat zurückgesetzt werden.",
+            "selectAsset": "Vermögenswert auswählen",
+            "disableTokenMessage": "Sammelzahlungen für diese Token kommen demnächst.",
+            "providePaymentData": "Zahlungsdaten bereitstellen",
+            "uploadFile": "Datei hochladen",
+            "provideData": "Daten bereitstellen",
+            "chooseFile": "Datei auswählen",
+            "orDragDrop": "oder per Drag & Drop",
+            "maxFileSize": "max. 1 Datei bis zu 1,5 MB, nur CSV-Datei",
+            "noFilePrompt": "Keine Datei zum Hochladen?",
+            "downloadTemplate": "Vorlage herunterladen",
+            "requirements": "Anforderungen für Sammelzahlungen",
+            "maxTransactions": "Max. {max} Transaktionen pro Import",
+            "singleTokenNetwork": "Einzelnes Token und Netzwerk",
+            "limitsUsed": "Sie haben alle Ihre Limits aufgebraucht",
+            "selectAndProvide": "Vermögenswert auswählen und Zahlungsdaten bereitstellen",
+            "continueToReview": "Weiter zur Prüfung",
+            "selectTokenError": "Bitte wählen Sie ein Token aus",
+            "providePaymentDataError": "Bitte stellen Sie Zahlungsdaten bereit"
+        },
+        "editStep": {
+            "title": "Zahlung bearbeiten",
+            "saveChanges": "Änderungen speichern"
+        },
+        "parsing": {
+            "rowPrefix": "Zeile {row}: {message}",
+            "missingRecipientFirstColumn": "Fehlende Empfängeradresse. Bitte fügen Sie eine Adresse in die erste Spalte ein.",
+            "invalidNearAddress": "Die Adresse \"{address}\" ist kein gültiges NEAR-Konto.",
+            "invalidChainAddress": "Die Adresse \"{address}\" ist kein gültiges {chain}-Konto.",
+            "rowNeedsAmountRecipient": "Jede Zeile benötigt Betrag und Empfänger, getrennt durch ein Komma. Beispiel: 100, alice.near",
+            "missingRecipientBeforeComma": "Fehlende Empfängeradresse. Bitte fügen Sie eine Adresse vor dem Komma hinzu.",
+            "missingAmountAfterComma": "Fehlender Betrag. Bitte fügen Sie eine Zahl nach dem Komma hinzu. Beispiel: {recipient}, 100",
+            "invalidAmountNumber": "Der Betrag \"{amountStr}\" ist keine gültige Zahl. Bitte verwenden Sie nur Zahlen und Dezimalstellen (z. B. 100 oder 100.50).",
+            "amountGreaterThanZero": "Der Betrag muss größer als 0 sein. Sie haben \"{amountStr}\" eingegeben.",
+            "amountTooLarge": "Der Betrag \"{amountStr}\" ist zu groß. Bitte verwenden Sie eine kleinere Zahl.",
+            "invalidAmountFallback": "Ungültiger Betrag. Bitte verwenden Sie nur Zahlen und Dezimalstellen (z. B. 100 oder 100.50).",
+            "pleaseRemoveChars": "Bitte entfernen Sie diese Zeichen: {chars}. Es sind nur Zahlen, Kommas und Punkte erlaubt.",
+            "amountCannotBeEmpty": "Betrag darf nicht leer sein.",
+            "tokenMismatch": "Sie haben \"{provided}\" eingegeben, aber {expected} ist oben ausgewählt. Entfernen Sie entweder das Token-Symbol oder wählen Sie {suggested} aus dem Dropdown.",
+            "multipleTokenSymbols": "Sie verwenden mehrere Token-Symbole ({symbols}). Bitte verwenden Sie in Ihrer Datei nur einen Token-Typ oder entfernen Sie die Token-Symbole und lassen Sie die obige Auswahl das Token bestimmen.",
+            "noPaymentDataFound": "Keine Zahlungsdaten gefunden. Bitte fügen Sie Ihre Zahlungen in diesem Format hinzu: recipient, amount",
+            "exceedsRecipientLimit": "Sie haben {count} Empfänger, aber das Limit beträgt {limit} pro Stapel. Bitte entfernen Sie {excess, plural, one {# Empfänger} other {# Empfänger}} oder teilen Sie sie in mehrere Stapel auf.",
+            "noPaymentDataProvided": "Keine Zahlungsdaten bereitgestellt. Bitte geben Sie Ihre Zahlungen in diesem Format ein: recipient, amount",
+            "headerColumnsNotFound": "Wir haben eine Kopfzeile erkannt, aber konnten die Spalten 'Recipient' und 'Amount' nicht finden. Bitte verwenden Sie diese Spaltennamen oder entfernen Sie die Kopfzeile.",
+            "failedToParseCsv": "CSV-Daten konnten nicht geparst werden",
+            "failedToParsePaste": "Eingefügte Daten konnten nicht geparst werden",
+            "failedToValidateAccount": "Konto konnte nicht validiert werden",
+            "feeEstimationFailed": "Netzwerkgebühr für diesen Betrag konnte nicht geschätzt werden. Bitte überprüfen und erneut versuchen.",
+            "feeEstimationFailedRow": "Zeile {row} ({recipient}): Netzwerkgebühr für diesen Betrag konnte nicht geschätzt werden. Bitte überprüfen und erneut versuchen."
+        },
+        "recipients": "Empfänger",
+        "insufficientTokens": "Unzureichende Token. Sie können die Anfrage einreichen und vor der Genehmigung aufladen.",
+        "removeRecipient": "Empfänger entfernen",
+        "removeRecipientConfirm": "Möchten Sie die Zahlung an <strong>{recipient}</strong> wirklich entfernen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "remove": "Entfernen",
+        "edit": "Bearbeiten"
+    },
+    "bulkPaymentCredits": {
+        "title": "Sammelzahlungen",
+        "unlimited": "Unbegrenzt",
+        "creditsPerPeriod": "{amount} / {period}",
+        "oneTimeTrial": "einmalige Testphase",
+        "month": "Monat",
+        "moreFlexibility": "Suchen Sie mehr Flexibilität?",
+        "contactUs": "Kontaktieren Sie uns"
+    },
+    "exchange": {
+        "validation": {
+            "amountPositive": "Betrag muss größer als 0 sein"
+        },
+        "requestSubmitted": "Tauschanfrage übermittelt",
+        "heading": "Tauschen",
+        "sell": "Verkaufen",
+        "receive": "Empfangen",
+        "slippageTolerance": "Slippage-Toleranz",
+        "disabled": {
+            "differentTokens": "Token müssen unterschiedlich sein",
+            "enterAmount": "Geben Sie einen Betrag zum Tauschen ein"
+        },
+        "review": "Tausch prüfen",
+        "poweredBy": "Bereitgestellt von",
+        "info": {
+            "priceDifference": "Preisunterschied",
+            "priceDifferenceTooltip": "Unterschied zwischen dem Angebotskurs und dem aktuellen Marktkurs. Positive Werte bedeuten einen besseren Kurs als der Markt.",
+            "estimatedTime": "Geschätzte Zeit",
+            "estimatedTimeValue": "{seconds} Sekunden",
+            "estimatedTimeTooltip": "Ungefähre Zeit zum Abschluss des Tauschs.",
+            "minimumReceived": "Mindestens erhalten",
+            "minimumReceivedTooltip": "Dies ist der Mindestbetrag, den Sie aus diesem Tausch erhalten, basierend auf dem für die Anfrage festgelegten Slippage-Limit.",
+            "depositAddress": "Einzahlungsadresse",
+            "depositAddressCopied": "Einzahlungsadresse kopiert",
+            "quoteExpires": "Angebot läuft ab",
+            "exchangeFee": "Tauschgebühr",
+            "exchangeFeeTooltip": "Die hier anfallende Gebühr von 0,70 % deckt die Kosten des NEAR Intents-Protokolls zur Abwicklung Ihres Trades sowie die Trezu-Widget-Gebühr. Dieser Betrag wird automatisch in Ihren angebotenen Kurs einberechnet."
+        },
+        "approveWithin24h": "Bitte genehmigen Sie diese Anfrage innerhalb von 24 Stunden, andernfalls läuft sie ab. Wir empfehlen, so bald wie möglich zu bestätigen.",
+        "confirmSubmit": "Anfrage bestätigen und absenden",
+        "refreshingIn": "Wechselkurs wird in {seconds}s aktualisiert"
+    },
+    "vesting": {
+        "validation": {
+            "amountMin": "Betrag muss größer oder gleich 3,5 sein",
+            "startBeforeEnd": "Startdatum muss vor dem Enddatum liegen",
+            "cliffBetween": "Cliff-Datum muss zwischen liegen"
+        },
+        "stepTitles": {
+            "details": "Details",
+            "settings": "Einstellungen",
+            "review": "Prüfung"
+        },
+        "proposalTitle": "Vesting-Plan für {address} erstellen",
+        "scheduleSubmitted": "Anfrage zur Erstellung des Vesting-Plans übermittelt",
+        "heading": "Neuer Vesting-Plan",
+        "amount": "Betrag",
+        "startDate": "Startdatum",
+        "endDate": "Enddatum",
+        "noteOptional": "Notiz (optional)",
+        "continue": "Weiter",
+        "advancedSettings": "Erweiterte Einstellungen",
+        "allowCancellation": "Kündigung erlauben",
+        "allowCancellationDescription": "Erlaubt der NEAR Foundation, die Sperrung jederzeit zu beenden. Nicht kündbare Sperrungen sind nicht mit Cliff-Daten kompatibel.",
+        "cliffDate": "Cliff-Datum",
+        "allowEarn": "Erträge erlauben",
+        "allowEarnDescription": "Erlaubt dem Inhaber der Sperrung, den vollen Token-Betrag in der Sperrung zu staken (auch vor dem Cliff-Datum).",
+        "commentPlaceholder": "Kommentar zu diesem Vesting-Plan hinzufügen (optional)...",
+        "reviewRequest": "Anfrage prüfen",
+        "reviewHeading": "Überprüfen Sie Ihren Vesting-Plan",
+        "confirmSubmit": "Anfrage bestätigen und absenden",
+        "review": {
+            "recipient": "Empfänger",
+            "startDate": "Startdatum",
+            "endDate": "Enddatum",
+            "cliffDate": "Cliff-Datum",
+            "cancelable": "Kündbar",
+            "allowEarn": "Erträge erlauben",
+            "na": "k. A."
+        }
+    },
+    "earn": {
+        "placeholder": "Erkunden Sie Ertragsmöglichkeiten und Staking-Belohnungen."
+    },
+    "createTreasury": {
+        "validation": {
+            "nameMin": "Treasury-Name sollte mindestens 2 Zeichen umfassen",
+            "nameMax": "Treasury-Name muss weniger als 64 Zeichen umfassen",
+            "accountMin": "Kontoname sollte mindestens 2 Zeichen umfassen",
+            "accountMax": "Kontoname muss weniger als 64 Zeichen umfassen",
+            "accountChars": "Kontoname darf nur lateinische Buchstaben, Zahlen und Bindestriche enthalten",
+            "accountTaken": "Dieser Kontoname ist bereits vergeben"
+        },
+        "votingNote": "Sie benötigen mehr Mitglieder, um die Abstimmungseinstellungen zu ändern. Fügen Sie ein weiteres Mitglied hinzu, um die Abstimmung zu konfigurieren.",
+        "minimumVoteNote": "Mindestens eine Genehmigungsstimme erforderlich.",
+        "heading": "Treasury erstellen",
+        "addMembers": "Mitglieder hinzufügen",
+        "addMembersInfo": "Sie können jetzt Mitglieder hinzufügen oder aktualisieren und dies jederzeit später bearbeiten.",
+        "treasuryName": "Treasury-Name",
+        "treasuryNamePlaceholder": "Meine Treasury",
+        "accountName": "Kontoname",
+        "accountNameInfo": "Dies ist der eindeutige Name Ihres Kontos. Er wird in Ihrer Treasury-URL verwendet und in Transaktionen angezeigt, um zu identifizieren, wer die Zahlung gesendet hat. Wählen Sie einen kurzen, einprägsamen Namen für Ihr Konto.",
+        "accountPlaceholder": "meine-treasury",
+        "continue": "Weiter",
+        "votingThreshold": "Abstimmungsschwellenwert",
+        "thresholdDescription": "Legen Sie fest, wie viele Stimmen zur Genehmigung von Anfragen erforderlich sind:",
+        "financial": "Finanzen",
+        "financialDescription": "Genehmigung von Zahlungs- und Tauschanfragen.",
+        "governance": "Governance",
+        "governanceDescription": "Genehmigung von Einstellungen, Mitgliedern und Abstimmungskonfiguration.",
+        "confidential": "Vertraulich",
+        "public": "Öffentlich",
+        "anyone": "Jeder",
+        "teamOnly": "Nur Team",
+        "soon": "Bald",
+        "publicDescription": "Alle Guthaben, Aktivitäten und Transaktionen sind für jeden auf der Blockchain sichtbar. Diese Option eignet sich am besten für transparente Organisationen und öffentliche DAOs.",
+        "balanceTransactions": "Guthaben, Transaktionen",
+        "membersVoting": "Mitglieder, Abstimmung",
+        "allFeatures": "Alle Funktionen verfügbar",
+        "confidentialDescription": "Alle Guthaben, Aktivitäten und Überweisungen bleiben auf der Blockchain privat. Nur Ihr Team kann diese Informationen einsehen. Am besten für private Unternehmen, Family Offices oder Teams, die finanzielle Privatsphäre wünschen.",
+        "recentTransactionsExport": "Export der letzten Transaktionen",
+        "bulkPayment": "Sammelzahlung",
+        "treasuryType": "Treasury-Typ",
+        "treasuryTypeWarning": "Sie können dies pro Treasury nur einmal auswählen und später nicht mehr ändern.",
+        "select": "Auswählen",
+        "visibleOnChain": "Auf der Chain sichtbar",
+        "featuresAvailable": "Verfügbare Funktionen",
+        "mostFeaturesSupported": "Die meisten Funktionen werden unterstützt",
+        "reviewTreasury": "Treasury prüfen",
+        "membersLabel": "Mitglieder",
+        "financialThreshold": "Finanz-Schwellenwert",
+        "governanceThreshold": "Governance-Schwellenwert",
+        "noDeploymentFee": "🎉 Keine Bereitstellungsgebühr",
+        "noDeploymentFeeDescription": "Zur Unterstützung neuer Projekte übernimmt TREZU alle einmaligen Bereitstellungs- und Netzwerkspeichergebühren.",
+        "createButton": "Treasury erstellen",
+        "connectWalletCreate": "Wallet verbinden, um Treasury zu erstellen",
+        "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten",
+        "creationFailed": "Erstellung der Treasury fehlgeschlagen. Bitte erneut versuchen.",
+        "stepTitles": {
+            "aboutYou": "Über Sie",
+            "details": "Details",
+            "members": "Mitglieder",
+            "treasuryType": "Treasury-Typ",
+            "review": "Prüfung"
+        },
+        "steps": {
+            "creatingNear": "Ihre Treasury wird auf NEAR erstellt",
+            "registeringKey": "Öffentlicher Schlüssel wird registriert",
+            "settingUpConfidential": "Vertrauliche Transaktionen werden eingerichtet",
+            "configuringMembers": "Treasury-Mitglieder werden konfiguriert",
+            "finalizingSetup": "Einrichtung wird abgeschlossen"
+        }
+    },
+    "manageTreasuries": {
+        "warningOne": "Mindestens eine Treasury sollte verfügbar bleiben",
+        "warningOnePeriod": "Mindestens eine Treasury sollte verfügbar bleiben.",
+        "activeHeading": "Aktive Treasuries",
+        "activeDescription": "Treasuries, die derzeit in Ihrer Kontenliste sichtbar sind.",
+        "activeEmpty": "Keine aktiven Treasuries.",
+        "hiddenHeading": "Ausgeblendete Treasuries",
+        "hiddenDescription": "Treasuries, die in Ihrer Kontenliste ausgeblendet sind.",
+        "removeGuestTitle": "Gast-Treasury entfernen",
+        "removeDialog": "Sie sind dabei, <bold>{name}</bold> zu entfernen. Nach Bestätigung kann diese Aktion nicht rückgängig gemacht werden.",
+        "tooltips": {
+            "removeFromList": "Aus Ihrer Liste entfernen",
+            "viewTreasury": "Treasury anzeigen",
+            "hideFromList": "Aus Ihrer Liste ausblenden",
+            "showInList": "In Ihrer Liste anzeigen"
+        }
+    },
+    "wallet": {
+        "proposal": {
+            "transfer": "Vorschlag von externer dApp: NEAR an {receiverId} überweisen",
+            "functionCall": "Vorschlag von externer dApp: {methods} auf {receiverId}",
+            "unsupportedAction": "Nicht unterstützter Aktionstyp \"{type}\". Nur Transfer- und FunctionCall-Aktionen können in Trezu-Vorschläge umgewandelt werden."
+        },
+        "loading": "Wird geladen...",
+        "connectPrompt": "Verbinden Sie Ihre NEAR-Wallet, um fortzufahren. Anschließend wählen Sie eine Treasury, in deren Namen Sie handeln möchten.",
+        "connectWallet": "Wallet verbinden",
+        "cancel": "Abbrechen",
+        "connectedAs": "Verbunden als <strong>{account}</strong>",
+        "loadingTreasuries": "Treasuries werden geladen...",
+        "selectSignIn": "Wählen Sie eine Treasury, mit der Sie sich anmelden möchten:",
+        "selectSignTx": "Wählen Sie eine Treasury, für die ein Vorschlag erstellt werden soll:",
+        "notMember": "Sie sind kein Mitglied einer Treasury.",
+        "actingAs": "Handelnd als",
+        "signedBy": "Signiert von {account}",
+        "createsNProposals": "Hierdurch wird {count, plural, one {ein Trezu-Vorschlag} other {# Trezu-Vorschläge}} erstellt für:",
+        "proposalDescriptionLabel": "Vorschlagsbeschreibung (optional)",
+        "proposalDescriptionPlaceholder": "Beschreiben Sie diesen Vorschlag...",
+        "createProposal": "Vorschlag erstellen",
+        "creatingProposal": "Vorschlag wird erstellt...",
+        "confirmInWallet": "Bitte bestätigen Sie in Ihrer Wallet",
+        "proposalSubmitted": "Vorschlag übermittelt",
+        "shareProposal": "Ihr Vorschlag wurde erstellt. Teilen Sie den untenstehenden Link mit den Treasury-Mitgliedern zur Abstimmung.",
+        "proposalLink": "{daoId} — Vorschlag #{id}",
+        "checking": "Wird geprüft...",
+        "proposalApprovedProceed": "Der Vorschlag ist genehmigt. Fortfahren",
+        "signedInSuccess": "Erfolgreich angemeldet",
+        "proposalCreatedSuccess": "Vorschlag erfolgreich erstellt",
+        "closeWindow": "Sie können dieses Fenster schließen.",
+        "errorGeneric": "Ein Fehler ist aufgetreten",
+        "tryAgain": "Erneut versuchen",
+        "errors": {
+            "parseTx": "Parsen der Transaktionsanforderung fehlgeschlagen. Bitte erneut versuchen.",
+            "fetchTreasuries": "Abrufen Ihrer Treasuries fehlgeschlagen. Bitte erneut versuchen.",
+            "connectFailed": "Wallet-Verbindung fehlgeschlagen",
+            "createProposalFailed": "Erstellung des Vorschlags fehlgeschlagen",
+            "stillPending": "Der Vorschlag wartet noch auf Genehmigung. Bitte warten Sie auf die Abstimmung der Treasury-Mitglieder.",
+            "wasStatus": "Vorschlag #{id} wurde {status}",
+            "awaitIndex": "Der Vorschlag ist genehmigt, aber die Ausführungstransaktion ist noch nicht indiziert. Bitte versuchen Sie es in einem Moment erneut.",
+            "checkStatusFailed": "Prüfung des Vorschlagsstatus fehlgeschlagen",
+            "userCancelled": "Vom Benutzer abgebrochen",
+            "proposalWasStatus": "Vorschlag wurde {status}"
+        }
+    },
+    "telegram": {
+        "tagPill": "Telegram",
+        "invalidLinkTitle": "Ungültiger Link",
+        "invalidLinkDescription": "Diesem Telegram-Verbindungslink fehlt ein Token. Klicken Sie in Telegram erneut auf 'Treasury verbinden', um einen neuen Link zu erstellen.",
+        "successTitle": "Erfolgreich verbunden",
+        "successDescription": "Treasuries wurden mit diesem Telegram-Chat verknüpft.",
+        "successToast": "Treasuries erfolgreich verbunden",
+        "goToApp": "Zur App",
+        "linkExpiredTitle": "Link abgelaufen",
+        "linkExpiredDescription": "Dieser Link ist abgelaufen oder wurde bereits verwendet. Geben Sie in Telegram den untenstehenden Befehl ein, um den Verbindungsablauf neu zu starten.",
+        "commandCopied": "Befehl kopiert",
+        "copy": "Kopieren",
+        "unableToLoadTitle": "Chat kann nicht geladen werden",
+        "unableToLoadDescription": "Die Chat-Details konnten derzeit nicht geladen werden. Bitte versuchen Sie es von Telegram aus erneut.",
+        "signInTitle": "Anmelden, um fortzufahren",
+        "signInDescription": "Verbinden Sie zuerst Ihre NEAR-Wallet und wählen Sie dann, welche Treasuries mit diesem Telegram-Chat verknüpft werden sollen.",
+        "connectWallet": "Wallet verbinden",
+        "selectTreasuriesTitle": "Treasuries auswählen",
+        "selectTreasuriesDescription": "Wählen Sie, welche Treasuries mit diesem Telegram-Chat verbunden werden sollen.",
+        "telegramChat": "Telegram-Chat",
+        "chatIdFallback": "Chat #{id}",
+        "failedToConnect": "Verbindung der Treasuries fehlgeschlagen. Bitte erneut versuchen.",
+        "relinking": "{count, plural, one {# ausgewählte Treasury ist mit einem anderen Telegram-Chat verknüpft. Beim Verbinden wird sie neu verbunden und ihre Chat-ID-Verknüpfung auf diesen Chat umgestellt.} other {# ausgewählte Treasuries sind mit anderen Telegram-Chats verknüpft. Beim Verbinden werden sie neu verbunden und ihre Chat-ID-Verknüpfungen auf diesen Chat umgestellt.}}",
+        "alreadyConnected": "Bereits mit diesem Chat verbunden",
+        "connectedToAnother": "Mit einem anderen Chat verbunden",
+        "notMember": "Sie sind kein Richtlinienmitglied einer Treasury.",
+        "connecting": "Wird verbunden…",
+        "connect": "Verbinden"
+    },
+    "systemStatus": {
+        "underMaintenance": "Wartungsarbeiten",
+        "maintenanceMessage": "Wir führen derzeit Wartungsarbeiten durch. Einige Funktionen sind möglicherweise vorübergehend nicht verfügbar. Bitte schauen Sie bald wieder vorbei."
+    },
+    "creditsQuota": {
+        "available": "{count} verfügbar",
+        "used": "{count} verwendet",
+        "resetOn": "Limit wird zurückgesetzt am {date}"
+    },
+    "approvalInfo": {
+        "infoText": "Stimmen, die zur Genehmigung zahlungsbezogener Anfragen erforderlich sind. In den Abstimmungseinstellungen bearbeitbar.",
+        "thresholdPill": "Schwellenwert {required} von {total}",
+        "alertBody": "Diese Zahlung erfordert vor der Ausführung die Genehmigung von <bold>{required}</bold> Treasury-Mitgliedern."
+    },
+    "guestBadge": {
+        "title": "Gast",
+        "tooltip": "Sie sind Gast dieser Treasury. Sie können nur die Daten einsehen."
+    },
+    "exportButton": {
+        "confidentialTooltip": "Export ist im vertraulichen Modus noch nicht verfügbar. Diese Funktion kommt demnächst!"
+    },
+    "sponsoredActions": {
+        "titleExhausted": "Gesponserte Aktionen verbraucht",
+        "titleAlmost": "Ihrem Team gehen die gesponserten Aktionen fast aus",
+        "closeNotice": "Hinweis schließen",
+        "teamUsage": "Team-Nutzung: {total} Aktionen pro Monat",
+        "available": "{count} verfügbar",
+        "used": "{count} verwendet",
+        "exhaustedBody": "Ihr Team hat die monatlichen gesponserten Aktionen erreicht. Sie können nach {date} fortfahren oder uns kontaktieren",
+        "almostBody": "TREZU sponsert derzeit Speicherkosten für alle Team-Aktionen, wie das Erstellen und Abstimmen von Anfragen. Ihr Team nähert sich dem monatlichen gesponserten Limit.",
+        "contactUs": "Kontaktieren Sie uns",
+        "nextMonthlyReset": "Ihre nächste monatliche Zurücksetzung",
+        "sidebarBody": "Ihr Team hat die monatlichen gesponserten Aktionen erreicht. Sie können nach {date} fortfahren oder ⬇️"
+    },
+    "acceptTerms": {
+        "title": "Bedingungen akzeptieren, um fortzufahren",
+        "privacyTitle": "Ihre Privatsphäre bei Trezu",
+        "privacyBody": "Trezu ist eine nicht-verwahrende Schnittstelle. Wir priorisieren Ihre Privatsphäre und stellen gleichzeitig sicher, dass die Plattform sicher und funktional bleibt.",
+        "minimalTitle": "Minimale Daten",
+        "minimalBody": "Wir erfassen begrenzte Informationen wie öffentliche Wallet-Adressen, IP-Adressen und Nutzungsanalysen, um die Schnittstelle zu betreiben und zu verbessern.",
+        "noCustodyTitle": "Keine Verwahrung",
+        "noCustodyBody": "Wir haben niemals Zugriff auf Ihre privaten Schlüssel, Wiederherstellungsphrasen oder digitalen Vermögenswerte.",
+        "publicTitle": "Öffentliche Aufzeichnungen",
+        "publicBody": "Beachten Sie, dass alle Blockchain-Transaktionen von Natur aus öffentlich sind und nicht von uns kontrolliert werden.",
+        "responsibilityTitle": "Ihre Verantwortung",
+        "responsibilityBody": "Sie sind allein dafür verantwortlich, Ihre Wallet-Aktivität zu überwachen und Ihre Anmeldedaten zu sichern.",
+        "futureTitle": "Zukünftige Aktualisierungen",
+        "futureBody": "Wenn Sie sich für zukünftige Benachrichtigungen entscheiden (wie E-Mail oder Telegram), verwenden wir diese Daten ausschließlich, um Sie zu informieren.",
+        "agreement": "Ich habe die <terms>Nutzungsbedingungen</terms> und die <privacy>Datenschutzerklärung</privacy> gelesen und stimme ihnen zu",
+        "accepting": "Wird akzeptiert...",
+        "continue": "Weiter"
+    },
+    "confidentialBanner": {
+        "label": "Vertraulich",
+        "description": "Guthaben, Aktivitäten und Überweisungen sind nur für Ihr Team sichtbar — nicht für die öffentliche Blockchain."
+    },
+    "supportCenter": {
+        "title": "Support-Center",
+        "resources": "Ressourcen",
+        "support": "Support",
+        "websiteTitle": "Trezu-Website",
+        "websiteDescription": "Erfahren Sie mehr über Trezu und lesen Sie unseren Blog.",
+        "demo": "Trezu-Demo",
+        "demoTitle": "Öffentliche Version erkunden",
+        "demoDescription": "Sehen Sie ein Live-Konto in Aktion.",
+        "confidentialDemoTitle": "Vertrauliche Version erkunden",
+        "confidentialDemoDescription": "Erkunden Sie ein vertrauliches Live-Konto in Aktion.",
+        "videoTitle": "Demo ansehen",
+        "videoDescription": "Sehen Sie ein kurzes Video, das zeigt, wie Trezu funktioniert.",
+        "xTitle": "Folgen Sie uns auf X",
+        "xDescription": "Bleiben Sie über unsere neuesten Releases und Einblicke informiert.",
+        "statsTitle": "Statistiken",
+        "statsDescription": "Sehen Sie sich die gesamten Vermögenswerte unter Verwaltung über alle Sputnik-DAOs hinweg an.",
+        "docsTitle": "Dokumentation",
+        "docsDescription": "Erfahren Sie alles über die Funktionen in der Dokumentation.",
+        "productSupportTitle": "Produkt-Support",
+        "productSupportDescription": "Kontaktieren Sie unser Support-Team für Hilfe."
+    },
+    "progressModal": {
+        "titleCreating": "Treasury wird erstellt...",
+        "titleDone": "Treasury erstellt",
+        "titleFailed": "Treasury-Erstellung fehlgeschlagen",
+        "viewTreasury": "Treasury anzeigen"
+    },
+    "memberValidation": {
+        "noManagePermission": "Sie haben keine Berechtigung, Mitglieder zu verwalten",
+        "pendingRequest": "Sie können keine Mitglieder verwalten, solange eine aktive Anfrage besteht",
+        "rolesAnd": "{first} und {second}",
+        "rolesMany": "{list} und {last}",
+        "cannotRemoveMember": "Dieses Mitglied kann nicht entfernt werden. Es ist die einzige Person, der die {roles}-{count, plural, one {Rolle} other {Rollen}} zugewiesen ist.",
+        "cannotRemoveMemberGov": "Dieses Mitglied kann nicht entfernt werden. Es ist die einzige Person, der die {roles}-{count, plural, one {Rolle zugewiesen ist, die} other {Rollen zugewiesen sind, die}} zur Verwaltung von Teammitgliedern und zur Konfiguration der Abstimmung erforderlich {count, plural, one {ist} other {sind}}.",
+        "cannotBulkRemove": "Diese Mitglieder können nicht entfernt werden. Dadurch bliebe die {roles}-{count, plural, one {Rolle} other {Rollen}} leer.",
+        "cannotBulkRemoveGov": "Diese Mitglieder können nicht entfernt werden. Dadurch bliebe die {roles}-{count, plural, one {Rolle leer, die} other {Rollen leer, die}} zur Verwaltung von Teammitgliedern und zur Konfiguration der Abstimmung erforderlich {count, plural, one {ist} other {sind}}.",
+        "cannotRemoveRole": "Sie können diesem Mitglied die {role}-Rolle nicht entziehen. Es ist die einzige Person mit dieser Rolle.",
+        "cannotRemoveRoleGov": "Sie können diesem Mitglied die {role}-Rolle nicht entziehen. Es ist das einzige {role}-Mitglied, und ohne diese Rolle können Sie keine Teammitglieder verwalten oder die Abstimmung konfigurieren."
+    },
+    "roleSelector": {
+        "setRole": "Rolle festlegen",
+        "allRoles": "Alle Rollen",
+        "roles": {
+            "governance": {
+                "title": "Governance",
+                "description": "Governance kann teambezogene Treasury-Einstellungen erstellen und darüber abstimmen, einschließlich Mitglieder, Berechtigungen und Treasury-Erscheinungsbild."
+            },
+            "requestor": {
+                "title": "Antragsteller",
+                "description": "Antragsteller kann zahlungsbezogene Transaktionsanfragen erstellen, ohne Abstimmungs- oder Genehmigungsrechte."
+            },
+            "financial": {
+                "title": "Finanzen",
+                "description": "Finanzen kann über zahlungsbezogene Transaktionsanfragen abstimmen, kann diese aber nicht erstellen."
+            }
+        }
+    },
+    "memberInput": {
+        "creatorYou": "Ersteller (Sie)",
+        "memberAddress": "Mitgliedsadresse",
+        "addNewMember": "Neues Mitglied hinzufügen",
+        "validation": {
+            "rolesRequired": "Mindestens eine Rolle ist erforderlich",
+            "duplicateAddress": "Adresse ist bereits Mitglied"
+        }
+    },
+    "recipientInput": {
+        "title": "An",
+        "placeholder": "Empfängeradresse"
+    },
+    "accountInput": {
+        "failedValidation": "Adressvalidierung fehlgeschlagen",
+        "invalidNearFormat": "Ungültiges NEAR-Kontoformat",
+        "invalidChainAddress": "Bitte geben Sie eine gültige {chain}-Adresse ein.",
+        "validating": "Adresse wird validiert...",
+        "validAddress": "Gültige Adresse",
+        "placeholderWithExample": "Empfängeradresse (z. B.: {example})",
+        "placeholderNoExample": "Empfängeradresse",
+        "nearExample": "alice.near, 0x... oder 64-stelliger Hex",
+        "near": {
+            "required": "Adresse ist erforderlich",
+            "length": "Adresse muss zwischen 2 und 64 Zeichen umfassen",
+            "missingTld": "Benannte Konten müssen mit .near, .aurora oder .tg enden",
+            "invalidChars": "Adresse darf nur Kleinbuchstaben, Ziffern und Trennzeichen (., -, _) enthalten",
+            "accountMissing": "Konto existiert nicht auf der NEAR-Blockchain",
+            "verifyFailed": "Überprüfung der Kontoexistenz fehlgeschlagen"
+        }
+    },
+    "csvUpload": {
+        "uploadFile": "Datei hochladen",
+        "provideData": "Daten bereitstellen",
+        "chooseFile": "Datei auswählen",
+        "orDragDrop": "oder per Drag & Drop",
+        "maxFileSize": "max. 1 Datei bis zu {maxSize} MB, nur CSV-Datei",
+        "noFilePrompt": "Keine Datei zum Hochladen?",
+        "downloadTemplate": "Vorlage herunterladen"
+    },
+    "tokenSelect": {
+        "selectToken": "Token auswählen",
+        "searchPlaceholder": "Token suchen...",
+        "noTokensFound": "Keine Token gefunden"
+    },
+    "filterOperations": {
+        "is": "Ist",
+        "isNot": "Ist nicht",
+        "before": "Vor",
+        "after": "Nach",
+        "between": "Zwischen",
+        "equal": "Gleich",
+        "moreThan": "Mehr als",
+        "lessThan": "Weniger als",
+        "contains": "Enthält"
+    },
+    "copyButton": {
+        "copied": "In die Zwischenablage kopiert",
+        "failed": "Kopieren fehlgeschlagen"
+    },
+    "recipientForm": {
+        "validation": {
+            "nameRequired": "Name ist erforderlich",
+            "nameMax": "Empfänger muss weniger als {max} Zeichen umfassen",
+            "addressRequired": "Adresse ist erforderlich",
+            "networksRequired": "Wählen Sie mindestens ein Netzwerk aus"
+        }
+    },
+    "paymentForm": {
+        "validation": {
+            "recipientMin": "Empfänger sollte mindestens 2 Zeichen umfassen",
+            "recipientMax": "Empfänger muss weniger als 128 Zeichen umfassen",
+            "amountGreaterThanZero": "Betrag muss größer als 0 sein",
+            "recipientSameAsToken": "Empfänger- und Token-Adresse dürfen nicht identisch sein",
+            "selectToken": "Bitte wählen Sie ein Token aus",
+            "recipientMax64": "Empfänger muss weniger als 64 Zeichen umfassen",
+            "amountMinLockup": "Betrag muss größer oder gleich 3,5 sein",
+            "startDateRequired": "Startdatum ist erforderlich",
+            "endDateRequired": "Enddatum ist erforderlich",
+            "cliffDateRequired": "Cliff-Datum ist erforderlich",
+            "startBeforeEnd": "Startdatum muss vor dem Enddatum liegen",
+            "cliffBetween": "Cliff-Datum muss zwischen {start} und {end} liegen"
+        }
+    },
+    "exportToasts": {
+        "downloadFailed": "Herunterladen des Exports fehlgeschlagen",
+        "invalidDateRange": "Ungültiger Datumsbereich",
+        "invalidDateRangeDescription": "Bitte wählen Sie einen gültigen Datumsbereich für den Export.",
+        "exportSuccess": "Export erfolgreich!",
+        "exportSuccessDescription": "Ihre {type}-Datei wurde heruntergeladen. Details finden Sie in Ihrem Export-Verlauf.",
+        "exportFailed": "Export fehlgeschlagen",
+        "exportFailedFallback": "Datenexport fehlgeschlagen. Bitte erneut versuchen.",
+        "noDownloadPermission": "Sie haben keine Berechtigung, die Datei herunterzuladen.",
+        "noExportPermission": "Sie haben keine Berechtigung zum Exportieren",
+        "quotaUsed": "Sie haben Ihr gesamtes Kontingent aufgebraucht",
+        "exporting": "Wird exportiert...",
+        "export": "Exportieren",
+        "columnSubmissionTime": "Einreichungszeit",
+        "columnDateRange": "Datumsbereich",
+        "columnGeneratedBy": "Erstellt von",
+        "columnStatus": "Status",
+        "typeAll": "Alle Typen",
+        "typeSent": "Gesendet",
+        "typeReceived": "Empfangen",
+        "typeStakingRewards": "Staking-Belohnungen",
+        "allAssets": "Alle Vermögenswerte",
+        "upgradeTrial": "Upgraden Sie Ihren Tarif, um mehr zu erhalten und weiterzumachen",
+        "upgradePaid": "Upgraden Sie Ihren Tarif für mehr Zugriff oder warten Sie, bis Ihre Limits nächsten Monat zurückgesetzt werden.",
+        "selectDateRange": "Datumsbereich auswählen",
+        "noExportsTitle": "Noch keine Exporte",
+        "noExportsDescription": "Ihre exportierten Dateien des letzten Monats erscheinen hier, sobald sie erstellt werden.",
+        "quotaTitle": "Export-Kontingent",
+        "unlimited": "Unbegrenzt",
+        "creditsPerMonth": "{total} / Monat",
+        "requirementsTitle": "Export-Anforderungen",
+        "exportFromPeriod": "Sie können Daten aus dem {period} exportieren.",
+        "availableFor48Hours": "Exportierte Dateien stehen 48 Stunden zum Download zur Verfügung.",
+        "moreFlexibility": "Suchen Sie mehr Flexibilität?",
+        "contactUs": "Kontaktieren Sie uns",
+        "last1Year": "Letztes 1 Jahr",
+        "last2Years": "Letzte 2 Jahre",
+        "invalidEmail": "Bitte geben Sie eine gültige E-Mail-Adresse ein"
+    },
+    "proposalKinds": {
+        "Batch Payment Request": "Stapel-Zahlungsanfrage",
+        "Payment Request": "Zahlungsanfrage",
+        "Confidential Request": "Vertrauliche Anfrage",
+        "Exchange": "Tauschen",
+        "Function Call": "Funktionsaufruf",
+        "Change Policy": "Richtlinie ändern",
+        "Update General Settings": "Allgemeine Einstellungen aktualisieren",
+        "Earn NEAR": "NEAR-Erträge",
+        "Unstake NEAR": "NEAR unstaken",
+        "Vesting": "Vesting",
+        "Withdraw Earnings": "Erträge abheben",
+        "Members": "Mitglieder",
+        "Upgrade": "Upgrade",
+        "Set Staking Contract": "Staking-Vertrag festlegen",
+        "Bounty": "Bounty",
+        "Vote": "Stimme",
+        "Factory Info Update": "Factory-Info-Aktualisierung",
+        "Unsupported": "Nicht unterstützt"
+    },
+    "paymentFormSection": {
+        "selectRecipient": "Empfänger auswählen",
+        "searchByNameOrAddress": "Nach Name oder Adresse suchen",
+        "restrictedRecipientTitle": "Transaktion nicht erlaubt",
+        "restrictedRecipientMessage": "Diese Adresse ist derzeit aufgrund von Sicherheitsprüfungen eingeschränkt. Wenn Sie der Meinung sind, dass diese Adresse zugelassen werden sollte, können Sie <link>eine Whitelist-Aufnahme beantragen</link>.",
+        "send": "Senden",
+        "to": "An"
+    },
+    "recipientNetworkSelect": {
+        "label": "Empfänger-Netzwerk",
+        "placeholder": "Empfänger-Netzwerk auswählen",
+        "enterAddressFirst": "Geben Sie zuerst die Empfängeradresse ein",
+        "noCompatibleNetwork": "Kein Netzwerk passt zu dieser Adresse",
+        "selectPlaceholder": "Netzwerk auswählen",
+        "title": "Netzwerk auswählen",
+        "available": "Verfügbar",
+        "fromAddressBook": "Aus dem Adressbuch",
+        "otherAvailable": "Andere verfügbar",
+        "incompatible": "Inkompatibel",
+        "comingSoon": "Demnächst verfügbar",
+        "nearComName": "near.com",
+        "nearComDescription": "Internes Netzwerk für near.com und Trezu"
+    },
+    "addressBookTable": {
+        "emptyTitle": "Noch keine Empfänger",
+        "emptyDescription": "Fügen Sie diesem Adressbuch Empfänger hinzu, um Auszahlungen zu beschleunigen.",
+        "selectAll": "Alle Empfänger auswählen",
+        "selectEntry": "{name} auswählen",
+        "recipient": "Empfänger",
+        "network": "Netzwerk",
+        "addedBy": "Hinzugefügt von",
+        "note": "Notiz",
+        "added": "Hinzugefügt",
+        "remove": "Entfernen",
+        "send": "Senden"
+    },
+    "publicDashboard": {
+        "updatesDaily": "Wird täglich aktualisiert",
+        "noDataTitle": "Noch keine Daten",
+        "noDataDescription": "Statistiken erscheinen, nachdem die erste tägliche Momentaufnahme berechnet wurde.",
+        "assetsSecured": "Mit Sputnik-DAO-Vertrag gesicherte Vermögenswerte",
+        "acrossDaos": "Über <bold>{count, plural, one {# DAO} other {# DAOs}}</bold>",
+        "updatedOn": "Aktualisiert am {date}",
+        "topAssets": "Top 20 Vermögenswerte",
+        "noAssetsTitle": "Noch keine Vermögenswerte",
+        "noAssetsDescription": "Token-Daten erscheinen, sobald die tägliche Momentaufnahme berechnet wurde.",
+        "tableToken": "Token",
+        "tableTotalValue": "Gesamtwert"
+    },
+    "telegramConnectInstructions": {
+        "title": "Telegram verbinden",
+        "subtitle": "Erhalten Sie Benachrichtigungen über Vorschläge und Aktivitäten in Ihrem Telegram.",
+        "step3": "Drücken Sie Start und folgen Sie den Anweisungen.",
+        "success": "Sie sind bereit!",
+        "copyBotTooltip": "Bot-Handle kopieren",
+        "botCopiedToast": "Bot-Handle kopiert",
+        "openInTelegram": "{bot} in Telegram öffnen"
+    },
+    "transactionHashCell": {
+        "copyHash": "Hash kopieren",
+        "hashCopied": "Hash kopiert",
+        "openInExplorer": "Im Explorer öffnen"
+    },
+    "treasurySelector": {
+        "select": "Treasury auswählen",
+        "connectWalletTooltip": "Wallet verbinden, um Treasuries anzuzeigen",
+        "manageTreasuries": "Treasuries verwalten",
+        "createTreasury": "Treasury erstellen",
+        "memberOf": "Mitglied von",
+        "guestTreasuries": "Gast-Treasuries"
+    },
+    "selectModal": {
+        "searchByName": "Nach Namen suchen",
+        "noResults": "Keine Ergebnisse gefunden"
+    },
+    "selectList": {
+        "noResults": "Keine Ergebnisse gefunden"
+    },
+    "datePicker": {
+        "pickDate": "Datum auswählen",
+        "timezone": "Zeitzone"
+    },
+    "datePresets": {
+        "today": "Heute",
+        "yesterday": "Gestern",
+        "last3Days": "Letzte 3 Tage",
+        "last7Days": "Letzte 7 Tage",
+        "last14Days": "Letzte 14 Tage",
+        "lastMonth": "Letzter Monat",
+        "last3Months": "Letzte 3 Monate",
+        "last6Months": "Letzte 6 Monate"
+    },
+    "input": {
+        "openSearch": "Suche öffnen"
+    },
+    "pagination": {
+        "previous": "Zurück",
+        "next": "Weiter"
+    },
+    "confidentialState": {
+        "title": "Vertraulich",
+        "description": "Nur Treasury-Mitglieder haben Zugriff."
+    },
+    "exchangeRate": {
+        "rate": "Kurs",
+        "clickToReverse": "Klicken, um Kurs umzukehren"
+    },
+    "exchangeSettings": {
+        "title": "Tausch-Einstellungen",
+        "slippageTolerance": "Slippage-Toleranz",
+        "custom": "Benutzerdefiniert",
+        "customPlaceholder": "z. B.: 2 %",
+        "slippageRange": "Slippage muss zwischen 0,01 % und 100 % liegen",
+        "enterSlippage": "Bitte geben Sie eine Slippage-Toleranz ein",
+        "slippageHelp": "Wenn sich der Preis um mehr als diesen Prozentsatz ändert, wird die Transaktion zum Schutz Ihrer Mittel abgebrochen.",
+        "save": "Speichern"
+    },
+    "assetsPage": {
+        "title": "Vermögenswerte",
+        "noAssetsTitle": "Noch keine Vermögenswerte",
+        "noAssetsDescription": "Um zu beginnen, fügen Sie durch eine Einzahlung Vermögenswerte zu Ihrer Treasury hinzu."
+    },
+    "newBadge": {
+        "label": "Neu"
+    },
+    "numberBadge": {
+        "pendingRequests": "{count, plural, one {# ausstehende Anfrage} other {# ausstehende Anfragen}}"
+    },
+    "balanceWithGraph": {
+        "allTokens": "Alle Token",
+        "deposit": "Einzahlen",
+        "send": "Senden",
+        "exchange": "Tauschen",
+        "chartNow": "Jetzt",
+        "totalBalance": "Gesamtguthaben",
+        "excludedTokens": "Ausgeschlossene Token:",
+        "noPriceHistory": "Kein Preisverlauf. Wählen Sie ein Token, um dessen Guthabenänderungen zu sehen.",
+        "bucketAvailable": "Verfügbar",
+        "bucketLocked": "Gesperrt",
+        "bucketEarning": "Erträge",
+        "period": {
+            "1W": "1W",
+            "1M": "1M",
+            "3M": "3M",
+            "1Y": "1J"
+        }
+    },
+    "changePolicyExpanded": {
+        "proposalBond": "Vorschlagskaution",
+        "proposalPeriod": "Vorschlagszeitraum",
+        "bountyBond": "Bounty-Kaution",
+        "bountyForgivenessPeriod": "Bounty-Kulanzzeitraum",
+        "votesCount": "{count} Stimmen",
+        "weightKind": "Gewichtungsart",
+        "quorum": "Quorum",
+        "threshold": "Schwellenwert",
+        "defaultThreshold": "Standardschwellenwert",
+        "roleThreshold": "{role}-Schwellenwert",
+        "member": "Mitglied",
+        "members": "Mitglieder",
+        "permissions": "Berechtigungen",
+        "oldPermissions": "Alte Berechtigungen",
+        "newPermissions": "Neue Berechtigungen",
+        "category": "Kategorie",
+        "transactionDetails": "Transaktionsdetails",
+        "addNewMember": "Neues Mitglied hinzufügen",
+        "addNewMembers": "Neue Mitglieder hinzufügen",
+        "removeMember": "Mitglied entfernen",
+        "removeMembers": "Mitglieder entfernen",
+        "updateMemberPermissions": "Mitgliederberechtigungen aktualisieren",
+        "updateMembersPermissions": "Mitgliederberechtigungen aktualisieren",
+        "memberIndex": "Mitglied {index}",
+        "membersCount": "{count} Mitglieder",
+        "collapseAll": "Alle einklappen",
+        "expandAll": "Alle ausklappen",
+        "loadingHistorical": "Historische Richtlinie wird geladen...",
+        "unableToDiff": "Unterschiede für diesen Vorschlag können nicht berechnet werden.",
+        "noChangesCurrent": "Keine Änderungen erkannt - die vorgeschlagene Richtlinie ist mit der aktuellen Richtlinie identisch.",
+        "noChangesHistorical": "Keine Änderungen erkannt - die vorgeschlagene Richtlinie ist mit der historischen Richtlinie identisch."
+    },
+    "balanceChart": {
+        "usdValue": "USD-Wert",
+        "tokenBalance": "Token-Guthaben",
+        "emptyTitle": "Noch nichts anzuzeigen",
+        "emptyDescription": "Fügen Sie Vermögenswerte hinzu, um Ihr Portfolio zu verfolgen."
+    },
+    "user": {
+        "saveToAddressBook": "Im Adressbuch speichern",
+        "walletCopiedToast": "Wallet-Adresse in die Zwischenablage kopiert",
+        "copyWalletAddress": "Wallet-Adresse kopieren"
+    },
+    "infoDisplay": {
+        "viewLess": "Weniger anzeigen",
+        "viewAllDetails": "Alle Details anzeigen"
+    },
+    "amountSummary": {
+        "defaultTitle": "Sie senden insgesamt"
+    },
+    "residency": {
+        "vestedToken": "Gevestetes Token",
+        "staked": "Gestaked",
+        "fungibleToken": "Fungibles Token",
+        "intentsToken": "Intents-Token",
+        "nativeToken": "Natives Token"
+    },
+    "exchangeErrors": {
+        "noRoute": "Kein Tausch gefunden. Versuchen Sie einen kleineren Betrag oder ein anderes Token.",
+        "amountTooLow": "Betrag zu niedrig für den Tausch. Cross-Chain-Tausche erfordern ein höheres Minimum, um Netzwerkgebühren abzudecken.",
+        "insufficientBalance": "Unzureichendes Guthaben für diesen Tausch.",
+        "networkError": "Netzwerkfehler. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+        "fetchFailed": "Abrufen des Angebots fehlgeschlagen"
+    },
+    "tokenSelectDialog": {
+        "selectToken": "Token auswählen",
+        "selectAsset": "Vermögenswert auswählen",
+        "selectNetworkFor": "Netzwerk für {asset} auswählen",
+        "searchByName": "Nach Namen suchen",
+        "noTokensWithBalance": "Keine Token mit Guthaben gefunden",
+        "noTokensFound": "Keine Token gefunden",
+        "yourAssets": "Ihre Vermögenswerte",
+        "otherAssets": "Andere Vermögenswerte",
+        "networksWithAssets": "Netzwerke mit Vermögenswerten",
+        "supportedNetworks": "Unterstützte Netzwerke",
+        "comingSoon": "Demnächst verfügbar"
+    },
+    "intentsQuote": {
+        "initializing": "Der Angebotsdienst wird noch initialisiert. Bitte erneut versuchen.",
+        "noRoute": "Derzeit kann keine Zahlungsroute vorbereitet werden. Bitte erneut versuchen.",
+        "fetchFailed": "Derzeit kann keine Zahlungsroute vorbereitet werden. Bitte erneut versuchen.",
+        "amountTooLow": "Der Betrag ist zu niedrig, um die Netzwerkgebühren zu decken. Geben Sie einen höheren Betrag ein und versuchen Sie es erneut.",
+        "amountTooLowWithMin": "Der Betrag ist zu niedrig, um die Netzwerkgebühren zu decken. Geben Sie mindestens {min} {token} ein.",
+        "networkFeeTooltip": "Diese Gebühr wird verwendet, um die Transaktion auf der ausgewählten Chain zu verarbeiten."
+    },
+    "pageTours": {
+        "paymentsBulk": "Sammelerstellung ist da! Erstellen Sie mehrere Anfragen in nur wenigen Schritten.",
+        "paymentsPending": "Sehen Sie sich hier Anfragen an, die auf Genehmigung warten.",
+        "exchangeSettings": "Hier können Sie festlegen, wie viel Preisänderung Sie akzeptieren möchten.",
+        "membersPending": "Klicken Sie, um aktive Anfragen zu sehen, die auf Genehmigung warten.",
+        "guestSaveIntro": "Sie sind Gast dieser Treasury. Sie können nur die Daten einsehen.",
+        "guestSaveAction": "Sie können diese Gast-Treasury in Ihrer Treasury-Liste speichern.",
+        "newFeatureRich": "Neu! 🎉 Speichern Sie häufig verwendete Adressen für schnellere, fehlerfreie Auszahlungen.<br></br> Ihre Kontakte bleiben privat und sind nur für Ihr Team sichtbar.",
+        "newFeatureCta": "Ausprobieren"
+    },
+    "statusDate": {
+        "expires": "Läuft ab",
+        "created": "Erstellt",
+        "expired": "Abgelaufen",
+        "removed": "Entfernt"
+    },
+    "relativeTime": {
+        "justNow": "Gerade eben",
+        "moments": "Momente"
+    },
+    "amount": {
+        "network": "Netzwerk: {network}"
+    },
+    "activityLabels": {
+        "exchangePending": "Tausch ausstehend",
+        "exchangeRequest": "Tauschanfrage",
+        "exchangeFulfillment": "Tauschabwicklung",
+        "stakingRewards": "Staking-Belohnungen",
+        "proposalAction": "Vorschlagsaktion",
+        "deposit": "{symbol} einzahlen",
+        "paymentSent": "Zahlung gesendet",
+        "transaction": "Transaktion",
+        "fallbackToken": "Token",
+        "viaIntents": "über NEAR Intents",
+        "from": "von {account}",
+        "to": "an {account}",
+        "viewAll": "Den gesamten Transaktionsverlauf anzeigen",
+        "sentReceived": "Gesendete und empfangene Transaktionen ({duration})",
+        "unlimitedHistory": "unbegrenzter Verlauf",
+        "oneYear": "1 Jahr",
+        "yearsCount": "{count} Jahre",
+        "monthsCount": "{count} Monate",
+        "lastDuration": "letzte {duration}"
+    },
+    "nearStore": {
+        "connectAndAcceptTerms": "Bitte verbinden Sie Ihre Wallet und akzeptieren Sie die Bedingungen, um fortzufahren.",
+        "transactionNotApproved": "Die Transaktion wurde in Ihrer Wallet nicht genehmigt.",
+        "failedSubmitVote": "Übermittlung der Stimme fehlgeschlagen",
+        "failedSubmitVotes": "Übermittlung der Stimmen fehlgeschlagen",
+        "viewRequest": "Anfrage anzeigen",
+        "proposalRemoved": "Ihr Vorschlag wurde entfernt",
+        "voteSubmitted": "Ihre Stimme wurde übermittelt",
+        "votesSubmitted": "Ihre Stimmen wurden übermittelt"
+    },
+    "tokenInput": {
+        "max": "MAX",
+        "insufficientTokens": "Unzureichende Token. Sie können die Anfrage einreichen und vor der Genehmigung aufladen.",
+        "balance": "Guthaben: {amount} {symbol}"
+    },
+    "createRequestButton": {
+        "idle": "Anfrage erstellen",
+        "noPermission": "Sie haben keine Berechtigung, eine Anfrage zu erstellen"
+    },
+    "address": {
+        "copied": "Adresse in die Zwischenablage kopiert"
+    },
+    "memberAvatars": {
+        "membersWhoCanVote": "Mitglieder, die abstimmen können",
+        "moreMembers": "+{count, plural, one {# Mitglied} other {# Mitglieder}}"
+    },
+    "accountIdInput": {
+        "minLength": "Konto-ID sollte mindestens 2 Zeichen umfassen",
+        "maxLength": "Konto-ID muss weniger als 64 Zeichen umfassen",
+        "charset": "Konto-ID darf nur Kleinbuchstaben, Ziffern, Punkte, Bindestriche und Unterstriche enthalten, ohne führende oder abschließende Trennzeichen",
+        "doesNotExist": "Konto-ID existiert nicht"
+    },
+    "addressBookMutations": {
+        "addedToast": "{count, plural, one {Empfänger hinzugefügt} other {# Empfänger hinzugefügt}}",
+        "addedSingleToast": "Empfänger hinzugefügt",
+        "addFailedToast": "Hinzufügen der Empfänger fehlgeschlagen",
+        "addSingleFailedToast": "Hinzufügen des Empfängers fehlgeschlagen",
+        "removedToast": "{count, plural, one {Empfänger entfernt} other {# Empfänger entfernt}}",
+        "removeFailedToast": "Entfernen der Empfänger fehlgeschlagen",
+        "exportFailedToast": "Export der Empfänger fehlgeschlagen"
+    },
+    "treasuryMutations": {
+        "savedToast": "Treasury in Ihrer Liste gespeichert",
+        "saveFailedToast": "Speichern der Treasury fehlgeschlagen",
+        "hiddenToast": "Treasury aus der Liste ausgeblendet",
+        "hideFailedToast": "Ausblenden der Treasury fehlgeschlagen",
+        "unhiddenToast": "Treasury ist wieder sichtbar",
+        "unhideFailedToast": "Einblenden der Treasury fehlgeschlagen",
+        "removedToast": "Treasury aus der gespeicherten Liste entfernt",
+        "removeFailedToast": "Entfernen der Treasury aus der gespeicherten Liste fehlgeschlagen"
+    },
+    "telegramSettings": {
+        "title": "Telegram",
+        "connectedTo": "Verbunden mit {chat}",
+        "chatNumber": "Chat #{id}",
+        "fallbackChat": "einem Telegram-Chat",
+        "disconnect": "Trennen",
+        "connect": "Verbinden",
+        "connectDescription": "Verknüpfen Sie Ihre Treasury mit einem Telegram-Chat, um Benachrichtigungen zu erhalten.",
+        "noTreasuryDescription": "Verknüpfen Sie Ihre Treasuries mit einem Telegram-Chat.",
+        "openSettingsHint": "Öffnen Sie die Einstellungen aus einer Treasury, um Integrationen zu verwalten.",
+        "disconnectedToast": "Telegram für diese Treasury getrennt",
+        "disconnectFailedToast": "Telegram konnte nicht getrennt werden. Bitte erneut versuchen."
+    },
+    "assetsTable": {
+        "noAssetsFound": "Keine Vermögenswerte gefunden.",
+        "assetDetails": "Vermögenswert-Details",
+        "coinPrice": "Coin-Preis",
+        "weight": "Gewicht",
+        "balance": "Guthaben",
+        "lockedBalance": "Gesperrtes Guthaben",
+        "totalBalance": "Gesamtguthaben",
+        "source": "Quelle",
+        "balanceByInvestors": "Guthaben nach {count, plural, one {Investor} other {Investoren}}",
+        "investors": "{count, plural, one {Investor} other {Investoren}}",
+        "poolBreakdown": "Pool-Aufschlüsselung",
+        "unlockedToken": "Entsperrtes Token",
+        "lockupStakingPool": "Lockup-Staking-Pool",
+        "exchange": "Tauschen",
+        "send": "Senden",
+        "details": "Details",
+        "columnToken": "Token",
+        "columnLocked": "Gesperrt",
+        "columnUnlocked": "Entsperrt",
+        "columnTotalAllocated": "Gesamt zugewiesen",
+        "columnAvailableToWithdraw": "Verfügbar zum Abheben",
+        "viewAvailable": "Verfügbar",
+        "viewLocked": "Gesperrt",
+        "viewEarning": "Erträge",
+        "fullAllocatedBalance": "Ihr gesamtes zugewiesenes Guthaben",
+        "partAllocatedBalance": "Teil Ihres zugewiesenen Guthabens",
+        "currentlyEarning": "({amount} {symbol}) erzielt derzeit Erträge.",
+        "willAppearHere": " Es erscheint hier, sobald Sie das Erzielen von Erträgen beenden.",
+        "seeInEarningTab": "Im Erträge-Tab anzeigen",
+        "seeInEarning": "In Erträge anzeigen"
+    },
+    "earningDetails": {
+        "title": "Ertrags-Details",
+        "totalStaked": "Gesamt gestaked",
+        "earningOverview": "Ertrags-Übersicht",
+        "poolBreakdown": "Pool-Aufschlüsselung ({count, plural, one {# Pool} other {# Pools}})",
+        "almostReady": "Erträge sind fast bereit!",
+        "finalizingFeature": "Wir schließen diese Funktion ab,<br></br>damit Sie bald Token verdienen können.",
+        "comingSoon": "Demnächst verfügbar",
+        "goToEarn": "Zu Erträge",
+        "readyToWithdraw": "Bereit zum Abheben",
+        "unstaking": "Wird unstaked",
+        "overview": {
+            "staked": "Gestaked",
+            "stakedInfo": "Token, die derzeit an Validatoren delegiert sind und Belohnungen erzielen.",
+            "pendingRelease": "Ausstehende Freigabe",
+            "pendingReleaseInfo": "Token, die unstaked wurden, sich aber noch in der Entbindungsphase befinden (typischerweise 2-3 Tage).",
+            "availableForWithdraw": "Verfügbar zum Abheben",
+            "availableForWithdrawInfo": "Unstakte Token, die die Entbindungsphase abgeschlossen haben und abgehoben werden können."
+        }
+    },
+    "lockupDetails": {
+        "title": "Lockup-Details",
+        "balance": "Guthaben",
+        "reservedForStorage": "Für Speicher reserviert",
+        "reservedForStorageInfo": "NEAR, das vom Lockup-Konto zur Bezahlung der Speicherkosten reserviert ist.",
+        "tokenBreakdown": "Token-Aufschlüsselung",
+        "allocatedAmount": "Zugewiesener Betrag",
+        "earned": "Verdient",
+        "progress": "Fortschritt",
+        "unlocked": "Entsperrt",
+        "locked": "Gesperrt",
+        "schedule": "Zeitplan",
+        "startDate": "Startdatum",
+        "endDate": "Enddatum",
+        "rounds": "Runden",
+        "releaseInterval": "Freigabeintervall",
+        "nextUnlockDate": "Nächstes Entsperrdatum",
+        "allEarning": "Die gesamten {amount} {symbol} aus Ihrem Lockup erzielen derzeit Erträge.",
+        "partEarning": "Ein Teil Ihres Lockups ({amount} {symbol}) erzielt derzeit Erträge.",
+        "stopEarningFirst": "Um entsperrte Token zu verwenden, beenden Sie zuerst das Erzielen von Erträgen und heben Sie sie ab.",
+        "howGrantWorks": "So funktioniert Ihre Zuteilung",
+        "ftStep1": "Sie erhalten eine Zuteilung für einen bestimmten Zeitraum. Anstatt den vollen Betrag auf einmal zu erhalten, werden die Vermögenswerte mit der Zeit in Teilen verfügbar.",
+        "ftStep2": "Wenn das Datum für die nächste Freigabe erreicht ist, wird dieser Token-Anteil automatisch entsperrt und auf Ihr Treasury-Guthaben übertragen.",
+        "ftStep3": "Sobald sie in Ihrem Guthaben erscheinen, können Sie sie sofort für Zahlungen, Überweisungen oder andere Transaktionen verwenden.",
+        "nearStep1": "Sie erhalten eine Zuteilung für einen festgelegten Zeitraum mit definiertem Start- und Enddatum.",
+        "nearStep2": "Während die Token entsperrt werden, werden sie automatisch in Ihrem Treasury-Guthaben verfügbar.",
+        "nearStep3": "Sie können die entsperrten Token sofort für Zahlungen, Überweisungen oder andere Transaktionen verwenden.",
+        "notAvailable": "k. A.",
+        "everyMonth": "Jeden Monat",
+        "everyQuarter": "Jedes Quartal",
+        "everyUnit": "Alle {unit}",
+        "everyMultiple": "Alle {text}",
+        "completed": "Abgeschlossen",
+        "unit": {
+            "year": "{count, plural, one {# Jahr} other {# Jahre}}",
+            "day": "{count, plural, one {# Tag} other {# Tage}}",
+            "hour": "{count, plural, one {# Stunde} other {# Stunden}}",
+            "minute": "{count, plural, one {# Minute} other {# Minuten}}",
+            "second": "{count, plural, one {# Sekunde} other {# Sekunden}}"
+        }
+    },
+    "vestingDetails": {
+        "title": "Vesting-Details",
+        "availableToUse": "Verfügbar zur Nutzung",
+        "vestingPeriod": "Vesting-Zeitraum",
+        "vestingPeriodDescription": "Token werden während dieses Zeitraums täglich freigeschaltet.",
+        "startDate": "Startdatum",
+        "endDate": "Enddatum",
+        "tokenBreakdown": "Token-Aufschlüsselung",
+        "originalVestedAmount": "Ursprünglicher Vesting-Betrag",
+        "reservedForStorage": "Für Speicher reserviert",
+        "reservedForStorageInfo": "Eine kleine Menge an Token, die erforderlich ist, um das Vesting aktiv zu halten und die Speicherkosten zu decken.",
+        "percentVested": "{percent}% gevestet",
+        "vestedOf": "{vested} von {total} {symbol}",
+        "send": "Senden"
+    },
+    "earningPoolDetails": {
+        "balance": "Guthaben",
+        "apy": "APY",
+        "fee": "Gebühr",
+        "notAvailable": "k. A.",
+        "lockupStakingPool": "Lockup-Staking-Pool",
+        "lockupAssetsNote": "Alle Vermögenswerte in dieser Position stammen aus Ihrem Lockup. Nachdem Sie das Erzielen von Erträgen beenden, können einige Token weiterhin gesperrt und nicht verfügbar sein - prüfen Sie Ihren Lockup-Zeitplan, um zu sehen, wann sie entsperrt werden."
+    },
+    "onboardingQuestions": {
+        "stepTitle": "Ein paar kurze Fragen zum Einstieg.",
+        "other": "Andere",
+        "placeholders": {
+            "describeRole": "Beschreiben Sie Ihre Rolle (optional)",
+            "describeUseCase": "Beschreiben Sie Ihren Anwendungsfall (optional)",
+            "networkName": "Netzwerknamen eingeben (optional)",
+            "currentChallenge": "Geben Sie Ihre aktuelle Herausforderung ein (optional)",
+            "describeOther": "Anderes beschreiben (optional)"
+        },
+        "questions": {
+            "role": "Was beschreibt Ihre Rolle am besten?",
+            "useCases": "Wofür möchten Sie Trezu nutzen?",
+            "teamSize": "Wie viele Personen werden die Treasury verwalten?",
+            "networks": "Welche Netzwerke nutzen Sie am häufigsten?",
+            "multisigExperience": "Welche Erfahrung haben Sie mit Multisig?",
+            "currentTools": "Welche Tools nutzen Sie derzeit zur Finanzverwaltung?",
+            "monthlyVolume": "Ungefähres monatliches Transaktionsvolumen?",
+            "biggestChallenges": "Was ist Ihre größte aktuelle Herausforderung?"
+        },
+        "options": {
+            "role": {
+                "founder": "Gründer",
+                "co-founder": "Mitgründer",
+                "cfo-finance-lead": "CFO / Finanzleiter",
+                "operations-manager": "Operations Manager",
+                "treasury-manager": "Treasury Manager",
+                "other": "Andere"
+            },
+            "useCases": {
+                "team-payroll-grants": "Team-Gehaltsabrechnung & Förderungen",
+                "company-assets-management": "Unternehmensvermögensverwaltung",
+                "dao-treasury-management": "DAO-Treasury-Management",
+                "investment-portfolio": "Investmentportfolio",
+                "operational-spending": "Betriebsausgaben",
+                "other": "Andere"
+            },
+            "teamSize": {
+                "just-me": "Nur ich",
+                "2-5-people": "2-5 Personen",
+                "6-15-people": "6-15 Personen",
+                "15-plus-people": "15+"
+            },
+            "networks": {
+                "near": "NEAR",
+                "bitcoin": "Bitcoin",
+                "ethereum": "Ethereum",
+                "solana": "Solana",
+                "arbitrum": "Arbitrum",
+                "base": "Base",
+                "optimism": "Optimism",
+                "polygon": "Polygon",
+                "gnosis": "Gnosis",
+                "avalanche": "Avalanche",
+                "bnb-chain": "BNB Chain",
+                "other": "Andere"
+            },
+            "multisigExperience": {
+                "never-heard-of-it": "Noch nie davon gehört",
+                "heard-about-it": "Davon gehört",
+                "never-used-it": "Noch nie genutzt",
+                "used-gnosis-safe-or-similar": "Gnosis Safe oder Ähnliches genutzt",
+                "experienced": "Erfahren",
+                "looking-for-a-better-option": "Suche nach einer besseren Option"
+            },
+            "currentTools": {
+                "gnosis-safe": "Gnosis Safe",
+                "fireblocks": "Fireblocks",
+                "tholos": "Tholos",
+                "squads-multisig": "Squads Multisig",
+                "mpc-vault": "MPC Vault",
+                "other": "Andere"
+            },
+            "monthlyVolume": {
+                "under-10k": "Unter 10.000 $",
+                "10k-100k": "10.000 $ - 100.000 $",
+                "100k-1m": "100.000 $ - 1 Mio. $",
+                "1m-plus": "1 Mio. $+"
+            },
+            "biggestChallenges": {
+                "slow-approvals-and-signing": "Langsame Genehmigungen und Signierungen",
+                "lack-of-transparency-in-the-team": "Mangelnde Transparenz im Team",
+                "hard-to-track-spending-and-balances": "Ausgaben und Guthaben schwer nachvollziehbar",
+                "security-and-access-control": "Sicherheit und Zugriffskontrolle",
+                "no-good-web3-tool-yet": "Noch kein gutes Web3-Tool",
+                "looking-for-crypto-earnings": "Ich suche nach Krypto-Erträgen",
+                "other": "Andere"
+            }
+        }
+    },
+    "onboarding": {
+        "tour": {
+            "addAssets": "Fügen Sie durch eine Einzahlung Vermögenswerte zu Ihrer Treasury hinzu.",
+            "makeRequests": "Erstellen Sie Zahlungsanfragen, wann immer Sie Vermögenswerte senden müssen.",
+            "exchangeAssets": "Hier können Sie Ihre Vermögenswerte tauschen.",
+            "addMembers": "Fügen Sie Ihrer Treasury Mitglieder hinzu und weisen Sie ihnen Rollen zu.",
+            "newTreasury": "Möchten Sie eine neue Treasury einrichten? Sie können dies hier in nur wenigen Klicks erledigen.",
+            "helpSupport": "Erhalten Sie Hilfe und Support, wann immer Sie ihn benötigen."
+        },
+        "tourCard": {
+            "close": "Schließen",
+            "stepProgress": "{current} von {total}",
+            "gotIt": "Verstanden",
+            "done": "Fertig",
+            "next": "Weiter"
+        },
+        "progress": {
+            "title": "Folgen Sie schnellen Schritten zur Erkundung der Treasury",
+            "createTreasuryTitle": "Treasury-Konto erstellen",
+            "createTreasuryDescription": "Sie haben Ihr Konto erfolgreich eingerichtet. Großartiger Start!",
+            "addAssetsTitle": "Fügen Sie Ihre Vermögenswerte hinzu",
+            "addAssetsDescription": "Beginnen Sie, indem Sie Vermögenswerte hinzufügen, um sie in Aktion zu sehen.",
+            "deposit": "Einzahlen",
+            "createPaymentTitle": "Zahlungsanfrage erstellen",
+            "createPaymentDescription": "Erstellen Sie eine Zahlungsanfrage, um Ihre Einrichtung abzuschließen.",
+            "send": "Senden"
+        },
+        "welcome": {
+            "heading": "🎉 Willkommen!",
+            "subheading": "Machen Sie eine kurze Tour durch die Treasury",
+            "body": "Hallo! Ihre Trezu ist bereit - beginnen Sie mit dem Aufbau Ihres Portfolios, indem Sie Vermögenswerte aus unterstützten Netzwerken hinzufügen.",
+            "progress": "{current} von {total}",
+            "next": "Weiter",
+            "body2": "Erfahren Sie, wie Sie eine Einzahlung tätigen, eine Anfrage erstellen und ein neues Konto einrichten.",
+            "noThanks": "Nein, danke",
+            "letsGo": "Los geht's"
+        },
+        "congrats": {
+            "heading": "🎉 Glückwunsch!",
+            "body": "Sie haben Ihre Treasury-Einrichtung abgeschlossen. Genießen Sie die einfache Verwaltung Ihrer Vermögenswerte.",
+            "letsGo": "Los geht's!"
+        },
+        "createBanner": {
+            "close": "Schließen",
+            "title": "Trezu erkunden",
+            "description": "Erstellen Sie ein Konto, um Berechtigungen für alle Funktionen und Vorteile von Trezu freizuschalten.",
+            "cta": "Treasury erstellen"
+        },
+        "questionnaire": {
+            "continue": "Weiter",
+            "skip": "Überspringen"
+        },
+        "createPrompt": {
+            "title": "Sie sind fast fertig",
+            "description": "Ihre Wallet ist verbunden, aber Sie haben noch keine Treasury erstellt. Erstellen Sie ein Konto, um Trezu zu nutzen, oder {suffix}",
+            "suffixDemo": "sehen Sie sich die Demo an.",
+            "suffixExploring": "erkunden Sie weiter.",
+            "createCta": "Treasury erstellen",
+            "viewDemo": "Demo ansehen",
+            "keepExploring": "Weiter erkunden"
+        },
+        "infoBox": {
+            "title": "Mehr aus Trezu herausholen",
+            "close": "Schließen",
+            "description": "Entdecken Sie, wie andere Treasury nutzen, probieren Sie die Demo aus und sehen Sie sich die Dokumentation an, um die Funktionen kennenzulernen.",
+            "demoTitle": "Trezu-Demo erkunden",
+            "demoDescription": "Sehen Sie ein Live-Demo-Konto in Aktion.",
+            "docsTitle": "Dokumentation",
+            "docsDescription": "Erfahren Sie alles über die Funktionen in der Dokumentation.",
+            "videoTitle": "Demo ansehen",
+            "videoDescription": "Sehen Sie ein kurzes Video, das zeigt, wie Trezu funktioniert."
+        }
+    }
+}

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -44,7 +44,16 @@
         "english": "English",
         "spanish": "Español",
         "ukrainian": "Українська",
-        "hebrew": "עברית"
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
     },
     "header": {
         "toggleSidebar": "Toggle sidebar",
@@ -634,7 +643,6 @@
             "approvalsReceived": "{received}/{required} approvals received",
             "expiresAt": "Expires At",
             "expiredAt": "Expired At",
-            "viewTransaction": "View Transaction",
             "exchangingTokens": "Exchanging Tokens",
             "exchangingTokensBody": "This request has been approved by the team. Token exchange is now in progress and may take some time.",
             "requestFailed": "Request Failed",
@@ -642,7 +650,6 @@
             "votingPeriod24h": "Voting period: 24 hours",
             "votingPeriod24hBody": "This exchange request has a 24-hour voting duration. Approve this request within this time, or the request will expire.",
             "reject": "Reject",
-            "deposit": "Deposit",
             "approve": "Approve"
         },
         "insufficientBalance": {

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -44,7 +44,16 @@
         "english": "English",
         "spanish": "Español",
         "ukrainian": "Українська",
-        "hebrew": "עברית"
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
     },
     "header": {
         "toggleSidebar": "Alternar barra lateral",
@@ -512,7 +521,7 @@
             "description": "Descripción",
             "methodName": "Nombre del método",
             "args": "Argumentos",
-            "deposit": "Depósito",
+            "deposit": "Depositar",
             "gas": "Gas",
             "totalDeposit": "Depósito total",
             "totalGas": "Gas total",
@@ -634,7 +643,6 @@
             "approvalsReceived": "{received}/{required} aprobaciones recibidas",
             "expiresAt": "Caduca el",
             "expiredAt": "Caducó el",
-            "viewTransaction": "Ver transacción",
             "exchangingTokens": "Intercambiando tokens",
             "exchangingTokensBody": "Esta solicitud ha sido aprobada por el equipo. El intercambio de tokens está en progreso y puede tardar un tiempo.",
             "requestFailed": "Solicitud fallida",
@@ -642,7 +650,6 @@
             "votingPeriod24h": "Periodo de votación: 24 horas",
             "votingPeriod24hBody": "Esta solicitud de intercambio tiene una duración de votación de 24 horas. Aprueba esta solicitud en ese plazo o caducará.",
             "reject": "Rechazar",
-            "deposit": "Depositar",
             "approve": "Aprobar"
         },
         "insufficientBalance": {

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -1,0 +1,2101 @@
+{
+    "common": {
+        "loading": "Chargement...",
+        "notAvailable": "N/D",
+        "connecting": "Connexion...",
+        "save": "Enregistrer",
+        "cancel": "Annuler",
+        "submit": "Envoyer",
+        "close": "Fermer",
+        "back": "Retour",
+        "seeDemo": "Voir la démo Trezu",
+        "search": "Rechercher",
+        "filter": "Filtrer",
+        "filterActive": "Filtre (actif)",
+        "export": "Exporter",
+        "exporting": "Exportation",
+        "import": "Importer",
+        "remove": "Supprimer",
+        "removing": "Suppression...",
+        "edit": "Modifier",
+        "continue": "Continuer",
+        "select": "Sélectionner",
+        "all": "Tous",
+        "none": "Aucun",
+        "retry": "Réessayer",
+        "tryAgain": "Veuillez réessayer.",
+        "confirm": "Confirmer",
+        "next": "Suivant",
+        "previous": "Précédent",
+        "yes": "Oui",
+        "no": "Non",
+        "approve": "Approuver",
+        "reject": "Rejeter",
+        "copy": "Copier",
+        "copied": "Copié",
+        "viewAll": "Tout voir",
+        "viewDetails": "Voir les détails",
+        "noResults": "Aucun résultat trouvé",
+        "add": "Ajouter"
+    },
+    "languageSwitcher": {
+        "label": "Langue",
+        "select": "Sélectionner la langue",
+        "english": "English",
+        "spanish": "Español",
+        "ukrainian": "Українська",
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
+    },
+    "header": {
+        "toggleSidebar": "Basculer la barre latérale",
+        "toggleTheme": "Basculer le thème"
+    },
+    "nav": {
+        "dashboard": "Tableau de bord",
+        "requests": "Demandes",
+        "payments": "Paiements",
+        "exchange": "Échange",
+        "addressBook": "Carnet d'adresses",
+        "members": "Membres",
+        "settings": "Paramètres",
+        "helpSupport": "Aide et support",
+        "saveGuestTreasury": "Enregistrez cette trésorerie invitée dans votre liste de trésoreries."
+    },
+    "signIn": {
+        "connect": "Connecter",
+        "connectWallet": "Connecter le portefeuille",
+        "wallet": "Portefeuille",
+        "termsOfService": "Conditions d'utilisation",
+        "privacyPolicy": "Politique de confidentialité",
+        "disconnect": "Déconnecter"
+    },
+    "auth": {
+        "noWallet": "Connectez votre portefeuille",
+        "noPermission": "Vous n'avez pas l'autorisation d'effectuer cette action",
+        "noVote": "Vous avez déjà voté sur cette proposition",
+        "noSponsoredTransactions": "Aucune transaction sponsorisée restante"
+    },
+    "landing": {
+        "welcome": "Bienvenue sur Trezu",
+        "chooseOption": "Choisissez une option ci-dessous pour commencer.",
+        "newUserTitle": "Je suis nouveau sur Trezu",
+        "newUserDescription": "J'ai entendu parler de Trezu mais je n'ai pas encore de trésorerie.",
+        "existingUserTitle": "J'utilise déjà Trezu",
+        "existingUserDescription": "J'ai un compte et je gère une trésorerie.",
+        "gradientTagline": "Sécurité multisig multi-chaînes pour gérer les actifs numériques",
+        "waitlistTitle": "Rejoignez la liste d'attente Trezu",
+        "waitlistSubmittedTitle": "Vous êtes sur la liste 🎉",
+        "waitlistSubmittedDescription": "Merci ! Nous vous avertirons dès que la création de trésorerie sera disponible.",
+        "waitlistDescription": "Nous avons atteint la limite de trésoreries pour aujourd'hui. Pas d'inquiétude — réessayez plus tard ou laissez vos coordonnées pour rejoindre la liste d'attente. Nous vous préviendrons dès qu'une place se libère.",
+        "waitlistInputPlaceholder": "Adresse e-mail ou Telegram (par ex. @username)",
+        "waitlistPrivacyNote": "Nous l'utiliserons uniquement pour vous prévenir",
+        "waitlistSubmit": "Rejoindre la liste d'attente",
+        "waitlistSubmitFailed": "Échec de l'envoi. Veuillez réessayer.",
+        "welcomeAlt": "bienvenue"
+    },
+    "blocked": {
+        "title": "Service non disponible dans votre pays",
+        "description": "En raison de restrictions, ce service n'est actuellement pas disponible dans votre région."
+    },
+    "notFound": {
+        "title": "Oups, cette page a disparu...",
+        "description": "Il semble que vous ayez suivi un lien qui ne fonctionne plus. Essayez de revenir en arrière ou retournez au tableau de bord.",
+        "backToDashboard": "Retour au tableau de bord"
+    },
+    "treasuryInfo": {
+        "logoAlt": "Logo de la trésorerie"
+    },
+    "dateInput": {
+        "placeholder": "jj/mm/aaaa"
+    },
+    "thresholdSlider": {
+        "warningSingleMember": "Un seuil de 1 sur {memberCount} signifie qu'un seul membre peut exécuter des transactions. Cela réduit la sécurité.",
+        "infoBalanced": "Un seuil de {currentThreshold} sur {memberCount} offre un bon équilibre entre sécurité et flexibilité opérationnelle."
+    },
+    "intentsFee": {
+        "amountTooLowForFee": "{prefix}Montant trop faible pour les frais de réseau ({fee} {symbol}). Ajoutez au moins {addMore} {symbol}."
+    },
+    "metadata": {
+        "treasuryTitle": "Tableau de bord | Trezu",
+        "landingTitle": "Trezu | Gestion de trésorerie multi-chaînes",
+        "description": "Gérez le capital de votre équipe en quelques minutes depuis un tableau de bord unique sans jamais céder vos clés.",
+        "ogTitle": "Trezu | Un seul multisig. N'importe quelle crypto. Contrôle total."
+    },
+    "pages": {
+        "dashboard": {
+            "title": "Tableau de bord",
+            "description": "Aperçu des actifs et de l'activité de votre trésorerie",
+            "descriptionLong": "Gérez les actifs de votre trésorerie et suivez l'activité"
+        },
+        "activity": {
+            "title": "Transactions récentes",
+            "descriptionDetails": "Détails de la demande",
+            "descriptionList": "Transactions récentes sur tous les actifs"
+        },
+        "requests": {
+            "title": "Demandes",
+            "description": "Consultez et gérez toutes les demandes multisig en attente",
+            "detailDescription": "Détails de la demande",
+            "detailTitle": "Demande #{id}"
+        },
+        "members": {
+            "title": "Membres",
+            "description": "Gérez les membres de l'équipe et les autorisations"
+        },
+        "settings": {
+            "title": "Paramètres",
+            "description": "Ajustez les paramètres de votre application"
+        },
+        "addressBook": {
+            "title": "Carnet d'adresses",
+            "description": "Gérez vos destinataires enregistrés"
+        },
+        "payments": {
+            "title": "Paiements",
+            "description": "Envoyez et recevez des fonds en toute sécurité"
+        },
+        "exchange": {
+            "title": "Échange",
+            "description": "Échangez vos tokens en toute sécurité et efficacité"
+        },
+        "vesting": {
+            "title": "Vesting",
+            "description": "Créez des calendriers de vesting rapidement et sans effort"
+        },
+        "earn": {
+            "title": "Gains",
+            "description": "Gagnez des récompenses sur vos actifs",
+            "placeholder": "Explorez les opportunités de gains et les récompenses de staking."
+        },
+        "createTreasury": {
+            "title": "Créer une trésorerie",
+            "description": "Configurez une nouvelle trésorerie multisig pour votre équipe"
+        },
+        "manageTreasuries": {
+            "title": "Gérer les trésoreries",
+            "description": "Contrôlez quelles trésoreries apparaissent dans votre compte"
+        },
+        "stats": {
+            "title": "Statistiques",
+            "description": "Actifs sous gestion en temps réel sur l'ensemble des trésoreries des DAO sputnik."
+        },
+        "telegram": {
+            "title": "Connecter la trésorerie",
+            "description": "Liez vos trésoreries à un chat Telegram",
+            "metaTitle": "Trezu — Connecter Telegram",
+            "metaDescription": "Connectez votre trésorerie Trezu à un chat Telegram"
+        },
+        "wallet": {
+            "title": "Portefeuille Trezu",
+            "description": "Signez les propositions de trésorerie via Trezu"
+        }
+    },
+    "depositModal": {
+        "validation": {
+            "selectAsset": "Veuillez sélectionner un actif",
+            "selectNetwork": "Veuillez sélectionner un réseau"
+        },
+        "sections": {
+            "supportedNetworks": "Réseaux pris en charge",
+            "networksWithAssets": "Réseaux avec actifs",
+            "yourAssets": "Vos actifs",
+            "otherAssets": "Autres actifs"
+        },
+        "errors": {
+            "addressUnavailable": "Impossible de récupérer l'adresse de dépôt pour l'actif et le réseau sélectionnés.",
+            "fetchFailed": "Échec de la récupération de l'adresse de dépôt. Veuillez réessayer."
+        },
+        "title": "Dépôt",
+        "subtitle": "Sélectionnez un actif et un réseau pour voir l'adresse de dépôt",
+        "assetLabel": "Actif",
+        "networkLabel": "Réseau",
+        "selectAsset": "Sélectionner un actif",
+        "selectNetwork": "Sélectionner un réseau",
+        "otherAssetName": "Autre",
+        "otherNetworkInfo": "Vous pouvez déposer tout token non listé dans les actifs, mais uniquement via le réseau NEAR.",
+        "depositAddressHeading": "Adresse de dépôt",
+        "depositAddressSubtitle": "Vérifiez toujours votre adresse de dépôt.",
+        "addressLabel": "Adresse",
+        "addressCopied": "Adresse copiée dans le presse-papiers",
+        "memoLabel": "Mémo",
+        "memoCopied": "Mémo copié dans le presse-papiers",
+        "memoWarning": "Vous <bold>devez</bold> inclure le mémo lors de l'envoi de fonds à cette adresse. Envoyer sans le mémo peut entraîner une perte permanente des fonds.",
+        "onlyDeposit": "Déposez uniquement <symbolTag>{symbol}</symbolTag> depuis le réseau <networkTag>{network}</networkTag>. Nous recommandons de commencer par une petite transaction de test pour vous assurer que tout fonctionne correctement avant d'envoyer le montant complet.",
+        "minimumDeposit": "Le dépôt minimum est de <amountTag>{amount} {symbol}</amountTag>",
+        "searchByName": "Rechercher par nom"
+    },
+    "assetDetails": {
+        "coinPrice": "Prix de la pièce",
+        "weight": "Poids",
+        "source": "Source",
+        "send": "Envoyer",
+        "exchange": "Échanger",
+        "comingSoon": "Bientôt disponible",
+        "vesting": "Vesting",
+        "vestedPercent": "{percent}% acquis",
+        "frozen": "Gelé",
+        "frozenTooltip": "Les tokens gelés sont verrouillés et ne peuvent pas être utilisés. Ils peuvent être verrouillés parce qu'ils sont utilisés pour le stockage, mis en staking ou non encore acquis.",
+        "vested": "Acquis"
+    },
+    "dashboard": {
+        "overview": "Aperçu des actifs et de l'activité de votre trésorerie",
+        "assets": "Actifs",
+        "balance": "Solde",
+        "totalBalance": "Solde total",
+        "deposit": "Dépôt",
+        "addAssets": "Ajouter des actifs",
+        "hidden": "Masqué",
+        "confidentialHidden": "Soldes masqués pour les trésoreries confidentielles",
+        "recentActivity": "Activité récente",
+        "viewAllTransactions": "Voir toutes les transactions"
+    },
+    "activity": {
+        "filters": {
+            "createdDate": "Date de création",
+            "token": "Token",
+            "from": "De",
+            "to": "À"
+        },
+        "tabs": {
+            "all": "Toutes",
+            "sent": "Envoyées",
+            "received": "Reçues",
+            "stakingRewards": "Récompenses de staking",
+            "exchange": "Échange"
+        },
+        "searchPlaceholder": "Rechercher par hash de transaction",
+        "searchPlaceholderShort": "Hash de transaction",
+        "fromPool": "depuis {pool}",
+        "table": {
+            "type": "TYPE",
+            "transaction": "TRANSACTION",
+            "from": "DE",
+            "to": "À",
+            "transactionHash": "HASH DE TRANSACTION",
+            "hashTooltip": "Identifiant unique (hash) de cette transaction"
+        },
+        "empty": {
+            "title": "Aucune transaction trouvée",
+            "description": "Vos transactions apparaîtront ici dès qu'elles auront lieu"
+        },
+        "emptyDashboard": {
+            "title": "Rien à afficher pour l'instant",
+            "description": "Vos transactions et actions apparaîtront ici dès qu'elles auront lieu"
+        },
+        "recentTitle": "Transactions récentes",
+        "details": {
+            "title": "Détails de la transaction",
+            "copyAddress": "Copier l'adresse",
+            "addressCopied": "Adresse copiée dans le presse-papiers",
+            "sell": "Vendre",
+            "receive": "Recevoir",
+            "pending": "En attente",
+            "type": "Type",
+            "date": "Date",
+            "from": "De",
+            "to": "À",
+            "method": "Méthode",
+            "contract": "Contrat",
+            "transaction": "Transaction"
+        }
+    },
+    "export": {
+        "types": {
+            "csv": ".CSV",
+            "json": ".JSON",
+            "xlsx": ".XLSX"
+        },
+        "transactionTypes": {
+            "all": "Tous les types",
+            "sent": "Envoyées",
+            "received": "Reçues",
+            "stakingRewards": "Récompenses de staking"
+        },
+        "validation": {
+            "invalidEmail": "Veuillez saisir une adresse e-mail valide"
+        },
+        "columns": {
+            "submissionTime": "Heure de soumission",
+            "dateRange": "Plage de dates",
+            "generatedBy": "Généré par",
+            "status": "Statut"
+        },
+        "status": {
+            "generating": "Génération",
+            "expired": "Expiré",
+            "failed": "Échoué"
+        },
+        "noPermission": "Vous n'avez pas l'autorisation de télécharger le fichier.",
+        "download": "Télécharger",
+        "heading": "Exporter les transactions récentes",
+        "teamOnly": "La génération et le téléchargement d'exports sont réservés aux membres de l'équipe.",
+        "creditsUsed": "Vous avez utilisé tous vos crédits",
+        "exportsUsed": "Vous avez utilisé tous vos exports",
+        "upgradePrompt": "Améliorez votre plan pour en obtenir plus et continuer",
+        "resetPrompt": "Améliorez votre plan pour plus d'accès, ou attendez la réinitialisation de vos limites le mois prochain.",
+        "tabs": {
+            "generate": "Générer un export",
+            "history": "Historique"
+        },
+        "fields": {
+            "documentType": "Type de document",
+            "timeRange": "Plage horaire",
+            "selectDateRange": "Sélectionner une plage de dates",
+            "asset": "Actif",
+            "allAssets": "Tous les actifs",
+            "transactionType": "Type de transaction"
+        },
+        "buttons": {
+            "noPermissionExport": "Vous n'avez pas l'autorisation d'exporter",
+            "quotaExhausted": "Vous avez utilisé tout votre quota",
+            "exporting": "Exportation...",
+            "export": "Exporter"
+        },
+        "empty": {
+            "title": "Aucun export pour l'instant",
+            "description": "Vos fichiers exportés du mois dernier apparaîtront ici une fois générés."
+        },
+        "requirements": {
+            "heading": "Exigences d'exportation",
+            "canExportFrom": "Vous pouvez exporter les données du",
+            "availability": "Les fichiers exportés sont disponibles au téléchargement pendant 48 heures."
+        },
+        "quota": {
+            "heading": "Quota d'exportation",
+            "unlimited": "Illimité",
+            "perMonth": "{count} / mois",
+            "flexibilityPrompt": "Vous cherchez plus de flexibilité ?",
+            "contactUs": "Contactez-nous"
+        }
+    },
+    "requests": {
+        "filters": {
+            "proposalTypes": {
+                "Payments": "Paiements",
+                "Exchange": "Échange",
+                "Earn": "Gains",
+                "Vesting": "Vesting",
+                "Function Call": "Appel de fonction",
+                "Change Policy": "Modification de politique",
+                "Settings": "Paramètres",
+                "Confidential": "Confidentiel"
+            },
+            "voteStatus": {
+                "Approved": "Approuvée",
+                "Rejected": "Rejetée",
+                "No Voted": "Non votée"
+            },
+            "requestsType": "Type de demandes",
+            "createdDate": "Date de création",
+            "recipient": "Destinataire",
+            "token": "Token",
+            "requester": "Demandeur",
+            "approver": "Approbateur",
+            "myVoteStatus": "Mon statut de vote",
+            "all": "TOUTES",
+            "amount": "Montant",
+            "from": "De",
+            "to": "À",
+            "min": "Min",
+            "max": "Max",
+            "invalidDate": "Date invalide",
+            "operationIsNot": " n'est pas",
+            "operationBefore": " avant",
+            "operationAfter": " après",
+            "operationContains": " contient",
+            "searchByAddress": "Rechercher par adresse",
+            "loadingMembers": "Chargement des membres...",
+            "noMembersFound": "Aucun membre trouvé. Appuyez sur Entrée pour ajouter « {query} »",
+            "noMembersAvailable": "Aucun membre disponible",
+            "reset": "Réinitialiser",
+            "clear": "Effacer",
+            "addFilter": "Ajouter un filtre"
+        },
+        "tabs": {
+            "all": "Toutes",
+            "pending": "En attente",
+            "executed": "Exécutées",
+            "rejected": "Rejetées",
+            "expired": "Expirées",
+            "failed": "Échouées"
+        },
+        "searchPlaceholder": "Rechercher une demande par nom ou ID",
+        "searchPlaceholderShort": "Rechercher par nom ou ID",
+        "errorLoading": "Erreur lors du chargement des propositions. Veuillez réessayer.",
+        "empty": {
+            "title": "Créez votre première demande",
+            "description": "Les demandes de paiements, d'échanges et autres actions apparaîtront ici une fois créées.",
+            "send": "Envoyer",
+            "exchange": "Échanger"
+        },
+        "actions": {
+            "approve": "Approuver",
+            "reject": "Rejeter",
+            "deposit": "Déposer",
+            "viewRequest": "Voir la demande"
+        },
+        "table": {
+            "selectAll": "Tout sélectionner",
+            "selectRow": "Sélectionner la ligne",
+            "request": "Demande",
+            "transaction": "Transaction",
+            "requester": "Demandeur",
+            "voting": "Vote",
+            "votingTooltip": "Le premier nombre indique les approbations reçues. Le second indique les approbations requises pour exécuter.",
+            "status": "Statut",
+            "notPending": "La proposition n'est pas en attente.",
+            "noPermissionVote": "Vous n'avez pas l'autorisation de voter sur cette demande.",
+            "alreadyVoted": "Vous avez déjà voté sur cette demande.",
+            "noResults": "Aucune demande ne correspond à vos filtres.",
+            "allCaughtUp": "Tout est à jour !",
+            "noPending": "Il n'y a aucune demande en attente.",
+            "send": "Envoyer",
+            "exchange": "Échanger",
+            "requestsSelected": "{count, plural, one {# demande sélectionnée} other {# demandes sélectionnées}}",
+            "bulkApproveDisabled": "Cette demande ne peut pas être approuvée car la trésorerie a un solde insuffisant."
+        },
+        "pending": {
+            "title": "Demandes en attente",
+            "viewAll": "Tout voir",
+            "emptyTitle": "Tout est à jour !",
+            "emptyDescription": "Il n'y a aucune demande en attente."
+        }
+    },
+    "proposals": {
+        "status": {
+            "pending": "En attente",
+            "approved": "Approuvée",
+            "rejected": "Rejetée",
+            "executed": "Exécutée",
+            "expired": "Expirée",
+            "failed": "Échouée",
+            "removed": "Supprimée",
+            "inProgress": "En cours"
+        },
+        "statusTooltip": {
+            "pending": "Cette demande est encore en attente et n'a pas encore atteint le nombre de votes requis pour être exécutée.",
+            "executed": "Exécutée après que {approved} sur {required} membres ont approuvé la demande.",
+            "rejected": "Rejetée après que {rejected} sur {required} membres ont voté pour rejeter la demande.",
+            "expired": "Expirée car elle n'a pas reçu suffisamment de votes pour être exécutée.",
+            "failed": "La demande n'a pas pu aboutir. Consultez les détails de la transaction <link>ici</link>.",
+            "failedPlain": "La demande n'a pas pu aboutir. Consultez les détails de la transaction ici."
+        },
+        "votes": {
+            "approved": "Approuvée",
+            "rejected": "Rejetée",
+            "pending": "En attente"
+        },
+        "voteModal": {
+            "confirmTitle": "Confirmer votre vote",
+            "removeTitle": "Supprimer la demande",
+            "bulkBody": "Vous êtes sur le point de {action} plusieurs demandes. Une fois soumise, cette décision ne pourra pas être modifiée.",
+            "singleBody": "Vous êtes sur le point de {action} cette demande. Une fois confirmée, cette action ne peut pas être annulée.",
+            "actionApprove": "approuver",
+            "actionReject": "rejeter",
+            "actionRemove": "supprimer",
+            "insufficientBalance": "Les demandes <highlight>{ids}</highlight> ne peuvent pas être approuvées en raison d'un solde insuffisant. Votre approbation s'appliquera uniquement aux demandes restantes.",
+            "remove": "Supprimer",
+            "confirm": "Confirmer"
+        },
+        "expanded": {
+            "recipient": "Destinataire",
+            "amount": "Montant",
+            "networkFee": "Frais de réseau",
+            "notes": "Notes",
+            "sent": "Envoyé",
+            "received": "Reçu",
+            "priceDifference": "Différence de prix",
+            "priceDifferenceTooltip": "Différence entre le taux du devis et le taux actuel du marché. Les valeurs positives indiquent un meilleur taux que le marché.",
+            "slippageTolerance": "Tolérance au glissement",
+            "estimatedTime": "Temps estimé",
+            "seconds": "{count} secondes",
+            "description": "Description",
+            "methodName": "Nom de la méthode",
+            "args": "Args",
+            "deposit": "Déposer",
+            "gas": "Gas",
+            "totalDeposit": "Dépôt total",
+            "totalGas": "Gas total",
+            "receiverId": "ID du destinataire",
+            "contractId": "ID du contrat",
+            "actionsCount": "{count, plural, one {# action} other {# actions}}",
+            "functionCallsCount": "{count, plural, one {# appel de fonction} other {# appels de fonction}}",
+            "showLess": "Afficher moins",
+            "showMore": "Afficher plus",
+            "stakingPool": "Pool de staking",
+            "validator": "Validateur",
+            "action": "Action",
+            "stake": "Staker",
+            "unstake": "Déstaker",
+            "withdraw": "Retirer",
+            "lockupOwner": "Propriétaire du lockup",
+            "lockupDuration": "Durée du lockup",
+            "cliff": "Cliff",
+            "releaseDuration": "Durée de libération",
+            "vestingSchedule": "Calendrier de vesting",
+            "cancellable": "Annulable",
+            "allowEarn": "Autoriser le staking",
+            "yes": "Oui",
+            "no": "Non",
+            "notSet": "Non défini",
+            "from": "De",
+            "to": "À",
+            "paymentsCount": "{count, plural, one {# paiement} other {# paiements}}",
+            "sourceWallet": "Portefeuille source",
+            "allNear": "Tous les NEAR",
+            "startDate": "Date de début",
+            "endDate": "Date de fin",
+            "cliffDate": "Date du cliff",
+            "allowCancellation": "Autoriser l'annulation",
+            "allowStaking": "Autoriser le staking",
+            "loadingHistorical": "Chargement de la configuration historique...",
+            "name": "Nom",
+            "purpose": "Objet",
+            "logo": "Logo",
+            "logoAlt": "Logo",
+            "primaryColor": "Couleur principale",
+            "noChangesCurrent": "Aucun changement détecté dans la configuration par rapport à l'état actuel.",
+            "noChangesHistorical": "Aucun changement détecté dans la configuration par rapport à l'état historique.",
+            "method": "Méthode",
+            "arguments": "Arguments",
+            "contract": "Contrat",
+            "actionNumber": "Action {number}",
+            "actions": "Actions",
+            "collapseAll": "Tout réduire",
+            "expandAll": "Tout développer",
+            "send": "Envoyer",
+            "receive": "Recevoir",
+            "rate": "Taux",
+            "priceSlippageLimit": "Limite de glissement de prix",
+            "slippageTooltip": "Il s'agit de la limite de glissement définie pour cette demande. Si le taux du marché change au-delà de ce seuil pendant l'exécution, la demande échouera automatiquement.",
+            "estimatedTimeTooltip": "Temps estimé pour que l'échange soit exécuté après confirmation de la transaction de dépôt.",
+            "minReceive": "Min. reçu",
+            "minimumReceived": "Minimum reçu",
+            "minReceiveTooltip": "Il s'agit du montant minimum que vous recevrez de cet échange, basé sur la limite de glissement définie pour la demande.",
+            "depositAddress": "Adresse de dépôt",
+            "depositAddressTooltip": "L'adresse de dépôt 1Click vers laquelle les tokens seront envoyés pour l'exécution du swap multi-chaînes.",
+            "quoteSignature": "Signature du devis",
+            "quoteSignatureTooltip": "La signature cryptographique de l'API 1Click qui valide ce devis.",
+            "quoteDeadline": "Date limite du devis 1-Click",
+            "quoteDeadlineTooltip": "Heure à laquelle l'adresse de dépôt devient inactive et les fonds peuvent être perdus.",
+            "status": "Statut",
+            "transactionLink": "Lien de transaction",
+            "viewTransaction": "Voir la transaction",
+            "recipientNumber": "Destinataire {number}",
+            "oopsTitle": "Oups ! Une erreur s'est produite",
+            "oopsDescription": "Nous n'avons pas pu trouver de données à afficher ici.",
+            "totalAmount": "Montant total",
+            "recipients": "Destinataires",
+            "recipientsCount": "{count, plural, one {# destinataire} other {# destinataires}}",
+            "unsupportedProposal": "Type de proposition non pris en charge",
+            "requestDetails": "Détails de la demande",
+            "linkCopied": "Lien copié dans le presse-papiers",
+            "copyLink": "Copier le lien",
+            "openRequestPage": "Ouvrir la page de la demande",
+            "deleteRequest": "Supprimer la demande",
+            "unknownRecipients": "Destinataires inconnus",
+            "loadingConfig": "Chargement de la configuration...",
+            "historicalData": "Données historiques...",
+            "generalUpdate": "Mise à jour générale",
+            "detailsUnavailable": "Détails indisponibles",
+            "changesCount": "{count, plural, one {# changement} other {# changements}}",
+            "policyUpdate": "Mise à jour de la politique",
+            "noChangesDetected": "Aucun changement détecté",
+            "loadingPolicy": "Chargement de la politique...",
+            "roleChanges": "Changements de rôle",
+            "policyParameters": "Paramètres de politique",
+            "defaultVotePolicy": "Politique de vote par défaut",
+            "policyRoleChanges": "Changements de politique et de rôle",
+            "membersAdded": "{count, plural, one {# membre ajouté} other {# membres ajoutés}}",
+            "membersRemoved": "{count, plural, one {# membre supprimé} other {# membres supprimés}}",
+            "membersUpdated": "{count, plural, one {# membre mis à jour} other {# membres mis à jour}}",
+            "rolesModified": "{count, plural, one {# rôle modifié} other {# rôles modifiés}}",
+            "parametersChanged": "{count, plural, one {# paramètre modifié} other {# paramètres modifiés}}",
+            "defaultVotePolicyPart": "politique de vote par défaut",
+            "onReceiver": "sur {receiver}",
+            "toPrefix": "À :",
+            "validatorPrefix": "Validateur :",
+            "validatorSubtitle": "Validateur : {address}",
+            "impactTitle": "Impact du changement de durée de vote",
+            "impactBody": "Vous êtes sur le point de mettre à jour la durée de vote. Cela affectera les demandes existantes suivantes.",
+            "activeRequestsBullet": "{count, plural, one {# demande sera active pour le vote après ce changement, avec des dates d'expiration mises à jour.} other {# demandes seront actives pour le vote après ce changement, avec des dates d'expiration mises à jour.}}",
+            "expiringRequestsBullet": "{count, plural, one {# demande sera marquée comme « Expirée » sous la nouvelle durée de vote.} other {# demandes seront marquées comme « Expirées » sous la nouvelle durée de vote.}}",
+            "remainActiveHeading": "Demandes qui restent actives pour le vote avec une nouvelle date d'expiration",
+            "willExpireHeading": "Demandes qui seront marquées comme « Expirées »",
+            "tableRequest": "Demande",
+            "tableTransaction": "Transaction",
+            "tableNewExpiry": "Nouvelle expiration",
+            "expireInDays": "{count, plural, one {Expire dans # jour} other {Expire dans # jours}}",
+            "today": "Aujourd'hui",
+            "uponApproval": "Lors de l'approbation",
+            "yesContinue": "Oui, continuer",
+            "transactionCreated": "Transaction créée",
+            "voting": "Vote",
+            "approvalsReceived": "{received}/{required} approbations reçues",
+            "expiresAt": "Expire le",
+            "expiredAt": "Expirée le",
+            "exchangingTokens": "Échange de tokens",
+            "exchangingTokensBody": "Cette demande a été approuvée par l'équipe. L'échange de tokens est en cours et peut prendre un certain temps.",
+            "requestFailed": "Demande échouée",
+            "requestFailedBody": "L'équipe a approuvé cette demande, mais elle a échoué en raison de fluctuations de taux. Veuillez créer une nouvelle demande et réessayer.",
+            "votingPeriod24h": "Période de vote : 24 heures",
+            "votingPeriod24hBody": "Cette demande d'échange a une durée de vote de 24 heures. Approuvez cette demande dans ce délai, sinon la demande expirera.",
+            "reject": "Rejeter",
+            "approve": "Approuver"
+        },
+        "insufficientBalance": {
+            "noAsset": "Cette demande ne peut pas être approuvée car le token requis n'est pas disponible dans la trésorerie.",
+            "bond": "Cette demande ne peut pas être approuvée car la trésorerie a un solde <token>{symbol}</token> insuffisant. Ajoutez <token>{amount} {symbol}</token> pour couvrir les frais de caution de la proposition.",
+            "continue": "Cette demande ne peut pas être approuvée car la trésorerie a un solde <token>{symbol}</token> insuffisant. Ajoutez <token>{amount} {symbol}</token> pour continuer.",
+            "modalTitle": "Solde NEAR insuffisant",
+            "modalBodyVote": "Vous n'avez pas assez de tokens NEAR dans votre portefeuille pour soumettre ce vote. Le vote nécessite un solde minimum de <amount>{required} NEAR</amount>. Veuillez ajouter du NEAR à votre portefeuille et réessayer.",
+            "modalBodyProposal": "Vous n'avez pas assez de tokens NEAR dans votre portefeuille pour créer cette demande. Créer une demande nécessite un solde minimum de <amount>{required} NEAR</amount>. Veuillez ajouter du NEAR à votre portefeuille et réessayer.",
+            "gotIt": "Compris"
+        }
+    },
+    "members": {
+        "title": "Membres",
+        "description": "Gérez les membres de l'équipe et les autorisations",
+        "permissions": "Autorisations",
+        "member": "Membre",
+        "activeMembers": "Membres actifs",
+        "noActiveMembers": "Aucun membre actif trouvé.",
+        "addNewMember": "Ajouter un nouveau membre",
+        "membersSelected": "{count, plural, =0 {aucun membre} one {# membre} other {# membres}} sélectionné{count, plural, =0 {} one {} other {s}}",
+        "remove": "Supprimer",
+        "edit": "Modifier",
+        "requestorOnlyTooltip": "Vous ne pouvez ajouter que le rôle de Demandeur pour ce membre, car il est responsable de la création des demandes de paiement depuis NEARN.",
+        "memberModal": {
+            "editRoles": "Modifier les rôles",
+            "addNewMember": "Ajouter un nouveau membre",
+            "validatingAddresses": "Validation des adresses...",
+            "creatingProposal": "Création de la proposition...",
+            "reviewRequest": "Vérifier la demande",
+            "noChanges": "Aucun changement n'a été apporté aux rôles des membres"
+        },
+        "previewModal": {
+            "title": "Vérifiez votre demande",
+            "youAreEditing": "Vous modifiez",
+            "youAreAdding": "Vous ajoutez",
+            "membersCount": "{count, plural, one {# membre} other {# membres}}",
+            "newMembersCount": "{count, plural, one {# nouveau membre} other {# nouveaux membres}}",
+            "updatedMembers": "Membres mis à jour",
+            "newMembers": "Nouveaux membres",
+            "creatingProposal": "Création de la proposition...",
+            "confirmSubmit": "Confirmer et soumettre la demande"
+        },
+        "removeDialog": {
+            "title": "Supprimer la demande",
+            "nearnBody": "Une fois approuvé, {account} sera définitivement supprimé de la trésorerie et toutes les autorisations associées seront révoquées. Après la suppression, ce compte ne pourra plus créer de demandes depuis NEARN.",
+            "genericBody": "Une fois approuvée, cette action supprimera définitivement <bold>{accounts}</bold> de la trésorerie et révoquera toutes les autorisations attribuées.",
+            "creatingProposal": "Création de la proposition..."
+        },
+        "validation": {
+            "accountIdRequired": "L'ID du compte est requis",
+            "invalidNearAddress": "Adresse NEAR invalide.",
+            "atLeastOneRole": "Au moins un rôle doit être sélectionné",
+            "atLeastOneMember": "Au moins un membre est requis",
+            "alreadyAdded": "Ce membre a déjà été ajouté ci-dessus",
+            "alreadyInTreasury": "Ce membre existe déjà dans la trésorerie",
+            "cannotRemoveRoleAfter": "Vous ne pouvez pas supprimer le rôle {role} de ce membre. Après tous vos changements, il serait la seule personne attribuée à ce rôle.",
+            "cannotRemoveRoleAfterGov": "Vous ne pouvez pas supprimer le rôle {role} de ce membre. Après tous vos changements, il serait le seul membre {role}, et sans ce rôle, vous ne pourrez plus gérer les membres de l'équipe ni configurer le vote."
+        },
+        "policy": {
+            "addMembers": "Mettre à jour la politique - Ajouter de nouveaux membres",
+            "addMembersSuccess": "Demande de nouveau membre créée avec succès",
+            "editMember": "Mettre à jour la politique - Modifier les autorisations d'un membre",
+            "editMembers": "Mettre à jour la politique - Modifier plusieurs membres",
+            "editMemberSuccess": "Demande de mise à jour des rôles du membre créée avec succès",
+            "editMembersSuccess": "Demande de mise à jour groupée des rôles des membres créée avec succès",
+            "removeMember": "Mettre à jour la politique - Supprimer un membre",
+            "removeMembers": "Mettre à jour la politique - Supprimer des membres",
+            "removeMemberSuccess": "Demande de suppression de membre créée avec succès"
+        }
+    },
+    "settings": {
+        "tabs": {
+            "general": "Général",
+            "voting": "Vote",
+            "preferences": "Préférences",
+            "integrations": "Intégrations"
+        },
+        "general": {
+            "validation": {
+                "displayNameRequired": "Le nom d'affichage est requis",
+                "displayNameMax": "Le nom d'affichage doit comporter moins de 100 caractères"
+            },
+            "proposalDescriptionTitle": "Mettre à jour la configuration - Thème et logo",
+            "proposalSubmitted": "Demande de mise à jour de la configuration soumise",
+            "treasuryNotFound": "Trésorerie introuvable",
+            "treasuryName": "Nom de la trésorerie",
+            "treasuryNameDescription": "Le nom de votre trésorerie. Il sera affiché dans toute l'application.",
+            "displayName": "Nom d'affichage",
+            "displayNamePlaceholder": "Saisir le nom d'affichage",
+            "accountName": "Nom du compte",
+            "logo": "Logo",
+            "logoDescription": "Téléchargez un logo pour votre trésorerie. SVG, PNG ou JPG recommandés (256x256 px).",
+            "treasuryLogoAlt": "Logo de la trésorerie",
+            "uploading": "Téléchargement...",
+            "uploadLogo": "Télécharger le logo",
+            "removeLogo": "Supprimer le logo",
+            "logoUploaded": "Logo téléchargé avec succès",
+            "uploadError": "Une erreur s'est produite lors du téléchargement de l'image, veuillez réessayer.",
+            "invalidLogo": "Logo invalide. Veuillez télécharger un fichier PNG, JPG ou SVG d'exactement 256x256 px",
+            "invalidImage": "Fichier image invalide. Veuillez télécharger une image valide.",
+            "fileReadError": "Erreur de lecture du fichier. Veuillez réessayer.",
+            "primaryColor": "Couleur principale",
+            "primaryColorDescription": "Définissez la couleur principale des éléments d'interface de votre trésorerie. Cette couleur sera utilisée en mode clair et sombre, gardez donc le contraste à l'esprit lors du choix de teintes neutres.",
+            "selectColorLabel": "Sélectionner la couleur {color}"
+        },
+        "voting": {
+            "validation": {
+                "required": "La durée de vote est requise",
+                "validNumber": "La durée de vote doit être un nombre valide",
+                "min": "La durée de vote doit être d'au moins 1 jour",
+                "max": "La durée de vote doit être inférieure à 1000 jours",
+                "whole": "La durée de vote doit être un jour entier"
+            },
+            "missingData": "Données requises manquantes",
+            "thresholdProposalTitle": "Mettre à jour la politique - Seuils de vote",
+            "thresholdProposalSummary": "{account} a demandé de modifier le seuil de vote de {oldValue} à {newValue}.",
+            "thresholdSubmitted": "Demande de mise à jour du seuil de vote soumise",
+            "createProposalFailed": "Échec de la création de la proposition",
+            "durationProposalTitle": "Mettre à jour la politique - Durée de vote",
+            "durationProposalSummary": "{account} a demandé de modifier la durée de vote de {oldValue} à {newValue}.",
+            "durationSubmitted": "Demande créée avec succès",
+            "pendingTitle": "Demande active de seuil de vote",
+            "pendingBody": "Pour éviter les conflits, vous devez terminer ou résoudre les demandes en attente existantes avant de continuer. Ces demandes sont actuellement actives et doivent d'abord être approuvées ou rejetées.",
+            "viewRequest": "Voir la demande",
+            "thresholdHeading": "Seuil de vote",
+            "thresholdDescriptionApprovers": "Définissez combien de votes sont requis pour approuver les demandes liées aux paiements et à l'équipe. Configurez les seuils séparément pour les Approbateurs et la Gouvernance.",
+            "thresholdDescriptionGeneric": "Définissez combien de votes sont requis pour approuver les demandes. Configurez les seuils pour chaque rôle en fonction de leurs responsabilités.",
+            "membersWhoCanVote": "Membres qui peuvent voter",
+            "votesRequired": "Votes requis pour approuver les demandes",
+            "durationHeading": "Durée de vote",
+            "durationDescription": "La durée (en jours) pendant laquelle une proposition restera ouverte au vote. Si le vote n'est pas terminé dans ce délai, la décision expire.",
+            "durationApprovers": " Cette durée s'applique également aux rôles Gouvernance et Approbateur.",
+            "durationGeneric": " Cette durée est cohérente pour tous les rôles de la trésorerie.",
+            "days": "Jours"
+        },
+        "preferences": {
+            "timeZone": "Fuseau horaire",
+            "timeZoneDescription": "Définissez votre fuseau horaire local pour un affichage précis de la date et de l'heure.",
+            "timeFormat": "Format horaire",
+            "hour12": "12 heures (1:00 PM)",
+            "hour24": "24 heures (13:00)",
+            "autoTimezone": "Définir le fuseau horaire automatiquement à partir de votre position",
+            "timezone": "Fuseau horaire",
+            "loadingTimezones": "Chargement des fuseaux horaires...",
+            "selectTimezone": "Sélectionner le fuseau horaire",
+            "searchTimezones": "Rechercher des fuseaux horaires...",
+            "noTimezones": "Aucun fuseau horaire trouvé",
+            "save": "Enregistrer",
+            "savedToast": "Préférences enregistrées avec succès",
+            "saveFailed": "Échec de l'enregistrement des préférences",
+            "loadFailed": "Échec du chargement des fuseaux horaires"
+        }
+    },
+    "addressBook": {
+        "emptyTitle": "Ajoutez votre premier destinataire",
+        "emptyDescription": "Enregistrez les adresses fréquemment utilisées pour des paiements plus rapides et sans erreur. Vos contacts restent privés et visibles uniquement par votre équipe.",
+        "import": "Importer",
+        "addRecipient": "Ajouter un destinataire",
+        "recipientsHeading": "Destinataires",
+        "recipientsSelected": "{count, plural, =0 {aucun destinataire} one {# destinataire} other {# destinataires}} sélectionné{count, plural, =0 {} one {} other {s}}",
+        "sectionHeading": "Destinataires",
+        "privacyNote": "Les adresses enregistrées sont privées et visibles uniquement par votre équipe.",
+        "searchPlaceholder": "Rechercher un destinataire par nom",
+        "searchPlaceholderShort": "Rechercher",
+        "review": {
+            "header": "Vérifier les détails",
+            "youAreAdding": "Vous ajoutez",
+            "newRecipients": "{count, plural, one {# nouveau destinataire} other {# nouveaux destinataires}}",
+            "onNetworks": "sur {count, plural, one {# réseau} other {# réseaux}}",
+            "recipients": "Destinataires",
+            "allDuplicates": "Tous les destinataires importés existent déjà dans votre carnet d'adresses. Revenez en arrière pour télécharger une autre liste ou supprimez les doublons de cette vérification.",
+            "someDuplicates": "{duplicates} destinataires en double sur {total} destinataires au total. Continuez pour importer uniquement les nouveaux destinataires.",
+            "duplicated": "Dupliqué",
+            "notePlaceholder": "Ajoutez une note pour aider à identifier ce destinataire (par ex. paiement de prestataire, distribution de vesting).",
+            "skipDuplicates": "Ignorer les doublons et n'importer que les nouveaux.",
+            "allDuplicatesTooltip": "Tous les destinataires importés sont déjà dans votre carnet d'adresses, il n'y a donc rien de nouveau à importer.",
+            "duplicateActionTooltip": "Activez le saut des doublons ou supprimez les destinataires en double pour continuer.",
+            "adding": "Ajout…",
+            "nothingNew": "Rien de nouveau à importer",
+            "addRecipientsButton": "{count, plural, one {Ajouter le destinataire} other {Ajouter les destinataires}}"
+        },
+        "removeDialog": {
+            "title": "Supprimer le destinataire",
+            "bulk": "Cela supprimera <bold>{count, plural, one {# destinataire} other {# destinataires}}</bold> de votre carnet d'adresses. Vous pourrez les ajouter à nouveau à tout moment.",
+            "single": "Cela supprimera <bold>{name}</bold> de votre carnet d'adresses. Vous pourrez ajouter ce destinataire à nouveau à tout moment."
+        },
+        "importFlow": {
+            "title": "Importer des destinataires",
+            "description": "Téléchargez une liste d'adresses de destinataires dans votre carnet d'adresses.",
+            "foundSummary": "{count, plural, one {# destinataire trouvé} other {# destinataires trouvés}} sur {networkCount, plural, one {# réseau} other {# réseaux}}",
+            "uploadPrompt": "Téléchargez ou collez les données du destinataire",
+            "fixErrors": "Corrigez les erreurs pour continuer",
+            "continueReview": "Continuer vers la vérification"
+        },
+        "form": {
+            "editRecipient": "Modifier le destinataire",
+            "addRecipient": "Ajouter un destinataire",
+            "import": "Importer",
+            "recipientName": "Nom du destinataire",
+            "namePlaceholder": "Alice",
+            "recipientAddress": "Adresse du destinataire",
+            "network": "Réseau",
+            "networkInfo": "Réseaux compatibles avec cette adresse",
+            "enterAddressFirst": "Saisissez d'abord l'adresse du destinataire",
+            "selectNetwork": "Sélectionner un réseau",
+            "selectNetworksTitle": "Sélectionner les réseaux",
+            "searchNetworksPlaceholder": "Rechercher des réseaux…",
+            "done": "Terminé",
+            "edit": "Modifier",
+            "remove": "Supprimer",
+            "incomplete": "Incomplet",
+            "addAnother": "Ajouter un autre destinataire",
+            "fillAllTooltip": "Vous devez remplir tous les champs pour ajouter un destinataire.",
+            "reviewDetails": "Vérifier les détails",
+            "reviewTooltip": "Tous les destinataires doivent être complets avant la vérification.",
+            "invalidAddress": "Adresse invalide",
+            "noCompatibleNetworks": "Aucun réseau compatible pour cette adresse"
+        },
+        "parsing": {
+            "rowPrefix": "Ligne {row} : {message}",
+            "missingName": "Nom du destinataire manquant. Veuillez ajouter un nom.",
+            "missingAddress": "Adresse du destinataire manquante. Veuillez ajouter une adresse de portefeuille.",
+            "invalidAddressFormat": "L'adresse « {address} » n'est pas un format valide pour aucun réseau pris en charge.",
+            "unknownNetwork": "Réseau inconnu « {network} ». Les réseaux pris en charge incluent : {available}.",
+            "incompatibleNetwork": "L'adresse « {address} » n'est pas compatible avec {network}. Réseaux compatibles : {compatible}.",
+            "noDataFound": "Aucune donnée trouvée. Veuillez ajouter les destinataires dans ce format : Name, Address, Network, Note",
+            "headerColumnsNotFound": "Nous avons détecté une ligne d'en-tête, mais nous n'avons pas trouvé les colonnes « Name » et « Address ». Veuillez utiliser ces noms de colonnes ou supprimer la ligne d'en-tête.",
+            "failedToParseCsv": "Échec de l'analyse des données CSV"
+        }
+    },
+    "payments": {
+        "validation": {
+            "recipientMin": "Le destinataire doit comporter au moins 2 caractères",
+            "recipientMax": "Le destinataire doit comporter moins de 128 caractères",
+            "amountPositive": "Le montant doit être supérieur à 0",
+            "recipientTokenSame": "Le destinataire et l'adresse du token ne peuvent pas être identiques"
+        },
+        "newPayment": "Nouveau paiement",
+        "reviewYourPayment": "Vérifiez votre paiement",
+        "reviewButton": "Vérifier le paiement",
+        "reviewButtonDisabled": "Saisissez le montant et l'adresse",
+        "comingSoon": "Bientôt disponible",
+        "bulkPayments": "Paiements groupés",
+        "summaryRecipients": "à {count, plural, one {# destinataire} other {# destinataires}}",
+        "networkFee": "Frais de réseau",
+        "networkFeeInfo": "Infos sur les frais de réseau",
+        "commentPlaceholder": "Ajoutez un commentaire (facultatif)...",
+        "preparingRoute": "Préparation de l'itinéraire de transfert 1Click...",
+        "confirmSubmit": "Confirmer et soumettre la demande",
+        "useDifferentAddress": "Utiliser une adresse différente",
+        "failed1ClickQuote": "Échec de la création du devis de transfert 1Click",
+        "paymentSubmitted": "Demande d'envoi de paiement soumise"
+    },
+    "bulkPayment": {
+        "comingSoonToast": "Les paiements groupés arrivent bientôt !",
+        "submittingList": "Soumission de la liste de paiements groupés",
+        "submittingProposal": "Soumission de la proposition",
+        "proposalSubmitted": "Proposition de paiement groupé soumise",
+        "submitListFailed": "Échec de la soumission de la liste de paiements",
+        "submitFailed": "Échec de la soumission du paiement groupé",
+        "upload": {
+            "pleaseUploadCsv": "Veuillez télécharger un fichier CSV",
+            "fileSizeLimit": "La taille du fichier doit être inférieure à 1,5 Mo",
+            "headerTitle": "Demandes de paiement groupé",
+            "headerSubtitle": "Payez plusieurs destinataires avec une seule proposition.",
+            "creditsUsed": "Vous avez utilisé tous vos crédits",
+            "bulkPaymentsUsed": "Vous avez utilisé tous vos paiements groupés",
+            "upgradeTrial": "Améliorez votre plan pour en obtenir plus et continuer",
+            "upgradePaid": "Améliorez votre plan pour plus d'accès, ou attendez la réinitialisation de vos limites le mois prochain.",
+            "selectAsset": "Sélectionner un actif",
+            "disableTokenMessage": "Les paiements groupés pour ces tokens arrivent bientôt.",
+            "providePaymentData": "Fournir les données de paiement",
+            "uploadFile": "Télécharger un fichier",
+            "provideData": "Fournir les données",
+            "chooseFile": "Choisir un fichier",
+            "orDragDrop": "ou glissez-déposez",
+            "maxFileSize": "max 1 fichier jusqu'à 1,5 Mo, fichier CSV uniquement",
+            "noFilePrompt": "Vous n'avez pas de fichier à télécharger ?",
+            "downloadTemplate": "Télécharger un modèle",
+            "requirements": "Exigences pour le paiement groupé",
+            "maxTransactions": "Max {max} transactions par import",
+            "singleTokenNetwork": "Token et réseau uniques",
+            "limitsUsed": "Vous avez utilisé toutes vos limites",
+            "selectAndProvide": "Sélectionnez un actif et fournissez les données de paiement",
+            "continueToReview": "Continuer vers la vérification",
+            "selectTokenError": "Veuillez sélectionner un token",
+            "providePaymentDataError": "Veuillez fournir les données de paiement"
+        },
+        "editStep": {
+            "title": "Modifier le paiement",
+            "saveChanges": "Enregistrer les modifications"
+        },
+        "parsing": {
+            "rowPrefix": "Ligne {row} : {message}",
+            "missingRecipientFirstColumn": "Adresse du destinataire manquante. Veuillez ajouter une adresse dans la première colonne.",
+            "invalidNearAddress": "L'adresse « {address} » n'est pas un compte NEAR valide.",
+            "invalidChainAddress": "L'adresse « {address} » n'est pas un compte {chain} valide.",
+            "rowNeedsAmountRecipient": "Chaque ligne nécessite un montant et un destinataire séparés par une virgule. Exemple : 100, alice.near",
+            "missingRecipientBeforeComma": "Adresse du destinataire manquante. Veuillez ajouter une adresse avant la virgule.",
+            "missingAmountAfterComma": "Montant manquant. Veuillez ajouter un nombre après la virgule. Exemple : {recipient}, 100",
+            "invalidAmountNumber": "Le montant « {amountStr} » n'est pas un nombre valide. Veuillez utiliser uniquement des chiffres et des décimales (par ex. 100 ou 100.50).",
+            "amountGreaterThanZero": "Le montant doit être supérieur à 0. Vous avez saisi « {amountStr} ».",
+            "amountTooLarge": "Le montant « {amountStr} » est trop élevé. Veuillez utiliser un nombre plus petit.",
+            "invalidAmountFallback": "Montant invalide. Veuillez utiliser uniquement des chiffres et des décimales (par ex. 100 ou 100.50).",
+            "pleaseRemoveChars": "Veuillez supprimer ces caractères : {chars}. Seuls les chiffres, les virgules et les points sont autorisés.",
+            "amountCannotBeEmpty": "Le montant ne peut pas être vide.",
+            "tokenMismatch": "Vous avez saisi « {provided} » mais {expected} est sélectionné ci-dessus. Supprimez le symbole du token ou sélectionnez {suggested} dans le menu déroulant.",
+            "multipleTokenSymbols": "Vous utilisez plusieurs symboles de tokens ({symbols}). Veuillez utiliser un seul type de token dans tout votre fichier, ou supprimez les symboles de tokens et laissez la sélection ci-dessus déterminer le token.",
+            "noPaymentDataFound": "Aucune donnée de paiement trouvée. Veuillez ajouter vos paiements dans ce format : recipient, amount",
+            "exceedsRecipientLimit": "Vous avez {count} destinataires, mais la limite est de {limit} par lot. Veuillez supprimer {excess, plural, one {# destinataire} other {# destinataires}} ou répartir en plusieurs lots.",
+            "noPaymentDataProvided": "Aucune donnée de paiement fournie. Veuillez saisir vos paiements dans ce format : recipient, amount",
+            "headerColumnsNotFound": "Nous avons détecté une ligne d'en-tête, mais nous n'avons pas trouvé les colonnes « Recipient » et « Amount ». Veuillez utiliser ces noms de colonnes ou supprimer la ligne d'en-tête.",
+            "failedToParseCsv": "Échec de l'analyse des données CSV",
+            "failedToParsePaste": "Échec de l'analyse des données collées",
+            "failedToValidateAccount": "Échec de la validation du compte",
+            "feeEstimationFailed": "Impossible d'estimer les frais de réseau pour ce montant. Veuillez vérifier et réessayer.",
+            "feeEstimationFailedRow": "Ligne {row} ({recipient}) : Impossible d'estimer les frais de réseau pour ce montant. Veuillez vérifier et réessayer."
+        },
+        "recipients": "Destinataires",
+        "insufficientTokens": "Tokens insuffisants. Vous pouvez soumettre la demande et faire l'appoint avant l'approbation.",
+        "removeRecipient": "Supprimer le destinataire",
+        "removeRecipientConfirm": "Êtes-vous sûr de vouloir supprimer le paiement à <strong>{recipient}</strong> ? Cette action ne peut pas être annulée.",
+        "remove": "Supprimer",
+        "edit": "Modifier"
+    },
+    "bulkPaymentCredits": {
+        "title": "Paiements groupés",
+        "unlimited": "Illimité",
+        "creditsPerPeriod": "{amount} / {period}",
+        "oneTimeTrial": "essai unique",
+        "month": "mois",
+        "moreFlexibility": "Vous cherchez plus de flexibilité ?",
+        "contactUs": "Contactez-nous"
+    },
+    "exchange": {
+        "validation": {
+            "amountPositive": "Le montant doit être supérieur à 0"
+        },
+        "requestSubmitted": "Demande d'échange soumise",
+        "heading": "Échange",
+        "sell": "Vendre",
+        "receive": "Recevoir",
+        "slippageTolerance": "Tolérance au glissement",
+        "disabled": {
+            "differentTokens": "Les tokens doivent être différents",
+            "enterAmount": "Saisissez un montant à échanger"
+        },
+        "review": "Vérifier l'échange",
+        "poweredBy": "Propulsé par",
+        "info": {
+            "priceDifference": "Différence de prix",
+            "priceDifferenceTooltip": "Différence entre le taux du devis et le taux actuel du marché. Les valeurs positives indiquent un meilleur taux que le marché.",
+            "estimatedTime": "Temps estimé",
+            "estimatedTimeValue": "{seconds} secondes",
+            "estimatedTimeTooltip": "Temps approximatif pour terminer l'échange.",
+            "minimumReceived": "Minimum reçu",
+            "minimumReceivedTooltip": "Il s'agit du montant minimum que vous recevrez de cet échange, basé sur la limite de glissement définie pour la demande.",
+            "depositAddress": "Adresse de dépôt",
+            "depositAddressCopied": "Adresse de dépôt copiée",
+            "quoteExpires": "Expiration du devis",
+            "exchangeFee": "Frais d'échange",
+            "exchangeFeeTooltip": "Les frais de 0,70 % couvrent ici les coûts du protocole NEAR Intents pour faciliter votre transaction et les frais du widget Trezu. Ce montant est automatiquement calculé dans votre taux coté."
+        },
+        "approveWithin24h": "Veuillez approuver cette demande dans les 24 heures, sinon elle expirera. Nous recommandons de confirmer dès que possible.",
+        "confirmSubmit": "Confirmer et soumettre la demande",
+        "refreshingIn": "Le taux d'échange sera actualisé dans {seconds} s"
+    },
+    "vesting": {
+        "validation": {
+            "amountMin": "Le montant doit être supérieur ou égal à 3,5",
+            "startBeforeEnd": "La date de début doit être antérieure à la date de fin",
+            "cliffBetween": "La date du cliff doit être comprise entre"
+        },
+        "stepTitles": {
+            "details": "Détails",
+            "settings": "Paramètres",
+            "review": "Vérification"
+        },
+        "proposalTitle": "Créer un calendrier de vesting pour {address}",
+        "scheduleSubmitted": "Demande de création de calendrier de vesting soumise",
+        "heading": "Nouveau calendrier de vesting",
+        "amount": "Montant",
+        "startDate": "Date de début",
+        "endDate": "Date de fin",
+        "noteOptional": "Note (facultatif)",
+        "continue": "Continuer",
+        "advancedSettings": "Paramètres avancés",
+        "allowCancellation": "Autoriser l'annulation",
+        "allowCancellationDescription": "Permet à la NEAR Foundation d'annuler le lockup à tout moment. Les lockups non annulables ne sont pas compatibles avec les dates de cliff.",
+        "cliffDate": "Date du cliff",
+        "allowEarn": "Autoriser les gains",
+        "allowEarnDescription": "Permet au propriétaire du lockup de staker la totalité des tokens du lockup (même avant la date du cliff).",
+        "commentPlaceholder": "Ajoutez un commentaire pour ce calendrier de vesting (facultatif)...",
+        "reviewRequest": "Vérifier la demande",
+        "reviewHeading": "Vérifiez votre calendrier de vesting",
+        "confirmSubmit": "Confirmer et soumettre la demande",
+        "review": {
+            "recipient": "Destinataire",
+            "startDate": "Date de début",
+            "endDate": "Date de fin",
+            "cliffDate": "Date du cliff",
+            "cancelable": "Annulable",
+            "allowEarn": "Autoriser les gains",
+            "na": "N/D"
+        }
+    },
+    "earn": {
+        "placeholder": "Explorez les opportunités de gains et les récompenses de staking."
+    },
+    "createTreasury": {
+        "validation": {
+            "nameMin": "Le nom de la trésorerie doit comporter au moins 2 caractères",
+            "nameMax": "Le nom de la trésorerie doit comporter moins de 64 caractères",
+            "accountMin": "Le nom du compte doit comporter au moins 2 caractères",
+            "accountMax": "Le nom du compte doit comporter moins de 64 caractères",
+            "accountChars": "Le nom du compte ne peut contenir que des lettres latines, des chiffres et des tirets",
+            "accountTaken": "Ce nom de compte est déjà pris"
+        },
+        "votingNote": "Vous avez besoin de plus de membres pour modifier les paramètres de vote. Ajoutez un autre membre pour configurer le vote.",
+        "minimumVoteNote": "Au moins un vote d'approbation requis.",
+        "heading": "Créer une trésorerie",
+        "addMembers": "Ajouter des membres",
+        "addMembersInfo": "Vous pouvez ajouter ou mettre à jour des membres maintenant et modifier cela plus tard à tout moment.",
+        "treasuryName": "Nom de la trésorerie",
+        "treasuryNamePlaceholder": "Ma trésorerie",
+        "accountName": "Nom du compte",
+        "accountNameInfo": "Il s'agit du nom unique de votre compte. Il sera utilisé dans l'URL de votre trésorerie et affiché dans les transactions pour identifier l'expéditeur du paiement. Choisissez un nom court et reconnaissable pour votre compte.",
+        "accountPlaceholder": "ma-tresorerie",
+        "continue": "Continuer",
+        "votingThreshold": "Seuil de vote",
+        "thresholdDescription": "Définissez combien de votes sont requis pour approuver les demandes :",
+        "financial": "Financier",
+        "financialDescription": "Approuver les demandes de paiement et d'échange.",
+        "governance": "Gouvernance",
+        "governanceDescription": "Approuver les paramètres, les membres et la configuration du vote.",
+        "confidential": "Confidentiel",
+        "public": "Public",
+        "anyone": "N'importe qui",
+        "teamOnly": "Équipe uniquement",
+        "soon": "Bientôt",
+        "publicDescription": "Tous les soldes, activités et transactions sont visibles par tous sur la blockchain. Cette option convient le mieux aux organisations transparentes et aux DAO publics.",
+        "balanceTransactions": "Solde, transactions",
+        "membersVoting": "Membres, vote",
+        "allFeatures": "Toutes les fonctionnalités disponibles",
+        "confidentialDescription": "Tous les soldes, activités et transferts sont privés sur la blockchain. Seule votre équipe peut voir ces informations. Idéal pour les entreprises privées, les family offices ou les équipes qui souhaitent une confidentialité financière.",
+        "recentTransactionsExport": "Export des transactions récentes",
+        "bulkPayment": "Paiement groupé",
+        "treasuryType": "Type de trésorerie",
+        "treasuryTypeWarning": "Vous ne pouvez sélectionner qu'une seule fois par trésorerie et vous ne pouvez pas le modifier plus tard.",
+        "select": "Sélectionner",
+        "visibleOnChain": "Visible on-chain",
+        "featuresAvailable": "Fonctionnalités disponibles",
+        "mostFeaturesSupported": "La plupart des fonctionnalités sont prises en charge",
+        "reviewTreasury": "Vérifier la trésorerie",
+        "membersLabel": "Membres",
+        "financialThreshold": "Seuil financier",
+        "governanceThreshold": "Seuil de gouvernance",
+        "noDeploymentFee": "🎉 Aucun frais de déploiement",
+        "noDeploymentFeeDescription": "Pour soutenir les nouveaux projets, TREZU couvre tous les frais ponctuels de déploiement et de stockage réseau.",
+        "createButton": "Créer la trésorerie",
+        "connectWalletCreate": "Connecter le portefeuille pour créer la trésorerie",
+        "unexpectedError": "Une erreur inattendue s'est produite",
+        "creationFailed": "Échec de la création de la trésorerie. Veuillez réessayer.",
+        "stepTitles": {
+            "aboutYou": "À propos de vous",
+            "details": "Détails",
+            "members": "Membres",
+            "treasuryType": "Type de trésorerie",
+            "review": "Vérification"
+        },
+        "steps": {
+            "creatingNear": "Création de votre trésorerie sur NEAR",
+            "registeringKey": "Enregistrement de la clé publique",
+            "settingUpConfidential": "Configuration des transactions confidentielles",
+            "configuringMembers": "Configuration des membres de la trésorerie",
+            "finalizingSetup": "Finalisation de la configuration"
+        }
+    },
+    "manageTreasuries": {
+        "warningOne": "Au moins une trésorerie doit rester disponible",
+        "warningOnePeriod": "Au moins une trésorerie doit rester disponible.",
+        "activeHeading": "Trésoreries actives",
+        "activeDescription": "Trésoreries actuellement visibles dans votre liste de comptes.",
+        "activeEmpty": "Aucune trésorerie active.",
+        "hiddenHeading": "Trésoreries masquées",
+        "hiddenDescription": "Trésoreries masquées de votre liste de comptes.",
+        "removeGuestTitle": "Supprimer la trésorerie invitée",
+        "removeDialog": "Vous êtes sur le point de supprimer <bold>{name}</bold>. Une fois confirmée, cette action ne pourra pas être annulée.",
+        "tooltips": {
+            "removeFromList": "Supprimer de votre liste",
+            "viewTreasury": "Voir la trésorerie",
+            "hideFromList": "Masquer de votre liste",
+            "showInList": "Afficher dans votre liste"
+        }
+    },
+    "wallet": {
+        "proposal": {
+            "transfer": "Proposition d'une dApp externe : transférer NEAR vers {receiverId}",
+            "functionCall": "Proposition d'une dApp externe : {methods} sur {receiverId}",
+            "unsupportedAction": "Type d'action non pris en charge « {type} ». Seules les actions Transfer et FunctionCall peuvent être converties en propositions Trezu."
+        },
+        "loading": "Chargement...",
+        "connectPrompt": "Connectez votre portefeuille NEAR pour continuer. Vous sélectionnerez ensuite une trésorerie au nom de laquelle agir.",
+        "connectWallet": "Connecter le portefeuille",
+        "cancel": "Annuler",
+        "connectedAs": "Connecté en tant que <strong>{account}</strong>",
+        "loadingTreasuries": "Chargement des trésoreries...",
+        "selectSignIn": "Sélectionnez une trésorerie pour vous connecter en tant que :",
+        "selectSignTx": "Sélectionnez une trésorerie sur laquelle créer une proposition :",
+        "notMember": "Vous n'êtes membre d'aucune trésorerie.",
+        "actingAs": "Agissant en tant que",
+        "signedBy": "Signé par {account}",
+        "createsNProposals": "Cela créera {count, plural, one {une proposition Trezu} other {# propositions Trezu}} pour :",
+        "proposalDescriptionLabel": "Description de la proposition (facultatif)",
+        "proposalDescriptionPlaceholder": "Décrivez cette proposition...",
+        "createProposal": "Créer la proposition",
+        "creatingProposal": "Création de la proposition...",
+        "confirmInWallet": "Veuillez confirmer dans votre portefeuille",
+        "proposalSubmitted": "Proposition soumise",
+        "shareProposal": "Votre proposition a été créée. Partagez le lien ci-dessous avec les membres de la trésorerie pour voter.",
+        "proposalLink": "{daoId} — Proposition #{id}",
+        "checking": "Vérification...",
+        "proposalApprovedProceed": "La proposition est approuvée. Continuer",
+        "signedInSuccess": "Connexion réussie",
+        "proposalCreatedSuccess": "Proposition créée avec succès",
+        "closeWindow": "Vous pouvez fermer cette fenêtre.",
+        "errorGeneric": "Une erreur s'est produite",
+        "tryAgain": "Réessayer",
+        "errors": {
+            "parseTx": "Échec de l'analyse de la requête de transaction. Veuillez réessayer.",
+            "fetchTreasuries": "Échec de la récupération de vos trésoreries. Veuillez réessayer.",
+            "connectFailed": "Échec de la connexion du portefeuille",
+            "createProposalFailed": "Échec de la création de la proposition",
+            "stillPending": "La proposition est encore en attente d'approbation. Veuillez attendre que les membres de la trésorerie votent.",
+            "wasStatus": "La proposition #{id} était {status}",
+            "awaitIndex": "La proposition est approuvée mais la transaction d'exécution n'est pas encore indexée. Veuillez réessayer dans un instant.",
+            "checkStatusFailed": "Échec de la vérification du statut de la proposition",
+            "userCancelled": "Annulé par l'utilisateur",
+            "proposalWasStatus": "La proposition était {status}"
+        }
+    },
+    "telegram": {
+        "tagPill": "Telegram",
+        "invalidLinkTitle": "Lien invalide",
+        "invalidLinkDescription": "Ce lien de connexion Telegram n'a pas de jeton. Cliquez à nouveau sur Connecter la trésorerie dans Telegram pour générer un nouveau lien.",
+        "successTitle": "Connecté avec succès",
+        "successDescription": "Les trésoreries ont été liées à ce chat Telegram.",
+        "successToast": "Trésoreries connectées avec succès",
+        "goToApp": "Aller à l'application",
+        "linkExpiredTitle": "Lien expiré",
+        "linkExpiredDescription": "Ce lien a expiré ou a déjà été utilisé. Dans Telegram, tapez la commande ci-dessous pour redémarrer le flux de connexion.",
+        "commandCopied": "Commande copiée",
+        "copy": "Copier",
+        "unableToLoadTitle": "Impossible de charger le chat",
+        "unableToLoadDescription": "Les détails du chat n'ont pas pu être chargés pour le moment. Veuillez réessayer depuis Telegram.",
+        "signInTitle": "Connectez-vous pour continuer",
+        "signInDescription": "Connectez d'abord votre portefeuille NEAR, puis choisissez les trésoreries à lier à ce chat Telegram.",
+        "connectWallet": "Connecter le portefeuille",
+        "selectTreasuriesTitle": "Sélectionner les trésoreries",
+        "selectTreasuriesDescription": "Choisissez les trésoreries à connecter à ce chat Telegram.",
+        "telegramChat": "Chat Telegram",
+        "chatIdFallback": "Chat #{id}",
+        "failedToConnect": "Échec de la connexion des trésoreries. Veuillez réessayer.",
+        "relinking": "{count, plural, one {# trésorerie sélectionnée est liée à un autre chat Telegram. La connexion la reconnectera et changera son lien d'ID de chat vers ce chat.} other {# trésoreries sélectionnées sont liées à d'autres chats Telegram. La connexion les reconnectera et changera leurs liens d'ID de chat vers ce chat.}}",
+        "alreadyConnected": "Déjà connecté à ce chat",
+        "connectedToAnother": "Connecté à un autre chat",
+        "notMember": "Vous n'êtes membre de la politique d'aucune trésorerie.",
+        "connecting": "Connexion…",
+        "connect": "Connecter"
+    },
+    "systemStatus": {
+        "underMaintenance": "En maintenance",
+        "maintenanceMessage": "Nous effectuons actuellement une maintenance. Certaines fonctionnalités peuvent être temporairement indisponibles. Veuillez revenir bientôt."
+    },
+    "creditsQuota": {
+        "available": "{count} disponibles",
+        "used": "{count} utilisés",
+        "resetOn": "La limite sera réinitialisée le {date}"
+    },
+    "approvalInfo": {
+        "infoText": "Votes requis pour approuver les demandes liées aux paiements. Modifiable dans les paramètres de vote.",
+        "thresholdPill": "Seuil {required} sur {total}",
+        "alertBody": "Ce paiement nécessitera l'approbation de <bold>{required}</bold> membres de la trésorerie avant exécution."
+    },
+    "guestBadge": {
+        "title": "Invité",
+        "tooltip": "Vous êtes un invité de cette trésorerie. Vous ne pouvez consulter que les données."
+    },
+    "exportButton": {
+        "confidentialTooltip": "L'export n'est pas encore disponible en mode confidentiel. Cette fonctionnalité arrive bientôt !"
+    },
+    "sponsoredActions": {
+        "titleExhausted": "Actions sponsorisées utilisées",
+        "titleAlmost": "Votre équipe est presque à court d'actions sponsorisées",
+        "closeNotice": "Fermer l'avis",
+        "teamUsage": "Utilisation de l'équipe : {total} actions par mois",
+        "available": "{count} disponibles",
+        "used": "{count} utilisées",
+        "exhaustedBody": "Votre équipe a atteint les actions sponsorisées mensuelles. Vous pouvez continuer après {date} ou nous contacter",
+        "almostBody": "TREZU sponsorise actuellement les coûts de stockage pour toutes les actions de l'équipe, telles que la création de demandes et le vote. Votre équipe est proche d'atteindre la limite mensuelle sponsorisée.",
+        "contactUs": "Contactez-nous",
+        "nextMonthlyReset": "votre prochaine réinitialisation mensuelle",
+        "sidebarBody": "Votre équipe a atteint les actions sponsorisées mensuelles. Vous pouvez continuer après {date} ou ⬇️"
+    },
+    "acceptTerms": {
+        "title": "Acceptez les conditions pour continuer",
+        "privacyTitle": "Votre vie privée chez Trezu",
+        "privacyBody": "Trezu est une interface non-custodiale. Nous accordons la priorité à votre vie privée tout en garantissant que la plateforme reste sécurisée et fonctionnelle.",
+        "minimalTitle": "Données minimales",
+        "minimalBody": "Nous collectons des informations limitées, telles que les adresses publiques de portefeuille, les adresses IP et les analyses d'utilisation, pour exploiter et améliorer l'interface.",
+        "noCustodyTitle": "Aucune custodie",
+        "noCustodyBody": "Nous n'avons jamais accès à vos clés privées, phrases de récupération ou actifs numériques.",
+        "publicTitle": "Registres publics",
+        "publicBody": "N'oubliez pas que toutes les transactions blockchain sont intrinsèquement publiques et ne sont pas contrôlées par nous.",
+        "responsibilityTitle": "Votre responsabilité",
+        "responsibilityBody": "Vous êtes seul responsable de la surveillance de l'activité de votre portefeuille et de la sécurité de vos identifiants.",
+        "futureTitle": "Mises à jour futures",
+        "futureBody": "Si vous optez pour de futures notifications (telles qu'e-mail ou Telegram), nous n'utiliserons ces données que pour vous tenir informé.",
+        "agreement": "J'ai lu et j'accepte les <terms>Conditions d'utilisation</terms> et la <privacy>Politique de confidentialité</privacy>",
+        "accepting": "Acceptation...",
+        "continue": "Continuer"
+    },
+    "confidentialBanner": {
+        "label": "Confidentiel",
+        "description": "Les soldes, l'activité et les transferts ne sont visibles que par votre équipe — pas par la blockchain publique."
+    },
+    "supportCenter": {
+        "title": "Centre d'assistance",
+        "resources": "Ressources",
+        "support": "Support",
+        "websiteTitle": "Site web Trezu",
+        "websiteDescription": "Apprenez-en plus sur Trezu et lisez notre blog.",
+        "demo": "Démo Trezu",
+        "demoTitle": "Explorer la version publique",
+        "demoDescription": "Voyez un compte public en direct en action.",
+        "confidentialDemoTitle": "Explorer la version confidentielle",
+        "confidentialDemoDescription": "Explorez un compte confidentiel en direct en action.",
+        "videoTitle": "Regarder la démo",
+        "videoDescription": "Regardez une courte vidéo montrant comment Trezu fonctionne.",
+        "xTitle": "Suivez-nous sur X",
+        "xDescription": "Restez informé de nos dernières sorties et perspectives.",
+        "statsTitle": "Statistiques",
+        "statsDescription": "Voir les actifs totaux sous gestion sur l'ensemble des DAO sputnik.",
+        "docsTitle": "Documentation",
+        "docsDescription": "Découvrez toutes les fonctionnalités dans la documentation.",
+        "productSupportTitle": "Support produit",
+        "productSupportDescription": "Contactez notre équipe de support pour obtenir de l'aide."
+    },
+    "progressModal": {
+        "titleCreating": "Création de la trésorerie...",
+        "titleDone": "Trésorerie créée",
+        "titleFailed": "Échec de la création de la trésorerie",
+        "viewTreasury": "Voir la trésorerie"
+    },
+    "memberValidation": {
+        "noManagePermission": "Vous n'avez pas l'autorisation de gérer les membres",
+        "pendingRequest": "Vous ne pouvez pas gérer les membres tant qu'une demande est active",
+        "rolesAnd": "{first} et {second}",
+        "rolesMany": "{list} et {last}",
+        "cannotRemoveMember": "Impossible de supprimer ce membre. Il est la seule personne attribuée au {count, plural, one {rôle} other {rôles}} {roles}.",
+        "cannotRemoveMemberGov": "Impossible de supprimer ce membre. Il est la seule personne attribuée au {count, plural, one {rôle, qui est} other {rôles, qui sont}} {roles} requis pour gérer les membres de l'équipe et configurer le vote.",
+        "cannotBulkRemove": "Impossible de supprimer ces membres. Cela laisserait le {count, plural, one {rôle} other {rôles}} {roles} vide.",
+        "cannotBulkRemoveGov": "Impossible de supprimer ces membres. Cela laisserait le {count, plural, one {rôle, qui est} other {rôles, qui sont}} {roles} vide, requis pour gérer les membres de l'équipe et configurer le vote.",
+        "cannotRemoveRole": "Vous ne pouvez pas supprimer le rôle {role} de ce membre. Il est la seule personne attribuée à ce rôle.",
+        "cannotRemoveRoleGov": "Vous ne pouvez pas supprimer le rôle {role} de ce membre. Il est le seul membre {role}, et sans ce rôle, vous ne pourrez plus gérer les membres de l'équipe ni configurer le vote."
+    },
+    "roleSelector": {
+        "setRole": "Définir le rôle",
+        "allRoles": "Tous les rôles",
+        "roles": {
+            "governance": {
+                "title": "Gouvernance",
+                "description": "La gouvernance peut créer et voter sur les paramètres de trésorerie liés à l'équipe, y compris les membres, les autorisations et l'apparence de la trésorerie."
+            },
+            "requestor": {
+                "title": "Demandeur",
+                "description": "Le demandeur peut créer des demandes de transaction liées aux paiements, sans droits de vote ni d'approbation."
+            },
+            "financial": {
+                "title": "Financier",
+                "description": "Le financier peut voter sur les demandes de transaction liées aux paiements mais ne peut pas les créer."
+            }
+        }
+    },
+    "memberInput": {
+        "creatorYou": "Créateur (vous)",
+        "memberAddress": "Adresse du membre",
+        "addNewMember": "Ajouter un nouveau membre",
+        "validation": {
+            "rolesRequired": "Au moins un rôle est requis",
+            "duplicateAddress": "L'adresse est déjà membre"
+        }
+    },
+    "recipientInput": {
+        "title": "À",
+        "placeholder": "Adresse du destinataire"
+    },
+    "accountInput": {
+        "failedValidation": "Échec de la validation de l'adresse",
+        "invalidNearFormat": "Format de compte NEAR invalide",
+        "invalidChainAddress": "Veuillez saisir une adresse {chain} valide.",
+        "validating": "Validation de l'adresse...",
+        "validAddress": "Adresse valide",
+        "placeholderWithExample": "Adresse du destinataire (par ex. : {example})",
+        "placeholderNoExample": "Adresse du destinataire",
+        "nearExample": "alice.near, 0x..., ou hex de 64 caractères",
+        "near": {
+            "required": "L'adresse est requise",
+            "length": "L'adresse doit comporter entre 2 et 64 caractères",
+            "missingTld": "Les comptes nommés doivent se terminer par .near, .aurora ou .tg",
+            "invalidChars": "L'adresse ne peut contenir que des lettres minuscules, des chiffres et des séparateurs (., -, _)",
+            "accountMissing": "Le compte n'existe pas sur la blockchain NEAR",
+            "verifyFailed": "Échec de la vérification de l'existence du compte"
+        }
+    },
+    "csvUpload": {
+        "uploadFile": "Télécharger un fichier",
+        "provideData": "Fournir les données",
+        "chooseFile": "Choisir un fichier",
+        "orDragDrop": "ou glissez-déposez",
+        "maxFileSize": "max 1 fichier jusqu'à {maxSize} Mo, fichier CSV uniquement",
+        "noFilePrompt": "Vous n'avez pas de fichier à télécharger ?",
+        "downloadTemplate": "Télécharger un modèle"
+    },
+    "tokenSelect": {
+        "selectToken": "Sélectionner un token",
+        "searchPlaceholder": "Rechercher des tokens...",
+        "noTokensFound": "Aucun token trouvé"
+    },
+    "filterOperations": {
+        "is": "Est",
+        "isNot": "N'est pas",
+        "before": "Avant",
+        "after": "Après",
+        "between": "Entre",
+        "equal": "Égal",
+        "moreThan": "Plus de",
+        "lessThan": "Moins de",
+        "contains": "Contient"
+    },
+    "copyButton": {
+        "copied": "Copié dans le presse-papiers",
+        "failed": "Échec de la copie"
+    },
+    "recipientForm": {
+        "validation": {
+            "nameRequired": "Le nom est requis",
+            "nameMax": "Le destinataire doit comporter moins de {max} caractères",
+            "addressRequired": "L'adresse est requise",
+            "networksRequired": "Sélectionnez au moins un réseau"
+        }
+    },
+    "paymentForm": {
+        "validation": {
+            "recipientMin": "Le destinataire doit comporter au moins 2 caractères",
+            "recipientMax": "Le destinataire doit comporter moins de 128 caractères",
+            "amountGreaterThanZero": "Le montant doit être supérieur à 0",
+            "recipientSameAsToken": "Le destinataire et l'adresse du token ne peuvent pas être identiques",
+            "selectToken": "Veuillez sélectionner un token",
+            "recipientMax64": "Le destinataire doit comporter moins de 64 caractères",
+            "amountMinLockup": "Le montant doit être supérieur ou égal à 3,5",
+            "startDateRequired": "La date de début est requise",
+            "endDateRequired": "La date de fin est requise",
+            "cliffDateRequired": "La date du cliff est requise",
+            "startBeforeEnd": "La date de début doit être antérieure à la date de fin",
+            "cliffBetween": "La date du cliff doit être comprise entre {start} et {end}"
+        }
+    },
+    "exportToasts": {
+        "downloadFailed": "Échec du téléchargement de l'export",
+        "invalidDateRange": "Plage de dates invalide",
+        "invalidDateRangeDescription": "Veuillez sélectionner une plage de dates valide pour l'export.",
+        "exportSuccess": "Export réussi !",
+        "exportSuccessDescription": "Votre fichier {type} a été téléchargé. Consultez votre historique d'exports pour plus de détails.",
+        "exportFailed": "Échec de l'export",
+        "exportFailedFallback": "Échec de l'export des données. Veuillez réessayer.",
+        "noDownloadPermission": "Vous n'avez pas l'autorisation de télécharger le fichier.",
+        "noExportPermission": "Vous n'avez pas l'autorisation d'exporter",
+        "quotaUsed": "Vous avez utilisé tout votre quota",
+        "exporting": "Exportation...",
+        "export": "Exporter",
+        "columnSubmissionTime": "Heure de soumission",
+        "columnDateRange": "Plage de dates",
+        "columnGeneratedBy": "Généré par",
+        "columnStatus": "Statut",
+        "typeAll": "Tous les types",
+        "typeSent": "Envoyées",
+        "typeReceived": "Reçues",
+        "typeStakingRewards": "Récompenses de staking",
+        "allAssets": "Tous les actifs",
+        "upgradeTrial": "Améliorez votre plan pour en obtenir plus et continuer",
+        "upgradePaid": "Améliorez votre plan pour plus d'accès, ou attendez la réinitialisation de vos limites le mois prochain.",
+        "selectDateRange": "Sélectionner une plage de dates",
+        "noExportsTitle": "Aucun export pour l'instant",
+        "noExportsDescription": "Vos fichiers exportés du mois dernier apparaîtront ici une fois générés.",
+        "quotaTitle": "Quota d'exportation",
+        "unlimited": "Illimité",
+        "creditsPerMonth": "{total} / mois",
+        "requirementsTitle": "Exigences d'exportation",
+        "exportFromPeriod": "Vous pouvez exporter les données de {period}.",
+        "availableFor48Hours": "Les fichiers exportés sont disponibles au téléchargement pendant 48 heures.",
+        "moreFlexibility": "Vous cherchez plus de flexibilité ?",
+        "contactUs": "Contactez-nous",
+        "last1Year": "Dernière année",
+        "last2Years": "2 dernières années",
+        "invalidEmail": "Veuillez saisir une adresse e-mail valide"
+    },
+    "proposalKinds": {
+        "Batch Payment Request": "Demande de paiement groupé",
+        "Payment Request": "Demande de paiement",
+        "Confidential Request": "Demande confidentielle",
+        "Exchange": "Échange",
+        "Function Call": "Appel de fonction",
+        "Change Policy": "Modification de politique",
+        "Update General Settings": "Mettre à jour les paramètres généraux",
+        "Earn NEAR": "Gagner du NEAR",
+        "Unstake NEAR": "Déstaker du NEAR",
+        "Vesting": "Vesting",
+        "Withdraw Earnings": "Retirer les gains",
+        "Members": "Membres",
+        "Upgrade": "Mise à niveau",
+        "Set Staking Contract": "Définir le contrat de staking",
+        "Bounty": "Bounty",
+        "Vote": "Vote",
+        "Factory Info Update": "Mise à jour des infos de la factory",
+        "Unsupported": "Non pris en charge"
+    },
+    "paymentFormSection": {
+        "selectRecipient": "Sélectionner un destinataire",
+        "searchByNameOrAddress": "Rechercher par nom ou adresse",
+        "restrictedRecipientTitle": "Transaction non autorisée",
+        "restrictedRecipientMessage": "Cette adresse est actuellement restreinte en raison de contrôles de sécurité. Si vous pensez que cette adresse devrait être autorisée, vous pouvez <link>demander à l'ajouter à la liste blanche</link>.",
+        "send": "Envoyer",
+        "to": "À"
+    },
+    "recipientNetworkSelect": {
+        "label": "Réseau du destinataire",
+        "placeholder": "Sélectionner le réseau du destinataire",
+        "enterAddressFirst": "Saisissez d'abord l'adresse du destinataire",
+        "noCompatibleNetwork": "Aucun réseau ne correspond à cette adresse",
+        "selectPlaceholder": "Sélectionner un réseau",
+        "title": "Sélectionner un réseau",
+        "available": "Disponible",
+        "fromAddressBook": "Depuis le carnet d'adresses",
+        "otherAvailable": "Autres disponibles",
+        "incompatible": "Incompatible",
+        "comingSoon": "Bientôt disponible",
+        "nearComName": "near.com",
+        "nearComDescription": "Réseau interne pour near.com et trezu"
+    },
+    "addressBookTable": {
+        "emptyTitle": "Aucun destinataire pour l'instant",
+        "emptyDescription": "Ajoutez des destinataires à ce carnet d'adresses pour des paiements plus rapides.",
+        "selectAll": "Sélectionner tous les destinataires",
+        "selectEntry": "Sélectionner {name}",
+        "recipient": "Destinataire",
+        "network": "Réseau",
+        "addedBy": "Ajouté par",
+        "note": "Note",
+        "added": "Ajouté",
+        "remove": "Supprimer",
+        "send": "Envoyer"
+    },
+    "publicDashboard": {
+        "updatesDaily": "Mises à jour quotidiennes",
+        "noDataTitle": "Aucune donnée pour l'instant",
+        "noDataDescription": "Les statistiques apparaîtront après le calcul du premier instantané quotidien.",
+        "assetsSecured": "Actifs sécurisés avec le contrat Sputnik DAO",
+        "acrossDaos": "Sur <bold>{count, plural, one {# DAO} other {# DAO}}</bold>",
+        "updatedOn": "Mis à jour le {date}",
+        "topAssets": "Top 20 des actifs",
+        "noAssetsTitle": "Aucun actif pour l'instant",
+        "noAssetsDescription": "Les données des tokens apparaîtront une fois l'instantané quotidien calculé.",
+        "tableToken": "Token",
+        "tableTotalValue": "Valeur totale"
+    },
+    "telegramConnectInstructions": {
+        "title": "Connecter Telegram",
+        "subtitle": "Recevez des notifications sur les propositions et l'activité dans votre Telegram.",
+        "step3": "Appuyez sur Démarrer et suivez les instructions.",
+        "success": "Tout est prêt !",
+        "copyBotTooltip": "Copier le pseudo du bot",
+        "botCopiedToast": "Pseudo du bot copié",
+        "openInTelegram": "Ouvrir {bot} dans Telegram"
+    },
+    "transactionHashCell": {
+        "copyHash": "Copier le hash",
+        "hashCopied": "Hash copié",
+        "openInExplorer": "Ouvrir dans l'explorateur"
+    },
+    "treasurySelector": {
+        "select": "Sélectionner une trésorerie",
+        "connectWalletTooltip": "Connectez le portefeuille pour voir les trésoreries",
+        "manageTreasuries": "Gérer les trésoreries",
+        "createTreasury": "Créer une trésorerie",
+        "memberOf": "Membre de",
+        "guestTreasuries": "Trésoreries invitées"
+    },
+    "selectModal": {
+        "searchByName": "Rechercher par nom",
+        "noResults": "Aucun résultat trouvé"
+    },
+    "selectList": {
+        "noResults": "Aucun résultat trouvé"
+    },
+    "datePicker": {
+        "pickDate": "Choisir une date",
+        "timezone": "Fuseau horaire"
+    },
+    "datePresets": {
+        "today": "Aujourd'hui",
+        "yesterday": "Hier",
+        "last3Days": "3 derniers jours",
+        "last7Days": "7 derniers jours",
+        "last14Days": "14 derniers jours",
+        "lastMonth": "Le mois dernier",
+        "last3Months": "3 derniers mois",
+        "last6Months": "6 derniers mois"
+    },
+    "input": {
+        "openSearch": "Ouvrir la recherche"
+    },
+    "pagination": {
+        "previous": "Précédent",
+        "next": "Suivant"
+    },
+    "confidentialState": {
+        "title": "Confidentiel",
+        "description": "Seuls les membres de la trésorerie y ont accès."
+    },
+    "exchangeRate": {
+        "rate": "Taux",
+        "clickToReverse": "Cliquez pour inverser le taux"
+    },
+    "exchangeSettings": {
+        "title": "Paramètres d'échange",
+        "slippageTolerance": "Tolérance au glissement",
+        "custom": "Personnalisé",
+        "customPlaceholder": "ex : 2 %",
+        "slippageRange": "Le glissement doit être compris entre 0,01 % et 100 %",
+        "enterSlippage": "Veuillez saisir une tolérance au glissement",
+        "slippageHelp": "Si le prix change de plus de ce pourcentage, la transaction sera annulée pour protéger vos fonds.",
+        "save": "Enregistrer"
+    },
+    "assetsPage": {
+        "title": "Actifs",
+        "noAssetsTitle": "Aucun actif pour l'instant",
+        "noAssetsDescription": "Pour commencer, ajoutez des actifs à votre trésorerie en effectuant un dépôt."
+    },
+    "newBadge": {
+        "label": "Nouveau"
+    },
+    "numberBadge": {
+        "pendingRequests": "{count, plural, one {# demande en attente} other {# demandes en attente}}"
+    },
+    "balanceWithGraph": {
+        "allTokens": "Tous les tokens",
+        "deposit": "Dépôt",
+        "send": "Envoyer",
+        "exchange": "Échanger",
+        "chartNow": "Maintenant",
+        "totalBalance": "Solde total",
+        "excludedTokens": "Tokens exclus :",
+        "noPriceHistory": "Aucun historique de prix. Sélectionnez un token pour voir ses variations de solde.",
+        "bucketAvailable": "Disponible",
+        "bucketLocked": "Verrouillé",
+        "bucketEarning": "En gain",
+        "period": {
+            "1W": "1S",
+            "1M": "1M",
+            "3M": "3M",
+            "1Y": "1A"
+        }
+    },
+    "changePolicyExpanded": {
+        "proposalBond": "Caution de proposition",
+        "proposalPeriod": "Période de proposition",
+        "bountyBond": "Caution de bounty",
+        "bountyForgivenessPeriod": "Période de remise de bounty",
+        "votesCount": "{count} votes",
+        "weightKind": "Type de pondération",
+        "quorum": "Quorum",
+        "threshold": "Seuil",
+        "defaultThreshold": "Seuil par défaut",
+        "roleThreshold": "Seuil {role}",
+        "member": "Membre",
+        "members": "Membres",
+        "permissions": "Autorisations",
+        "oldPermissions": "Anciennes autorisations",
+        "newPermissions": "Nouvelles autorisations",
+        "category": "Catégorie",
+        "transactionDetails": "Détails de la transaction",
+        "addNewMember": "Ajouter un nouveau membre",
+        "addNewMembers": "Ajouter de nouveaux membres",
+        "removeMember": "Supprimer un membre",
+        "removeMembers": "Supprimer des membres",
+        "updateMemberPermissions": "Mettre à jour les autorisations du membre",
+        "updateMembersPermissions": "Mettre à jour les autorisations des membres",
+        "memberIndex": "Membre {index}",
+        "membersCount": "{count} membres",
+        "collapseAll": "Tout réduire",
+        "expandAll": "Tout développer",
+        "loadingHistorical": "Chargement de la politique historique...",
+        "unableToDiff": "Impossible de calculer les différences pour cette proposition.",
+        "noChangesCurrent": "Aucun changement détecté - la politique proposée est identique à la politique actuelle.",
+        "noChangesHistorical": "Aucun changement détecté - la politique proposée est identique à la politique historique."
+    },
+    "balanceChart": {
+        "usdValue": "Valeur USD",
+        "tokenBalance": "Solde du token",
+        "emptyTitle": "Rien à afficher pour l'instant",
+        "emptyDescription": "Ajoutez des actifs pour commencer à suivre votre portefeuille."
+    },
+    "user": {
+        "saveToAddressBook": "Enregistrer dans le carnet d'adresses",
+        "walletCopiedToast": "Adresse du portefeuille copiée dans le presse-papiers",
+        "copyWalletAddress": "Copier l'adresse du portefeuille"
+    },
+    "infoDisplay": {
+        "viewLess": "Voir moins",
+        "viewAllDetails": "Voir tous les détails"
+    },
+    "amountSummary": {
+        "defaultTitle": "Vous envoyez un total de"
+    },
+    "residency": {
+        "vestedToken": "Token acquis",
+        "staked": "Staké",
+        "fungibleToken": "Token fongible",
+        "intentsToken": "Token Intents",
+        "nativeToken": "Token natif"
+    },
+    "exchangeErrors": {
+        "noRoute": "Aucun échange trouvé. Essayez un montant plus petit ou un token différent.",
+        "amountTooLow": "Montant trop faible pour le swap. Les swaps multi-chaînes nécessitent un minimum plus élevé pour couvrir les frais de réseau.",
+        "insufficientBalance": "Solde insuffisant pour ce swap.",
+        "networkError": "Erreur réseau. Veuillez vérifier votre connexion et réessayer.",
+        "fetchFailed": "Échec de la récupération du devis"
+    },
+    "tokenSelectDialog": {
+        "selectToken": "Sélectionner un token",
+        "selectAsset": "Sélectionner un actif",
+        "selectNetworkFor": "Sélectionner le réseau pour {asset}",
+        "searchByName": "Rechercher par nom",
+        "noTokensWithBalance": "Aucun token avec solde trouvé",
+        "noTokensFound": "Aucun token trouvé",
+        "yourAssets": "Vos actifs",
+        "otherAssets": "Autres actifs",
+        "networksWithAssets": "Réseaux avec actifs",
+        "supportedNetworks": "Réseaux pris en charge",
+        "comingSoon": "Bientôt disponible"
+    },
+    "intentsQuote": {
+        "initializing": "Le service de devis est encore en cours d'initialisation. Veuillez réessayer.",
+        "noRoute": "Impossible de préparer un itinéraire de paiement pour le moment. Veuillez réessayer.",
+        "fetchFailed": "Impossible de préparer un itinéraire de paiement pour le moment. Veuillez réessayer.",
+        "amountTooLow": "Le montant est trop faible pour couvrir les frais de réseau. Saisissez un montant plus élevé et réessayez.",
+        "amountTooLowWithMin": "Le montant est trop faible pour couvrir les frais de réseau. Saisissez au moins {min} {token}.",
+        "networkFeeTooltip": "Ces frais sont utilisés pour traiter la transaction sur la chaîne sélectionnée."
+    },
+    "pageTours": {
+        "paymentsBulk": "La création groupée est arrivée ! Créez plusieurs demandes en quelques étapes.",
+        "paymentsPending": "Consultez ici les demandes en attente d'approbation.",
+        "exchangeSettings": "Vous pouvez définir ici la variation de prix que vous êtes prêt à accepter.",
+        "membersPending": "Cliquez pour voir les demandes actives en attente d'approbation.",
+        "guestSaveIntro": "Vous êtes un invité de cette trésorerie. Vous ne pouvez consulter que les données.",
+        "guestSaveAction": "Vous pouvez enregistrer cette trésorerie invitée dans votre liste de trésoreries.",
+        "newFeatureRich": "Nouveau ! 🎉 Enregistrez les adresses fréquemment utilisées pour des paiements plus rapides et sans erreur.<br></br> Vos contacts restent privés et visibles uniquement par votre équipe.",
+        "newFeatureCta": "Essayer"
+    },
+    "statusDate": {
+        "expires": "Expire",
+        "created": "Créée",
+        "expired": "Expirée",
+        "removed": "Supprimée"
+    },
+    "relativeTime": {
+        "justNow": "À l'instant",
+        "moments": "instants"
+    },
+    "amount": {
+        "network": "Réseau : {network}"
+    },
+    "activityLabels": {
+        "exchangePending": "Échange en attente",
+        "exchangeRequest": "Demande d'échange",
+        "exchangeFulfillment": "Exécution de l'échange",
+        "stakingRewards": "Récompenses de staking",
+        "proposalAction": "Action de proposition",
+        "deposit": "Dépôt {symbol}",
+        "paymentSent": "Paiement envoyé",
+        "transaction": "Transaction",
+        "fallbackToken": "Token",
+        "viaIntents": "via NEAR Intents",
+        "from": "de {account}",
+        "to": "vers {account}",
+        "viewAll": "Voir tout votre historique de transactions",
+        "sentReceived": "Transactions envoyées et reçues ({duration})",
+        "unlimitedHistory": "historique illimité",
+        "oneYear": "1 an",
+        "yearsCount": "{count} ans",
+        "monthsCount": "{count} mois",
+        "lastDuration": "{duration} dernier(s)"
+    },
+    "nearStore": {
+        "connectAndAcceptTerms": "Veuillez connecter le portefeuille et accepter les conditions pour continuer.",
+        "transactionNotApproved": "La transaction n'a pas été approuvée dans votre portefeuille.",
+        "failedSubmitVote": "Échec de la soumission du vote",
+        "failedSubmitVotes": "Échec de la soumission des votes",
+        "viewRequest": "Voir la demande",
+        "proposalRemoved": "Votre proposition a été supprimée",
+        "voteSubmitted": "Votre vote a été soumis",
+        "votesSubmitted": "Vos votes ont été soumis"
+    },
+    "tokenInput": {
+        "max": "MAX",
+        "insufficientTokens": "Tokens insuffisants. Vous pouvez soumettre la demande et faire l'appoint avant l'approbation.",
+        "balance": "Solde : {amount} {symbol}"
+    },
+    "createRequestButton": {
+        "idle": "Créer une demande",
+        "noPermission": "Vous n'avez pas l'autorisation de créer une demande"
+    },
+    "address": {
+        "copied": "Adresse copiée dans le presse-papiers"
+    },
+    "memberAvatars": {
+        "membersWhoCanVote": "Membres qui peuvent voter",
+        "moreMembers": "+{count, plural, one {# membre} other {# membres}}"
+    },
+    "accountIdInput": {
+        "minLength": "L'ID du compte doit comporter au moins 2 caractères",
+        "maxLength": "L'ID du compte doit comporter moins de 64 caractères",
+        "charset": "L'ID du compte doit contenir uniquement des lettres minuscules, des chiffres, des points, des tirets et des traits de soulignement, sans séparateurs en début ou en fin",
+        "doesNotExist": "L'ID du compte n'existe pas"
+    },
+    "addressBookMutations": {
+        "addedToast": "{count, plural, one {Destinataire ajouté} other {# destinataires ajoutés}}",
+        "addedSingleToast": "Destinataire ajouté",
+        "addFailedToast": "Échec de l'ajout des destinataires",
+        "addSingleFailedToast": "Échec de l'ajout du destinataire",
+        "removedToast": "{count, plural, one {Destinataire supprimé} other {# destinataires supprimés}}",
+        "removeFailedToast": "Échec de la suppression des destinataires",
+        "exportFailedToast": "Échec de l'export des destinataires"
+    },
+    "treasuryMutations": {
+        "savedToast": "Trésorerie enregistrée dans votre liste",
+        "saveFailedToast": "Échec de l'enregistrement de la trésorerie",
+        "hiddenToast": "Trésorerie masquée de la liste",
+        "hideFailedToast": "Échec du masquage de la trésorerie",
+        "unhiddenToast": "La trésorerie est à nouveau visible",
+        "unhideFailedToast": "Échec de l'affichage de la trésorerie",
+        "removedToast": "Trésorerie supprimée de la liste enregistrée",
+        "removeFailedToast": "Échec de la suppression de la trésorerie de la liste enregistrée"
+    },
+    "telegramSettings": {
+        "title": "Telegram",
+        "connectedTo": "Connecté à {chat}",
+        "chatNumber": "Chat #{id}",
+        "fallbackChat": "un chat Telegram",
+        "disconnect": "Déconnecter",
+        "connect": "Connecter",
+        "connectDescription": "Liez votre trésorerie à un chat Telegram pour recevoir des notifications.",
+        "noTreasuryDescription": "Liez vos trésoreries à un chat Telegram.",
+        "openSettingsHint": "Ouvrez les paramètres depuis une trésorerie pour gérer les intégrations.",
+        "disconnectedToast": "Telegram déconnecté pour cette trésorerie",
+        "disconnectFailedToast": "Impossible de déconnecter Telegram. Réessayez."
+    },
+    "assetsTable": {
+        "noAssetsFound": "Aucun actif trouvé.",
+        "assetDetails": "Détails de l'actif",
+        "coinPrice": "Prix de la pièce",
+        "weight": "Poids",
+        "balance": "Solde",
+        "lockedBalance": "Solde verrouillé",
+        "totalBalance": "Solde total",
+        "source": "Source",
+        "balanceByInvestors": "Solde par {count, plural, one {investisseur} other {investisseurs}}",
+        "investors": "{count, plural, one {Investisseur} other {Investisseurs}}",
+        "poolBreakdown": "Détail du pool",
+        "unlockedToken": "Token déverrouillé",
+        "lockupStakingPool": "Pool de staking de lockup",
+        "exchange": "Échanger",
+        "send": "Envoyer",
+        "details": "Détails",
+        "columnToken": "Token",
+        "columnLocked": "Verrouillé",
+        "columnUnlocked": "Déverrouillé",
+        "columnTotalAllocated": "Total alloué",
+        "columnAvailableToWithdraw": "Disponible au retrait",
+        "viewAvailable": "Disponible",
+        "viewLocked": "Verrouillé",
+        "viewEarning": "En gain",
+        "fullAllocatedBalance": "Votre solde alloué complet",
+        "partAllocatedBalance": "Une partie de votre solde alloué",
+        "currentlyEarning": "({amount} {symbol}) est actuellement en gain.",
+        "willAppearHere": " Cela apparaîtra ici une fois que vous aurez arrêté de gagner.",
+        "seeInEarningTab": "Voir dans l'onglet Gains",
+        "seeInEarning": "Voir dans Gains"
+    },
+    "earningDetails": {
+        "title": "Détails des gains",
+        "totalStaked": "Total staké",
+        "earningOverview": "Aperçu des gains",
+        "poolBreakdown": "Détail du pool ({count, plural, one {# pool} other {# pools}})",
+        "almostReady": "Les gains sont presque prêts !",
+        "finalizingFeature": "Nous finalisons cette fonctionnalité<br></br>pour que vous puissiez bientôt commencer à gagner des tokens.",
+        "comingSoon": "Bientôt disponible",
+        "goToEarn": "Aller à Gains",
+        "readyToWithdraw": "Prêt à retirer",
+        "unstaking": "Déstaking",
+        "overview": {
+            "staked": "Staké",
+            "stakedInfo": "Tokens actuellement délégués aux validateurs gagnant des récompenses.",
+            "pendingRelease": "Libération en attente",
+            "pendingReleaseInfo": "Tokens qui ont été déstakés mais sont encore dans la période de déliaison (généralement 2-3 jours).",
+            "availableForWithdraw": "Disponible au retrait",
+            "availableForWithdrawInfo": "Tokens déstakés qui ont terminé la période de déliaison et peuvent être retirés."
+        }
+    },
+    "lockupDetails": {
+        "title": "Détails du lockup",
+        "balance": "Solde",
+        "reservedForStorage": "Réservé pour le stockage",
+        "reservedForStorageInfo": "NEAR réservés par le compte de lockup pour payer les coûts de stockage.",
+        "tokenBreakdown": "Détail du token",
+        "allocatedAmount": "Montant alloué",
+        "earned": "Gagné",
+        "progress": "Progression",
+        "unlocked": "Déverrouillé",
+        "locked": "Verrouillé",
+        "schedule": "Calendrier",
+        "startDate": "Date de début",
+        "endDate": "Date de fin",
+        "rounds": "Tranches",
+        "releaseInterval": "Intervalle de libération",
+        "nextUnlockDate": "Prochaine date de déverrouillage",
+        "allEarning": "Tous les {amount} {symbol} de votre lockup sont actuellement en gain.",
+        "partEarning": "Une partie de votre lockup ({amount} {symbol}) est actuellement en gain.",
+        "stopEarningFirst": "Pour utiliser les tokens déverrouillés, arrêtez d'abord de gagner et retirez-les.",
+        "howGrantWorks": "Comment fonctionne votre allocation",
+        "ftStep1": "Vous recevez une allocation pour une période donnée. Au lieu d'obtenir le montant total en une fois, les actifs deviennent disponibles par parties au fil du temps.",
+        "ftStep2": "Lorsque la date de la prochaine libération arrive, cette portion de tokens est automatiquement déverrouillée et déplacée vers le solde de votre trésorerie.",
+        "ftStep3": "Une fois qu'ils apparaissent dans votre solde, vous pouvez immédiatement les utiliser pour des paiements, des transferts ou d'autres transactions.",
+        "nearStep1": "Vous recevez une allocation pour une période définie avec une date de début et de fin précises.",
+        "nearStep2": "À mesure que les tokens se déverrouillent, ils deviennent automatiquement disponibles dans le solde de votre trésorerie.",
+        "nearStep3": "Vous pouvez utiliser les tokens déverrouillés immédiatement pour des paiements, des transferts ou d'autres transactions.",
+        "notAvailable": "N/D",
+        "everyMonth": "Chaque mois",
+        "everyQuarter": "Chaque trimestre",
+        "everyUnit": "Chaque {unit}",
+        "everyMultiple": "Chaque {text}",
+        "completed": "Terminé",
+        "unit": {
+            "year": "{count, plural, one {# an} other {# ans}}",
+            "day": "{count, plural, one {# jour} other {# jours}}",
+            "hour": "{count, plural, one {# heure} other {# heures}}",
+            "minute": "{count, plural, one {# minute} other {# minutes}}",
+            "second": "{count, plural, one {# seconde} other {# secondes}}"
+        }
+    },
+    "vestingDetails": {
+        "title": "Détails du vesting",
+        "availableToUse": "Disponible à utiliser",
+        "vestingPeriod": "Période de vesting",
+        "vestingPeriodDescription": "Les tokens se déverrouillent quotidiennement pendant cette période.",
+        "startDate": "Date de début",
+        "endDate": "Date de fin",
+        "tokenBreakdown": "Détail du token",
+        "originalVestedAmount": "Montant initial acquis",
+        "reservedForStorage": "Réservé pour le stockage",
+        "reservedForStorageInfo": "Une petite quantité de tokens nécessaire pour maintenir le vesting actif et couvrir les coûts de stockage.",
+        "percentVested": "{percent}% acquis",
+        "vestedOf": "{vested} sur {total} {symbol}",
+        "send": "Envoyer"
+    },
+    "earningPoolDetails": {
+        "balance": "Solde",
+        "apy": "APY",
+        "fee": "Frais",
+        "notAvailable": "N/D",
+        "lockupStakingPool": "Pool de staking de lockup",
+        "lockupAssetsNote": "Tous les actifs de cette position proviennent de votre lockup. Après avoir arrêté de gagner, certains tokens peuvent encore être verrouillés et indisponibles - consultez votre calendrier de lockup pour voir quand ils se déverrouillent."
+    },
+    "onboardingQuestions": {
+        "stepTitle": "Quelques questions rapides pour commencer.",
+        "other": "Autre",
+        "placeholders": {
+            "describeRole": "Décrivez votre rôle (facultatif)",
+            "describeUseCase": "Décrivez votre cas d'usage (facultatif)",
+            "networkName": "Saisissez le nom du réseau (facultatif)",
+            "currentChallenge": "Saisissez votre défi actuel (facultatif)",
+            "describeOther": "Décrivez autre (facultatif)"
+        },
+        "questions": {
+            "role": "Qu'est-ce qui décrit le mieux votre rôle ?",
+            "useCases": "Pour quoi prévoyez-vous d'utiliser Trezu ?",
+            "teamSize": "Combien de personnes géreront la trésorerie ?",
+            "networks": "Quels réseaux utilisez-vous le plus souvent ?",
+            "multisigExperience": "Quelle est votre expérience avec le multisig ?",
+            "currentTools": "Quels outils utilisez-vous actuellement pour gérer les finances ?",
+            "monthlyVolume": "Volume mensuel de transactions approximatif ?",
+            "biggestChallenges": "Quel est votre plus grand défi en ce moment ?"
+        },
+        "options": {
+            "role": {
+                "founder": "Fondateur",
+                "co-founder": "Cofondateur",
+                "cfo-finance-lead": "CFO / Responsable financier",
+                "operations-manager": "Responsable des opérations",
+                "treasury-manager": "Responsable de trésorerie",
+                "other": "Autre"
+            },
+            "useCases": {
+                "team-payroll-grants": "Paie d'équipe et subventions",
+                "company-assets-management": "Gestion des actifs d'entreprise",
+                "dao-treasury-management": "Gestion de trésorerie DAO",
+                "investment-portfolio": "Portefeuille d'investissement",
+                "operational-spending": "Dépenses opérationnelles",
+                "other": "Autre"
+            },
+            "teamSize": {
+                "just-me": "Juste moi",
+                "2-5-people": "2-5 personnes",
+                "6-15-people": "6-15 personnes",
+                "15-plus-people": "15+"
+            },
+            "networks": {
+                "near": "NEAR",
+                "bitcoin": "Bitcoin",
+                "ethereum": "Ethereum",
+                "solana": "Solana",
+                "arbitrum": "Arbitrum",
+                "base": "Base",
+                "optimism": "Optimism",
+                "polygon": "Polygon",
+                "gnosis": "Gnosis",
+                "avalanche": "Avalanche",
+                "bnb-chain": "BNB Chain",
+                "other": "Autre"
+            },
+            "multisigExperience": {
+                "never-heard-of-it": "Jamais entendu parler",
+                "heard-about-it": "Entendu parler",
+                "never-used-it": "Jamais utilisé",
+                "used-gnosis-safe-or-similar": "Utilisé Gnosis Safe ou similaire",
+                "experienced": "Expérimenté",
+                "looking-for-a-better-option": "À la recherche d'une meilleure option"
+            },
+            "currentTools": {
+                "gnosis-safe": "Gnosis Safe",
+                "fireblocks": "Fireblocks",
+                "tholos": "Tholos",
+                "squads-multisig": "Squads Multisig",
+                "mpc-vault": "MPC Vault",
+                "other": "Autre"
+            },
+            "monthlyVolume": {
+                "under-10k": "Moins de 10 000 $",
+                "10k-100k": "10 000 $ - 100 000 $",
+                "100k-1m": "100 000 $ - 1 M$",
+                "1m-plus": "1 M$+"
+            },
+            "biggestChallenges": {
+                "slow-approvals-and-signing": "Approbations et signatures lentes",
+                "lack-of-transparency-in-the-team": "Manque de transparence dans l'équipe",
+                "hard-to-track-spending-and-balances": "Difficile de suivre les dépenses et les soldes",
+                "security-and-access-control": "Sécurité et contrôle d'accès",
+                "no-good-web3-tool-yet": "Pas encore de bon outil Web3",
+                "looking-for-crypto-earnings": "Je cherche des gains en crypto",
+                "other": "Autre"
+            }
+        }
+    },
+    "onboarding": {
+        "tour": {
+            "addAssets": "Ajoutez des actifs à votre trésorerie en effectuant un dépôt.",
+            "makeRequests": "Effectuez des demandes de paiement chaque fois que vous devez envoyer des actifs.",
+            "exchangeAssets": "Vous pouvez ici échanger vos actifs.",
+            "addMembers": "Ajoutez des membres à votre trésorerie et attribuez-leur des rôles.",
+            "newTreasury": "Vous voulez configurer une nouvelle trésorerie ? Vous pouvez le faire ici en quelques clics.",
+            "helpSupport": "Obtenez de l'aide et du support chaque fois que vous en avez besoin."
+        },
+        "tourCard": {
+            "close": "Fermer",
+            "stepProgress": "{current} sur {total}",
+            "gotIt": "Compris",
+            "done": "Terminé",
+            "next": "Suivant"
+        },
+        "progress": {
+            "title": "Suivez les étapes rapides pour explorer la trésorerie",
+            "createTreasuryTitle": "Créer un compte de trésorerie",
+            "createTreasuryDescription": "Vous avez configuré votre compte avec succès. Excellent début !",
+            "addAssetsTitle": "Ajoutez vos actifs",
+            "addAssetsDescription": "Commencez par ajouter des actifs pour les voir en action.",
+            "deposit": "Dépôt",
+            "createPaymentTitle": "Créer une demande de paiement",
+            "createPaymentDescription": "Créez une demande de paiement pour terminer votre configuration.",
+            "send": "Envoyer"
+        },
+        "welcome": {
+            "heading": "🎉 Bienvenue !",
+            "subheading": "Faites une visite rapide de la trésorerie",
+            "body": "Bonjour ! Votre Trezu est prêt - commencez à constituer votre portefeuille en ajoutant des actifs depuis les réseaux pris en charge.",
+            "progress": "{current} sur {total}",
+            "next": "Suivant",
+            "body2": "Découvrez comment effectuer un dépôt, créer une demande et configurer un nouveau compte.",
+            "noThanks": "Non, merci",
+            "letsGo": "C'est parti"
+        },
+        "congrats": {
+            "heading": "🎉 Félicitations !",
+            "body": "Vous avez terminé la configuration de votre trésorerie. Profitez d'une gestion facile de vos actifs.",
+            "letsGo": "C'est parti !"
+        },
+        "createBanner": {
+            "close": "Fermer",
+            "title": "Explorer Trezu",
+            "description": "Créez un compte pour débloquer les autorisations à toutes les fonctionnalités et avantages de Trezu.",
+            "cta": "Créer une trésorerie"
+        },
+        "questionnaire": {
+            "continue": "Continuer",
+            "skip": "Passer"
+        },
+        "createPrompt": {
+            "title": "Vous y êtes presque",
+            "description": "Votre portefeuille est connecté, mais vous n'avez pas encore créé de trésorerie. Créez un compte pour commencer à utiliser Trezu, ou {suffix}",
+            "suffixDemo": "consultez la démo.",
+            "suffixExploring": "continuez à explorer.",
+            "createCta": "Créer une trésorerie",
+            "viewDemo": "Voir la démo",
+            "keepExploring": "Continuer à explorer"
+        },
+        "infoBox": {
+            "title": "Tirez le meilleur parti de Trezu",
+            "close": "Fermer",
+            "description": "Découvrez comment d'autres utilisent la trésorerie, essayez la démo et consultez la documentation pour découvrir les fonctionnalités.",
+            "demoTitle": "Explorer la démo Trezu",
+            "demoDescription": "Voyez un compte de démo en direct en action.",
+            "docsTitle": "Documentation",
+            "docsDescription": "Découvrez toutes les fonctionnalités dans la documentation.",
+            "videoTitle": "Regarder la démo",
+            "videoDescription": "Regardez une courte vidéo montrant comment Trezu fonctionne."
+        }
+    }
+}

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -44,7 +44,16 @@
         "english": "English",
         "spanish": "Español",
         "ukrainian": "Українська",
-        "hebrew": "עברית"
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
     },
     "header": {
         "toggleSidebar": "הצג/הסתר סרגל צד",
@@ -634,7 +643,6 @@
             "approvalsReceived": "{received}/{required} אישורים התקבלו",
             "expiresAt": "פג תוקף ב-",
             "expiredAt": "פג תוקף ב-",
-            "viewTransaction": "הצג עסקה",
             "exchangingTokens": "מחליף טוקנים",
             "exchangingTokensBody": "בקשה זו אושרה על ידי הצוות. החלפת הטוקנים מתבצעת כעת ועשויה לקחת זמן מה.",
             "requestFailed": "הבקשה נכשלה",
@@ -642,7 +650,6 @@
             "votingPeriod24h": "תקופת הצבעה: 24 שעות",
             "votingPeriod24hBody": "לבקשת החלפה זו יש משך הצבעה של 24 שעות. אשר בקשה זו בתוך זמן זה, אחרת הבקשה תפוג.",
             "reject": "דחייה",
-            "deposit": "הפקדה",
             "approve": "אישור"
         },
         "insufficientBalance": {
@@ -1487,6 +1494,8 @@
         "selectPlaceholder": "בחר רשת",
         "title": "בחר רשת",
         "available": "זמין",
+        "fromAddressBook": "מספר הכתובות",
+        "otherAvailable": "זמינים אחרים",
         "incompatible": "לא תואם",
         "comingSoon": "בקרוב",
         "nearComName": "near.com",

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -1,0 +1,2101 @@
+{
+    "common": {
+        "loading": "Memuat...",
+        "notAvailable": "T/A",
+        "connecting": "Menghubungkan...",
+        "save": "Simpan",
+        "cancel": "Batal",
+        "submit": "Kirim",
+        "close": "Tutup",
+        "back": "Kembali",
+        "seeDemo": "Lihat Demo Trezu",
+        "search": "Cari",
+        "filter": "Filter",
+        "filterActive": "Filter (aktif)",
+        "export": "Ekspor",
+        "exporting": "Mengekspor",
+        "import": "Impor",
+        "remove": "Hapus",
+        "removing": "Menghapus...",
+        "edit": "Ubah",
+        "continue": "Lanjutkan",
+        "select": "Pilih",
+        "all": "Semua",
+        "none": "Tidak ada",
+        "retry": "Coba lagi",
+        "tryAgain": "Silakan coba lagi.",
+        "confirm": "Konfirmasi",
+        "next": "Berikutnya",
+        "previous": "Sebelumnya",
+        "yes": "Ya",
+        "no": "Tidak",
+        "approve": "Setujui",
+        "reject": "Tolak",
+        "copy": "Salin",
+        "copied": "Tersalin",
+        "viewAll": "Lihat Semua",
+        "viewDetails": "Lihat detail",
+        "noResults": "Tidak ada hasil ditemukan",
+        "add": "Tambah"
+    },
+    "languageSwitcher": {
+        "label": "Bahasa",
+        "select": "Pilih bahasa",
+        "english": "English",
+        "spanish": "Español",
+        "ukrainian": "Українська",
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
+    },
+    "header": {
+        "toggleSidebar": "Alihkan bilah samping",
+        "toggleTheme": "Alihkan tema"
+    },
+    "nav": {
+        "dashboard": "Dasbor",
+        "requests": "Permintaan",
+        "payments": "Pembayaran",
+        "exchange": "Tukar",
+        "addressBook": "Buku Alamat",
+        "members": "Anggota",
+        "settings": "Pengaturan",
+        "helpSupport": "Bantuan & Dukungan",
+        "saveGuestTreasury": "Simpan treasury tamu ini ke daftar treasury Anda."
+    },
+    "signIn": {
+        "connect": "Hubungkan",
+        "connectWallet": "Hubungkan Dompet",
+        "wallet": "Dompet",
+        "termsOfService": "Ketentuan Layanan",
+        "privacyPolicy": "Kebijakan Privasi",
+        "disconnect": "Putuskan"
+    },
+    "auth": {
+        "noWallet": "Hubungkan dompet Anda",
+        "noPermission": "Anda tidak memiliki izin untuk melakukan tindakan ini",
+        "noVote": "Anda sudah memberikan suara pada usulan ini",
+        "noSponsoredTransactions": "Tidak ada transaksi tersponsor yang tersisa"
+    },
+    "landing": {
+        "welcome": "Selamat datang di Trezu",
+        "chooseOption": "Pilih salah satu opsi di bawah untuk memulai.",
+        "newUserTitle": "Saya baru di Trezu",
+        "newUserDescription": "Saya pernah mendengar tentang Trezu tetapi belum memiliki treasury.",
+        "existingUserTitle": "Saya sudah menggunakan Trezu",
+        "existingUserDescription": "Saya memiliki akun dan mengelola treasury.",
+        "gradientTagline": "Keamanan multisig lintas-rantai untuk mengelola aset digital",
+        "waitlistTitle": "Bergabung dengan Daftar Tunggu Trezu",
+        "waitlistSubmittedTitle": "Anda sudah masuk daftar 🎉",
+        "waitlistSubmittedDescription": "Terima kasih! Kami akan memberi tahu Anda segera setelah pembuatan treasury tersedia.",
+        "waitlistDescription": "Kami telah mencapai batas treasury hari ini. Tidak masalah - coba lagi nanti atau tinggalkan kontak Anda untuk bergabung dengan daftar tunggu. Kami akan memberi tahu Anda saat tersedia tempat.",
+        "waitlistInputPlaceholder": "Alamat email atau Telegram (mis. @username)",
+        "waitlistPrivacyNote": "Kami hanya akan menggunakan ini untuk memberi tahu Anda",
+        "waitlistSubmit": "Bergabung dengan Daftar Tunggu",
+        "waitlistSubmitFailed": "Gagal mengirim. Silakan coba lagi.",
+        "welcomeAlt": "selamat datang"
+    },
+    "blocked": {
+        "title": "Layanan tidak tersedia di negara Anda",
+        "description": "Karena pembatasan, layanan ini saat ini tidak tersedia di wilayah Anda."
+    },
+    "notFound": {
+        "title": "Wah, halaman ini hilang...",
+        "description": "Sepertinya Anda mengikuti tautan yang sudah tidak berfungsi. Coba kembali atau pergi ke Dasbor.",
+        "backToDashboard": "Kembali ke Dasbor"
+    },
+    "treasuryInfo": {
+        "logoAlt": "Logo Treasury"
+    },
+    "dateInput": {
+        "placeholder": "dd/mm/yyyy"
+    },
+    "thresholdSlider": {
+        "warningSingleMember": "Ambang batas 1-dari-{memberCount} berarti satu anggota mana pun dapat mengeksekusi transaksi. Ini mengurangi keamanan.",
+        "infoBalanced": "Ambang batas {currentThreshold}-dari-{memberCount} memberikan keseimbangan yang baik antara keamanan dan fleksibilitas operasional."
+    },
+    "intentsFee": {
+        "amountTooLowForFee": "{prefix}Jumlah terlalu rendah untuk biaya jaringan ({fee} {symbol}). Tambahkan minimal {addMore} {symbol}."
+    },
+    "metadata": {
+        "treasuryTitle": "Dasbor | Trezu",
+        "landingTitle": "Trezu | Manajemen Treasury Lintas-rantai",
+        "description": "Kelola modal tim Anda dalam hitungan menit dari satu dasbor tanpa harus menyerahkan kunci Anda.",
+        "ogTitle": "Trezu | Satu multisig. Semua kripto. Kendali penuh."
+    },
+    "pages": {
+        "dashboard": {
+            "title": "Dasbor",
+            "description": "Ringkasan aset dan aktivitas treasury Anda",
+            "descriptionLong": "Kelola aset treasury Anda dan lacak aktivitas"
+        },
+        "activity": {
+            "title": "Transaksi Terbaru",
+            "descriptionDetails": "Detail Permintaan",
+            "descriptionList": "Transaksi terbaru di semua aset"
+        },
+        "requests": {
+            "title": "Permintaan",
+            "description": "Lihat dan kelola semua permintaan multisig yang tertunda",
+            "detailDescription": "Detail Permintaan",
+            "detailTitle": "Permintaan #{id}"
+        },
+        "members": {
+            "title": "Anggota",
+            "description": "Kelola anggota tim dan izin"
+        },
+        "settings": {
+            "title": "Pengaturan",
+            "description": "Sesuaikan pengaturan aplikasi Anda"
+        },
+        "addressBook": {
+            "title": "Buku Alamat",
+            "description": "Kelola penerima yang Anda simpan"
+        },
+        "payments": {
+            "title": "Pembayaran",
+            "description": "Kirim dan terima dana dengan aman"
+        },
+        "exchange": {
+            "title": "Tukar",
+            "description": "Tukar token Anda dengan aman dan efisien"
+        },
+        "vesting": {
+            "title": "Vesting",
+            "description": "Buat jadwal vesting dengan cepat dan mudah"
+        },
+        "earn": {
+            "title": "Pendapatan",
+            "description": "Dapatkan imbalan atas aset Anda",
+            "placeholder": "Jelajahi peluang pendapatan dan imbalan staking."
+        },
+        "createTreasury": {
+            "title": "Buat Treasury",
+            "description": "Siapkan treasury multisig baru untuk tim Anda"
+        },
+        "manageTreasuries": {
+            "title": "Kelola Treasury",
+            "description": "Kontrol treasury mana yang muncul di akun Anda"
+        },
+        "stats": {
+            "title": "Statistik",
+            "description": "Aset di bawah pengelolaan secara real-time di semua treasury sputnik DAO."
+        },
+        "telegram": {
+            "title": "Hubungkan Treasury",
+            "description": "Tautkan treasury Anda ke chat Telegram",
+            "metaTitle": "Trezu — Hubungkan Telegram",
+            "metaDescription": "Hubungkan treasury Trezu Anda ke chat Telegram"
+        },
+        "wallet": {
+            "title": "Dompet Trezu",
+            "description": "Tandatangani usulan treasury via Trezu"
+        }
+    },
+    "depositModal": {
+        "validation": {
+            "selectAsset": "Silakan pilih aset",
+            "selectNetwork": "Silakan pilih jaringan"
+        },
+        "sections": {
+            "supportedNetworks": "Jaringan yang Didukung",
+            "networksWithAssets": "Jaringan dengan Aset",
+            "yourAssets": "Aset Anda",
+            "otherAssets": "Aset Lainnya"
+        },
+        "errors": {
+            "addressUnavailable": "Tidak dapat mengambil alamat deposit untuk aset dan jaringan yang dipilih.",
+            "fetchFailed": "Gagal mengambil alamat deposit. Silakan coba lagi."
+        },
+        "title": "Deposit",
+        "subtitle": "Pilih aset dan jaringan untuk melihat alamat deposit",
+        "assetLabel": "Aset",
+        "networkLabel": "Jaringan",
+        "selectAsset": "Pilih Aset",
+        "selectNetwork": "Pilih Jaringan",
+        "otherAssetName": "Lainnya",
+        "otherNetworkInfo": "Anda dapat mendepositkan token apa pun yang tidak tercantum dalam aset, tetapi hanya melalui jaringan NEAR.",
+        "depositAddressHeading": "Alamat Deposit",
+        "depositAddressSubtitle": "Selalu periksa kembali alamat deposit Anda.",
+        "addressLabel": "Alamat",
+        "addressCopied": "Alamat disalin ke papan klip",
+        "memoLabel": "Memo",
+        "memoCopied": "Memo disalin ke papan klip",
+        "memoWarning": "Anda <bold>harus</bold> menyertakan memo saat mengirim dana ke alamat ini. Mengirim tanpa memo dapat mengakibatkan kehilangan dana secara permanen.",
+        "onlyDeposit": "Hanya deposit <symbolTag>{symbol}</symbolTag> dari jaringan <networkTag>{network}</networkTag>. Kami sarankan memulai dengan transaksi uji coba kecil untuk memastikan semuanya berjalan dengan benar sebelum mengirim jumlah penuh.",
+        "minimumDeposit": "Deposit minimum adalah <amountTag>{amount} {symbol}</amountTag>",
+        "searchByName": "Cari berdasarkan nama"
+    },
+    "assetDetails": {
+        "coinPrice": "Harga Koin",
+        "weight": "Bobot",
+        "source": "Sumber",
+        "send": "Kirim",
+        "exchange": "Tukar",
+        "comingSoon": "Segera hadir",
+        "vesting": "Vesting",
+        "vestedPercent": "{percent}% Tervesting",
+        "frozen": "Dibekukan",
+        "frozenTooltip": "Token yang dibekukan terkunci dan tidak dapat digunakan. Mereka mungkin terkunci karena digunakan untuk penyimpanan, di-staking, atau belum tervesting.",
+        "vested": "Tervesting"
+    },
+    "dashboard": {
+        "overview": "Ringkasan aset dan aktivitas treasury Anda",
+        "assets": "Aset",
+        "balance": "Saldo",
+        "totalBalance": "Saldo Total",
+        "deposit": "Deposit",
+        "addAssets": "Tambah aset",
+        "hidden": "Tersembunyi",
+        "confidentialHidden": "Saldo disembunyikan untuk treasury rahasia",
+        "recentActivity": "Aktivitas Terbaru",
+        "viewAllTransactions": "Lihat semua transaksi"
+    },
+    "activity": {
+        "filters": {
+            "createdDate": "Tanggal Dibuat",
+            "token": "Token",
+            "from": "Dari",
+            "to": "Ke"
+        },
+        "tabs": {
+            "all": "Semua",
+            "sent": "Terkirim",
+            "received": "Diterima",
+            "stakingRewards": "Imbalan Staking",
+            "exchange": "Tukar"
+        },
+        "searchPlaceholder": "Cari berdasarkan hash transaksi",
+        "searchPlaceholderShort": "Hash transaksi",
+        "fromPool": "dari {pool}",
+        "table": {
+            "type": "TIPE",
+            "transaction": "TRANSAKSI",
+            "from": "DARI",
+            "to": "KE",
+            "transactionHash": "HASH TRANSAKSI",
+            "hashTooltip": "Pengenal unik (hash) dari transaksi ini"
+        },
+        "empty": {
+            "title": "Tidak ada transaksi ditemukan",
+            "description": "Transaksi Anda akan muncul di sini setelah terjadi"
+        },
+        "emptyDashboard": {
+            "title": "Belum ada apa-apa untuk ditampilkan",
+            "description": "Transaksi dan tindakan Anda akan muncul di sini setelah terjadi"
+        },
+        "recentTitle": "Transaksi Terbaru",
+        "details": {
+            "title": "Detail Transaksi",
+            "copyAddress": "Salin Alamat",
+            "addressCopied": "Alamat disalin ke papan klip",
+            "sell": "Jual",
+            "receive": "Terima",
+            "pending": "Tertunda",
+            "type": "Tipe",
+            "date": "Tanggal",
+            "from": "Dari",
+            "to": "Ke",
+            "method": "Metode",
+            "contract": "Kontrak",
+            "transaction": "Transaksi"
+        }
+    },
+    "export": {
+        "types": {
+            "csv": ".CSV",
+            "json": ".JSON",
+            "xlsx": ".XLSX"
+        },
+        "transactionTypes": {
+            "all": "Semua Tipe",
+            "sent": "Terkirim",
+            "received": "Diterima",
+            "stakingRewards": "Imbalan Staking"
+        },
+        "validation": {
+            "invalidEmail": "Silakan masukkan alamat email yang valid"
+        },
+        "columns": {
+            "submissionTime": "Waktu Pengiriman",
+            "dateRange": "Rentang Tanggal",
+            "generatedBy": "Dibuat Oleh",
+            "status": "Status"
+        },
+        "status": {
+            "generating": "Membuat",
+            "expired": "Kedaluwarsa",
+            "failed": "Gagal"
+        },
+        "noPermission": "Anda tidak memiliki izin untuk mengunduh file.",
+        "download": "Unduh",
+        "heading": "Ekspor Transaksi Terbaru",
+        "teamOnly": "Pembuatan dan pengunduhan ekspor hanya tersedia untuk anggota tim.",
+        "creditsUsed": "Anda telah menggunakan semua kredit Anda",
+        "exportsUsed": "Anda telah menggunakan semua ekspor Anda",
+        "upgradePrompt": "Tingkatkan paket Anda untuk mendapatkan lebih banyak dan terus berlanjut",
+        "resetPrompt": "Tingkatkan paket Anda untuk akses lebih banyak, atau tunggu hingga batas Anda diatur ulang bulan depan.",
+        "tabs": {
+            "generate": "Buat Ekspor",
+            "history": "Riwayat"
+        },
+        "fields": {
+            "documentType": "Tipe Dokumen",
+            "timeRange": "Rentang Waktu",
+            "selectDateRange": "Pilih rentang tanggal",
+            "asset": "Aset",
+            "allAssets": "Semua Aset",
+            "transactionType": "Tipe Transaksi"
+        },
+        "buttons": {
+            "noPermissionExport": "Anda tidak memiliki izin untuk mengekspor",
+            "quotaExhausted": "Anda telah menggunakan semua kuota Anda",
+            "exporting": "Mengekspor...",
+            "export": "Ekspor"
+        },
+        "empty": {
+            "title": "Belum ada ekspor",
+            "description": "File yang Anda ekspor dari bulan terakhir akan muncul di sini setelah dibuat."
+        },
+        "requirements": {
+            "heading": "Persyaratan Ekspor",
+            "canExportFrom": "Anda dapat mengekspor data dari",
+            "availability": "File yang diekspor tersedia untuk diunduh selama 48 jam."
+        },
+        "quota": {
+            "heading": "Kuota Ekspor",
+            "unlimited": "Tidak Terbatas",
+            "perMonth": "{count} / bulan",
+            "flexibilityPrompt": "Mencari fleksibilitas lebih?",
+            "contactUs": "Hubungi Kami"
+        }
+    },
+    "requests": {
+        "filters": {
+            "proposalTypes": {
+                "Payments": "Pembayaran",
+                "Exchange": "Tukar",
+                "Earn": "Pendapatan",
+                "Vesting": "Vesting",
+                "Function Call": "Panggilan Fungsi",
+                "Change Policy": "Ubah Kebijakan",
+                "Settings": "Pengaturan",
+                "Confidential": "Rahasia"
+            },
+            "voteStatus": {
+                "Approved": "Disetujui",
+                "Rejected": "Ditolak",
+                "No Voted": "Belum Memilih"
+            },
+            "requestsType": "Tipe Permintaan",
+            "createdDate": "Tanggal Dibuat",
+            "recipient": "Penerima",
+            "token": "Token",
+            "requester": "Pemohon",
+            "approver": "Penyetuju",
+            "myVoteStatus": "Status Suara Saya",
+            "all": "SEMUA",
+            "amount": "Jumlah",
+            "from": "Dari",
+            "to": "Ke",
+            "min": "Min",
+            "max": "Max",
+            "invalidDate": "Tanggal tidak valid",
+            "operationIsNot": " bukan",
+            "operationBefore": " sebelum",
+            "operationAfter": " setelah",
+            "operationContains": " mengandung",
+            "searchByAddress": "Cari berdasarkan alamat",
+            "loadingMembers": "Memuat anggota...",
+            "noMembersFound": "Tidak ada anggota ditemukan. Tekan Enter untuk menambahkan \"{query}\"",
+            "noMembersAvailable": "Tidak ada anggota yang tersedia",
+            "reset": "Atur Ulang",
+            "clear": "Bersihkan",
+            "addFilter": "Tambah Filter"
+        },
+        "tabs": {
+            "all": "Semua",
+            "pending": "Tertunda",
+            "executed": "Dieksekusi",
+            "rejected": "Ditolak",
+            "expired": "Kedaluwarsa",
+            "failed": "Gagal"
+        },
+        "searchPlaceholder": "Cari permintaan berdasarkan nama atau ID",
+        "searchPlaceholderShort": "Cari berdasarkan nama atau ID",
+        "errorLoading": "Kesalahan saat memuat usulan. Silakan coba lagi.",
+        "empty": {
+            "title": "Buat permintaan pertama Anda",
+            "description": "Permintaan pembayaran, pertukaran, dan tindakan lainnya akan muncul di sini setelah dibuat.",
+            "send": "Kirim",
+            "exchange": "Tukar"
+        },
+        "actions": {
+            "approve": "Setujui",
+            "reject": "Tolak",
+            "deposit": "Deposit",
+            "viewRequest": "Lihat Permintaan"
+        },
+        "table": {
+            "selectAll": "Pilih semua",
+            "selectRow": "Pilih baris",
+            "request": "Permintaan",
+            "transaction": "Transaksi",
+            "requester": "Pemohon",
+            "voting": "Pemungutan Suara",
+            "votingTooltip": "Angka pertama menunjukkan persetujuan yang diterima. Angka kedua menunjukkan persetujuan yang diperlukan untuk mengeksekusi.",
+            "status": "Status",
+            "notPending": "Usulan tidak tertunda.",
+            "noPermissionVote": "Anda tidak memiliki izin untuk memilih pada permintaan ini.",
+            "alreadyVoted": "Anda sudah memilih pada permintaan ini.",
+            "noResults": "Tidak ada permintaan yang cocok dengan filter Anda.",
+            "allCaughtUp": "Semua sudah selesai!",
+            "noPending": "Tidak ada permintaan yang tertunda.",
+            "send": "Kirim",
+            "exchange": "Tukar",
+            "requestsSelected": "{count, plural, other {# Permintaan Dipilih}}",
+            "bulkApproveDisabled": "Permintaan ini tidak dapat disetujui karena treasury memiliki saldo yang tidak mencukupi."
+        },
+        "pending": {
+            "title": "Permintaan Tertunda",
+            "viewAll": "Lihat Semua",
+            "emptyTitle": "Semua sudah selesai!",
+            "emptyDescription": "Tidak ada permintaan yang tertunda."
+        }
+    },
+    "proposals": {
+        "status": {
+            "pending": "Tertunda",
+            "approved": "Disetujui",
+            "rejected": "Ditolak",
+            "executed": "Dieksekusi",
+            "expired": "Kedaluwarsa",
+            "failed": "Gagal",
+            "removed": "Dihapus",
+            "inProgress": "Sedang Berlangsung"
+        },
+        "statusTooltip": {
+            "pending": "Permintaan ini masih tertunda dan belum mencapai jumlah suara yang diperlukan untuk eksekusi.",
+            "executed": "Dieksekusi setelah {approved} dari {required} anggota menyetujui permintaan.",
+            "rejected": "Ditolak setelah {rejected} dari {required} anggota memilih untuk menolak permintaan.",
+            "expired": "Kedaluwarsa karena tidak menerima cukup suara untuk dieksekusi.",
+            "failed": "Permintaan gagal diselesaikan. Periksa detail transaksi <link>di sini</link>.",
+            "failedPlain": "Permintaan gagal diselesaikan. Periksa detail transaksi di sini."
+        },
+        "votes": {
+            "approved": "Disetujui",
+            "rejected": "Ditolak",
+            "pending": "Tertunda"
+        },
+        "voteModal": {
+            "confirmTitle": "Konfirmasi Suara Anda",
+            "removeTitle": "Hapus Permintaan",
+            "bulkBody": "Anda akan {action} beberapa permintaan. Setelah dikirim, keputusan ini tidak dapat diubah.",
+            "singleBody": "Anda akan {action} permintaan ini. Setelah dikonfirmasi, tindakan ini tidak dapat dibatalkan.",
+            "actionApprove": "menyetujui",
+            "actionReject": "menolak",
+            "actionRemove": "menghapus",
+            "insufficientBalance": "Permintaan <highlight>{ids}</highlight> tidak dapat disetujui karena saldo tidak mencukupi. Persetujuan Anda hanya akan berlaku untuk permintaan yang tersisa.",
+            "remove": "Hapus",
+            "confirm": "Konfirmasi"
+        },
+        "expanded": {
+            "recipient": "Penerima",
+            "amount": "Jumlah",
+            "networkFee": "Biaya Jaringan",
+            "notes": "Catatan",
+            "sent": "Terkirim",
+            "received": "Diterima",
+            "priceDifference": "Selisih Harga",
+            "priceDifferenceTooltip": "Selisih antara nilai tukar kuotasi dan nilai tukar pasar saat ini. Nilai positif menunjukkan nilai tukar yang lebih baik dari pasar.",
+            "slippageTolerance": "Toleransi Slippage",
+            "estimatedTime": "Estimasi Waktu",
+            "seconds": "{count} detik",
+            "description": "Deskripsi",
+            "methodName": "Nama Metode",
+            "args": "Argumen",
+            "deposit": "Deposit",
+            "gas": "Gas",
+            "totalDeposit": "Total Deposit",
+            "totalGas": "Total Gas",
+            "receiverId": "ID Penerima",
+            "contractId": "ID Kontrak",
+            "actionsCount": "{count, plural, other {# tindakan}}",
+            "functionCallsCount": "{count, plural, other {# panggilan fungsi}}",
+            "showLess": "Tampilkan lebih sedikit",
+            "showMore": "Tampilkan lebih banyak",
+            "stakingPool": "Pool Staking",
+            "validator": "Validator",
+            "action": "Tindakan",
+            "stake": "Stake",
+            "unstake": "Unstake",
+            "withdraw": "Tarik",
+            "lockupOwner": "Pemilik lockup",
+            "lockupDuration": "Durasi lockup",
+            "cliff": "Cliff",
+            "releaseDuration": "Durasi rilis",
+            "vestingSchedule": "Jadwal vesting",
+            "cancellable": "Dapat dibatalkan",
+            "allowEarn": "Izinkan staking",
+            "yes": "Ya",
+            "no": "Tidak",
+            "notSet": "Belum diatur",
+            "from": "Dari",
+            "to": "Ke",
+            "paymentsCount": "{count, plural, other {# pembayaran}}",
+            "sourceWallet": "Dompet Sumber",
+            "allNear": "Semua NEAR",
+            "startDate": "Tanggal Mulai",
+            "endDate": "Tanggal Berakhir",
+            "cliffDate": "Tanggal Cliff",
+            "allowCancellation": "Izinkan Pembatalan",
+            "allowStaking": "Izinkan Staking",
+            "loadingHistorical": "Memuat konfigurasi historis...",
+            "name": "Nama",
+            "purpose": "Tujuan",
+            "logo": "Logo",
+            "logoAlt": "Logo",
+            "primaryColor": "Warna Utama",
+            "noChangesCurrent": "Tidak ada perubahan terdeteksi pada konfigurasi dibandingkan dengan kondisi saat ini.",
+            "noChangesHistorical": "Tidak ada perubahan terdeteksi pada konfigurasi dibandingkan dengan kondisi historis.",
+            "method": "Metode",
+            "arguments": "Argumen",
+            "contract": "Kontrak",
+            "actionNumber": "Tindakan {number}",
+            "actions": "Tindakan",
+            "collapseAll": "Tutup semua",
+            "expandAll": "Buka semua",
+            "send": "Kirim",
+            "receive": "Terima",
+            "rate": "Nilai Tukar",
+            "priceSlippageLimit": "Batas Slippage Harga",
+            "slippageTooltip": "Ini adalah batas slippage yang ditentukan untuk permintaan ini. Jika nilai tukar pasar berubah melampaui ambang ini selama eksekusi, permintaan akan otomatis gagal.",
+            "estimatedTimeTooltip": "Estimasi waktu untuk swap dieksekusi setelah transaksi deposit dikonfirmasi.",
+            "minReceive": "Min. Diterima",
+            "minimumReceived": "Minimum Diterima",
+            "minReceiveTooltip": "Ini adalah jumlah minimum yang akan Anda terima dari pertukaran ini, berdasarkan batas slippage yang ditetapkan untuk permintaan.",
+            "depositAddress": "Alamat Deposit",
+            "depositAddressTooltip": "Alamat deposit 1Click tempat token akan dikirim untuk eksekusi swap lintas-rantai.",
+            "quoteSignature": "Tanda Tangan Kuotasi",
+            "quoteSignatureTooltip": "Tanda tangan kriptografi dari API 1Click yang memvalidasi kuotasi ini.",
+            "quoteDeadline": "Batas Waktu Kuotasi 1-Click",
+            "quoteDeadlineTooltip": "Waktu ketika alamat deposit menjadi tidak aktif dan dana mungkin hilang.",
+            "status": "Status",
+            "transactionLink": "Tautan Transaksi",
+            "viewTransaction": "Lihat Transaksi",
+            "recipientNumber": "Penerima {number}",
+            "oopsTitle": "Ups! Terjadi kesalahan",
+            "oopsDescription": "Kami tidak dapat menemukan data untuk ditampilkan di sini.",
+            "totalAmount": "Jumlah Total",
+            "recipients": "Penerima",
+            "recipientsCount": "{count, plural, other {# penerima}}",
+            "unsupportedProposal": "Tipe usulan tidak didukung",
+            "requestDetails": "Detail Permintaan",
+            "linkCopied": "Tautan disalin ke papan klip",
+            "copyLink": "Salin Tautan",
+            "openRequestPage": "Buka Halaman Permintaan",
+            "deleteRequest": "Hapus Permintaan",
+            "unknownRecipients": "Penerima tidak diketahui",
+            "loadingConfig": "Memuat konfigurasi...",
+            "historicalData": "Data historis...",
+            "generalUpdate": "Pembaruan Umum",
+            "detailsUnavailable": "Detail tidak tersedia",
+            "changesCount": "{count, plural, other {# Perubahan}}",
+            "policyUpdate": "Pembaruan Kebijakan",
+            "noChangesDetected": "Tidak ada perubahan terdeteksi",
+            "loadingPolicy": "Memuat kebijakan...",
+            "roleChanges": "Perubahan Peran",
+            "policyParameters": "Parameter Kebijakan",
+            "defaultVotePolicy": "Kebijakan Suara Default",
+            "policyRoleChanges": "Perubahan Kebijakan & Peran",
+            "membersAdded": "{count, plural, other {# anggota ditambahkan}}",
+            "membersRemoved": "{count, plural, other {# anggota dihapus}}",
+            "membersUpdated": "{count, plural, other {# anggota diperbarui}}",
+            "rolesModified": "{count, plural, other {# peran dimodifikasi}}",
+            "parametersChanged": "{count, plural, other {# parameter diubah}}",
+            "defaultVotePolicyPart": "kebijakan suara default",
+            "onReceiver": "pada {receiver}",
+            "toPrefix": "Ke:",
+            "validatorPrefix": "Validator:",
+            "validatorSubtitle": "Validator: {address}",
+            "impactTitle": "Dampak Perubahan Durasi Pemungutan Suara",
+            "impactBody": "Anda akan memperbarui durasi pemungutan suara. Ini akan memengaruhi permintaan yang ada berikut.",
+            "activeRequestsBullet": "{count, plural, other {# permintaan akan aktif untuk pemungutan suara setelah perubahan ini, dengan tanggal kedaluwarsa yang diperbarui.}}",
+            "expiringRequestsBullet": "{count, plural, other {# permintaan akan ditandai sebagai \"Kedaluwarsa\" di bawah durasi pemungutan suara baru.}}",
+            "remainActiveHeading": "Permintaan yang tetap aktif untuk pemungutan suara dengan tanggal kedaluwarsa baru",
+            "willExpireHeading": "Permintaan yang akan ditandai sebagai \"Kedaluwarsa\"",
+            "tableRequest": "Permintaan",
+            "tableTransaction": "Transaksi",
+            "tableNewExpiry": "Kedaluwarsa Baru",
+            "expireInDays": "{count, plural, other {Kedaluwarsa dalam # hari}}",
+            "today": "Hari ini",
+            "uponApproval": "Saat persetujuan",
+            "yesContinue": "Ya, Lanjutkan",
+            "transactionCreated": "Transaksi Dibuat",
+            "voting": "Pemungutan Suara",
+            "approvalsReceived": "{received}/{required} persetujuan diterima",
+            "expiresAt": "Kedaluwarsa Pada",
+            "expiredAt": "Kedaluwarsa Pada",
+            "exchangingTokens": "Menukar Token",
+            "exchangingTokensBody": "Permintaan ini telah disetujui oleh tim. Pertukaran token sedang berlangsung dan mungkin memerlukan beberapa waktu.",
+            "requestFailed": "Permintaan Gagal",
+            "requestFailedBody": "Tim menyetujui permintaan ini, tetapi gagal karena fluktuasi nilai tukar. Silakan buat permintaan baru dan coba lagi.",
+            "votingPeriod24h": "Periode pemungutan suara: 24 jam",
+            "votingPeriod24hBody": "Permintaan pertukaran ini memiliki durasi pemungutan suara 24 jam. Setujui permintaan ini dalam waktu ini, atau permintaan akan kedaluwarsa.",
+            "reject": "Tolak",
+            "approve": "Setujui"
+        },
+        "insufficientBalance": {
+            "noAsset": "Permintaan ini tidak dapat disetujui karena token yang diperlukan tidak tersedia di treasury.",
+            "bond": "Permintaan ini tidak dapat disetujui karena treasury memiliki saldo <token>{symbol}</token> yang tidak mencukupi. Tambahkan <token>{amount} {symbol}</token> untuk menutupi biaya bond usulan.",
+            "continue": "Permintaan ini tidak dapat disetujui karena treasury memiliki saldo <token>{symbol}</token> yang tidak mencukupi. Tambahkan <token>{amount} {symbol}</token> untuk melanjutkan.",
+            "modalTitle": "Saldo NEAR Tidak Mencukupi",
+            "modalBodyVote": "Anda tidak memiliki cukup token NEAR di dompet Anda untuk memberikan suara ini. Pemungutan suara memerlukan saldo minimum <amount>{required} NEAR</amount>. Silakan tambahkan NEAR ke dompet Anda dan coba lagi.",
+            "modalBodyProposal": "Anda tidak memiliki cukup token NEAR di dompet Anda untuk membuat permintaan ini. Membuat permintaan memerlukan saldo minimum <amount>{required} NEAR</amount>. Silakan tambahkan NEAR ke dompet Anda dan coba lagi.",
+            "gotIt": "Mengerti"
+        }
+    },
+    "members": {
+        "title": "Anggota",
+        "description": "Kelola anggota tim dan izin",
+        "permissions": "Izin",
+        "member": "Anggota",
+        "activeMembers": "Anggota Aktif",
+        "noActiveMembers": "Tidak ada anggota aktif ditemukan.",
+        "addNewMember": "Tambah Anggota Baru",
+        "membersSelected": "{count, plural, =0 {tidak ada anggota} other {# anggota}} dipilih",
+        "remove": "Hapus",
+        "edit": "Ubah",
+        "requestorOnlyTooltip": "Anda hanya dapat menambahkan peran Requestor untuk anggota ini, karena mereka bertanggung jawab membuat permintaan pembayaran dari NEARN.",
+        "memberModal": {
+            "editRoles": "Ubah Peran",
+            "addNewMember": "Tambah Anggota Baru",
+            "validatingAddresses": "Memvalidasi alamat...",
+            "creatingProposal": "Membuat usulan...",
+            "reviewRequest": "Tinjau Permintaan",
+            "noChanges": "Tidak ada perubahan yang dilakukan pada peran anggota"
+        },
+        "previewModal": {
+            "title": "Tinjau Permintaan Anda",
+            "youAreEditing": "Anda sedang mengubah",
+            "youAreAdding": "Anda sedang menambahkan",
+            "membersCount": "{count, plural, other {# anggota}}",
+            "newMembersCount": "{count, plural, other {# anggota baru}}",
+            "updatedMembers": "Anggota yang Diperbarui",
+            "newMembers": "Anggota Baru",
+            "creatingProposal": "Membuat Usulan...",
+            "confirmSubmit": "Konfirmasi dan Kirim Permintaan"
+        },
+        "removeDialog": {
+            "title": "Hapus Permintaan",
+            "nearnBody": "Setelah disetujui, {account} akan dihapus secara permanen dari treasury dan semua izin terkait akan dicabut. Setelah dihapus, akun ini tidak akan dapat lagi membuat permintaan dari NEARN.",
+            "genericBody": "Setelah disetujui, tindakan ini akan menghapus secara permanen <bold>{accounts}</bold> dari treasury dan mencabut semua izin yang ditetapkan.",
+            "creatingProposal": "Membuat Usulan..."
+        },
+        "validation": {
+            "accountIdRequired": "ID Akun diperlukan",
+            "invalidNearAddress": "Alamat NEAR tidak valid.",
+            "atLeastOneRole": "Setidaknya satu peran harus dipilih",
+            "atLeastOneMember": "Setidaknya satu anggota diperlukan",
+            "alreadyAdded": "Anggota ini sudah ditambahkan di atas",
+            "alreadyInTreasury": "Anggota ini sudah ada di treasury",
+            "cannotRemoveRoleAfter": "Anda tidak dapat menghapus peran {role} dari anggota ini. Setelah semua perubahan Anda, mereka akan menjadi satu-satunya orang yang ditugaskan ke peran ini.",
+            "cannotRemoveRoleAfterGov": "Anda tidak dapat menghapus peran {role} dari anggota ini. Setelah semua perubahan Anda, mereka akan menjadi satu-satunya anggota {role}, dan tanpa peran ini Anda tidak akan dapat mengelola anggota tim atau mengonfigurasi pemungutan suara."
+        },
+        "policy": {
+            "addMembers": "Perbarui Kebijakan - Tambah Anggota Baru",
+            "addMembersSuccess": "Permintaan anggota baru berhasil dibuat",
+            "editMember": "Perbarui Kebijakan - Ubah Izin Anggota",
+            "editMembers": "Perbarui Kebijakan - Ubah Beberapa Anggota",
+            "editMemberSuccess": "Permintaan pembaruan peran anggota berhasil dibuat",
+            "editMembersSuccess": "Permintaan pembaruan peran anggota massal berhasil dibuat",
+            "removeMember": "Perbarui Kebijakan - Hapus Anggota",
+            "removeMembers": "Perbarui Kebijakan - Hapus Anggota",
+            "removeMemberSuccess": "Permintaan penghapusan anggota berhasil dibuat"
+        }
+    },
+    "settings": {
+        "tabs": {
+            "general": "Umum",
+            "voting": "Pemungutan Suara",
+            "preferences": "Preferensi",
+            "integrations": "Integrasi"
+        },
+        "general": {
+            "validation": {
+                "displayNameRequired": "Nama tampilan diperlukan",
+                "displayNameMax": "Nama tampilan harus kurang dari 100 karakter"
+            },
+            "proposalDescriptionTitle": "Perbarui Konfigurasi - Tema & logo",
+            "proposalSubmitted": "Permintaan untuk memperbarui konfigurasi telah dikirim",
+            "treasuryNotFound": "Treasury tidak ditemukan",
+            "treasuryName": "Nama Treasury",
+            "treasuryNameDescription": "Nama treasury Anda. Ini akan ditampilkan di seluruh aplikasi.",
+            "displayName": "Nama Tampilan",
+            "displayNamePlaceholder": "Masukkan nama tampilan",
+            "accountName": "Nama Akun",
+            "logo": "Logo",
+            "logoDescription": "Unggah logo untuk treasury Anda. Direkomendasikan SVG, PNG, atau JPG (256x256 px).",
+            "treasuryLogoAlt": "Logo treasury",
+            "uploading": "Mengunggah...",
+            "uploadLogo": "Unggah Logo",
+            "removeLogo": "Hapus Logo",
+            "logoUploaded": "Logo berhasil diunggah",
+            "uploadError": "Terjadi kesalahan saat mengunggah gambar, silakan coba lagi.",
+            "invalidLogo": "Logo tidak valid. Silakan unggah file PNG, JPG, atau SVG yang berukuran tepat 256x256 px",
+            "invalidImage": "File gambar tidak valid. Silakan unggah gambar yang valid.",
+            "fileReadError": "Kesalahan membaca file. Silakan coba lagi.",
+            "primaryColor": "Warna Utama",
+            "primaryColorDescription": "Tetapkan warna utama untuk elemen antarmuka treasury Anda. Warna ini akan digunakan dalam mode terang dan gelap, jadi pertimbangkan kontras saat memilih corak netral.",
+            "selectColorLabel": "Pilih warna {color}"
+        },
+        "voting": {
+            "validation": {
+                "required": "Durasi suara diperlukan",
+                "validNumber": "Durasi suara harus berupa angka yang valid",
+                "min": "Durasi suara harus minimal 1 hari",
+                "max": "Durasi suara harus kurang dari 1000 hari",
+                "whole": "Durasi suara harus berupa hari penuh"
+            },
+            "missingData": "Data yang diperlukan hilang",
+            "thresholdProposalTitle": "Perbarui kebijakan - Ambang Pemungutan Suara",
+            "thresholdProposalSummary": "{account} meminta untuk mengubah ambang pemungutan suara dari {oldValue} menjadi {newValue}.",
+            "thresholdSubmitted": "Permintaan untuk memperbarui ambang pemungutan suara telah dikirim",
+            "createProposalFailed": "Gagal membuat usulan",
+            "durationProposalTitle": "Perbarui kebijakan - Durasi Pemungutan Suara",
+            "durationProposalSummary": "{account} meminta untuk mengubah durasi pemungutan suara dari {oldValue} menjadi {newValue}.",
+            "durationSubmitted": "Permintaan berhasil dibuat",
+            "pendingTitle": "Permintaan Ambang Pemungutan Suara Aktif",
+            "pendingBody": "Untuk menghindari konflik, Anda perlu menyelesaikan atau menyelesaikan permintaan tertunda yang ada sebelum melanjutkan. Permintaan ini saat ini aktif dan harus disetujui atau ditolak terlebih dahulu.",
+            "viewRequest": "Lihat Permintaan",
+            "thresholdHeading": "Ambang Pemungutan Suara",
+            "thresholdDescriptionApprovers": "Tentukan berapa banyak suara yang diperlukan untuk menyetujui permintaan pembayaran dan terkait tim. Konfigurasikan ambang secara terpisah untuk Approver dan Governance.",
+            "thresholdDescriptionGeneric": "Tentukan berapa banyak suara yang diperlukan untuk menyetujui permintaan. Konfigurasikan ambang untuk setiap peran berdasarkan tanggung jawab mereka.",
+            "membersWhoCanVote": "Anggota yang dapat memilih",
+            "votesRequired": "Suara diperlukan untuk menyetujui permintaan",
+            "durationHeading": "Durasi Pemungutan Suara",
+            "durationDescription": "Lamanya waktu (dalam hari) sebuah usulan akan tetap terbuka untuk pemungutan suara. Jika pemungutan suara tidak selesai dalam periode ini, keputusan akan kedaluwarsa.",
+            "durationApprovers": " Durasi ini berlaku sama untuk peran Governance dan Approver.",
+            "durationGeneric": " Durasi ini konsisten di semua peran treasury.",
+            "days": "Hari"
+        },
+        "preferences": {
+            "timeZone": "Zona Waktu",
+            "timeZoneDescription": "Tetapkan zona waktu lokal Anda untuk tampilan tanggal dan waktu yang akurat.",
+            "timeFormat": "Format Waktu",
+            "hour12": "12 jam (1:00 PM)",
+            "hour24": "24 jam (13:00)",
+            "autoTimezone": "Atur zona waktu otomatis menggunakan lokasi Anda",
+            "timezone": "Zona Waktu",
+            "loadingTimezones": "Memuat zona waktu...",
+            "selectTimezone": "Pilih Zona Waktu",
+            "searchTimezones": "Cari zona waktu...",
+            "noTimezones": "Tidak ada zona waktu ditemukan",
+            "save": "Simpan",
+            "savedToast": "Preferensi berhasil disimpan",
+            "saveFailed": "Gagal menyimpan preferensi",
+            "loadFailed": "Gagal memuat zona waktu"
+        }
+    },
+    "addressBook": {
+        "emptyTitle": "Tambahkan penerima pertama Anda",
+        "emptyDescription": "Simpan alamat yang sering digunakan untuk pembayaran yang lebih cepat dan bebas kesalahan. Kontak Anda tetap pribadi dan hanya terlihat oleh tim Anda.",
+        "import": "Impor",
+        "addRecipient": "Tambah Penerima",
+        "recipientsHeading": "Penerima",
+        "recipientsSelected": "{count, plural, =0 {tidak ada penerima} other {# penerima}} dipilih",
+        "sectionHeading": "Penerima",
+        "privacyNote": "Alamat yang disimpan bersifat pribadi dan hanya terlihat oleh tim Anda.",
+        "searchPlaceholder": "Cari penerima berdasarkan nama",
+        "searchPlaceholderShort": "Cari",
+        "review": {
+            "header": "Tinjau Detail",
+            "youAreAdding": "Anda menambahkan",
+            "newRecipients": "{count, plural, other {# penerima baru}}",
+            "onNetworks": "di {count, plural, other {# jaringan}}",
+            "recipients": "Penerima",
+            "allDuplicates": "Semua penerima yang diimpor sudah ada di buku alamat Anda. Kembali untuk mengunggah daftar berbeda atau hapus duplikat dari tinjauan ini.",
+            "someDuplicates": "{duplicates} penerima duplikat dari total {total} penerima. Lanjutkan untuk mengunggah hanya penerima baru.",
+            "duplicated": "Duplikat",
+            "notePlaceholder": "Tambahkan catatan untuk membantu mengidentifikasi penerima ini (mis. pembayaran kontraktor, distribusi vesting).",
+            "skipDuplicates": "Lewati duplikat dan hanya impor yang baru.",
+            "allDuplicatesTooltip": "Semua penerima yang diimpor sudah ada di buku alamat Anda, jadi tidak ada yang baru untuk diimpor.",
+            "duplicateActionTooltip": "Aktifkan lewati duplikat atau hapus penerima duplikat untuk melanjutkan.",
+            "adding": "Menambahkan…",
+            "nothingNew": "Tidak Ada yang Baru untuk Diimpor",
+            "addRecipientsButton": "{count, plural, other {Tambah Penerima}}"
+        },
+        "removeDialog": {
+            "title": "Hapus Penerima",
+            "bulk": "Ini akan menghapus <bold>{count, plural, other {# penerima}}</bold> dari buku alamat Anda. Anda dapat menambahkannya lagi kapan saja.",
+            "single": "Ini akan menghapus <bold>{name}</bold> dari buku alamat Anda. Anda dapat menambahkan penerima ini lagi kapan saja."
+        },
+        "importFlow": {
+            "title": "Impor Penerima",
+            "description": "Unggah daftar alamat penerima ke buku alamat Anda.",
+            "foundSummary": "Ditemukan {count, plural, other {# penerima}} di {networkCount, plural, other {# jaringan}}",
+            "uploadPrompt": "Unggah atau tempel data penerima",
+            "fixErrors": "Perbaiki kesalahan untuk melanjutkan",
+            "continueReview": "Lanjutkan ke Tinjauan"
+        },
+        "form": {
+            "editRecipient": "Ubah Penerima",
+            "addRecipient": "Tambah Penerima",
+            "import": "Impor",
+            "recipientName": "Nama Penerima",
+            "namePlaceholder": "Alice",
+            "recipientAddress": "Alamat Penerima",
+            "network": "Jaringan",
+            "networkInfo": "Jaringan yang kompatibel dengan alamat ini",
+            "enterAddressFirst": "Masukkan alamat penerima terlebih dahulu",
+            "selectNetwork": "Pilih jaringan",
+            "selectNetworksTitle": "Pilih Jaringan",
+            "searchNetworksPlaceholder": "Cari jaringan…",
+            "done": "Selesai",
+            "edit": "Ubah",
+            "remove": "Hapus",
+            "incomplete": "Tidak lengkap",
+            "addAnother": "Tambah Penerima Lain",
+            "fillAllTooltip": "Anda harus mengisi semua kolom untuk menambahkan penerima.",
+            "reviewDetails": "Tinjau Detail",
+            "reviewTooltip": "Semua penerima harus lengkap sebelum ditinjau.",
+            "invalidAddress": "Alamat tidak valid",
+            "noCompatibleNetworks": "Tidak ada jaringan yang kompatibel untuk alamat ini"
+        },
+        "parsing": {
+            "rowPrefix": "Baris {row}: {message}",
+            "missingName": "Nama penerima hilang. Silakan tambahkan nama.",
+            "missingAddress": "Alamat penerima hilang. Silakan tambahkan alamat dompet.",
+            "invalidAddressFormat": "Alamat \"{address}\" bukan format yang valid untuk jaringan yang didukung.",
+            "unknownNetwork": "Jaringan tidak dikenal \"{network}\". Jaringan yang didukung meliputi: {available}.",
+            "incompatibleNetwork": "Alamat \"{address}\" tidak kompatibel dengan {network}. Jaringan yang kompatibel: {compatible}.",
+            "noDataFound": "Tidak ada data ditemukan. Silakan tambahkan penerima dalam format ini: Name, Address, Network, Note",
+            "headerColumnsNotFound": "Kami mendeteksi baris header, tetapi tidak dapat menemukan kolom 'Name' dan 'Address'. Silakan gunakan nama kolom ini, atau hapus baris header.",
+            "failedToParseCsv": "Gagal mengurai data CSV"
+        }
+    },
+    "payments": {
+        "validation": {
+            "recipientMin": "Penerima harus minimal 2 karakter",
+            "recipientMax": "Penerima harus kurang dari 128 karakter",
+            "amountPositive": "Jumlah harus lebih besar dari 0",
+            "recipientTokenSame": "Alamat penerima dan token tidak boleh sama"
+        },
+        "newPayment": "Pembayaran Baru",
+        "reviewYourPayment": "Tinjau Pembayaran Anda",
+        "reviewButton": "Tinjau Pembayaran",
+        "reviewButtonDisabled": "Masukkan jumlah dan alamat",
+        "comingSoon": "Segera hadir",
+        "bulkPayments": "Pembayaran Massal",
+        "summaryRecipients": "ke {count, plural, other {# penerima}}",
+        "networkFee": "Biaya Jaringan",
+        "networkFeeInfo": "Info biaya jaringan",
+        "commentPlaceholder": "Tambahkan komentar (opsional)...",
+        "preparingRoute": "Menyiapkan rute transfer 1Click...",
+        "confirmSubmit": "Konfirmasi dan Kirim Permintaan",
+        "useDifferentAddress": "Gunakan alamat berbeda",
+        "failed1ClickQuote": "Gagal membuat kuotasi transfer 1Click",
+        "paymentSubmitted": "Permintaan untuk mengirim pembayaran telah dikirim"
+    },
+    "bulkPayment": {
+        "comingSoonToast": "Pembayaran massal akan segera hadir!",
+        "submittingList": "Mengirim daftar pembayaran massal",
+        "submittingProposal": "Mengirim usulan",
+        "proposalSubmitted": "Usulan pembayaran massal telah dikirim",
+        "submitListFailed": "Gagal mengirim daftar pembayaran",
+        "submitFailed": "Gagal mengirim pembayaran massal",
+        "upload": {
+            "pleaseUploadCsv": "Silakan unggah file CSV",
+            "fileSizeLimit": "Ukuran file harus kurang dari 1.5 MB",
+            "headerTitle": "Permintaan Pembayaran Massal",
+            "headerSubtitle": "Bayar beberapa penerima dengan satu usulan.",
+            "creditsUsed": "Anda telah menggunakan semua kredit Anda",
+            "bulkPaymentsUsed": "Anda telah menggunakan semua pembayaran massal Anda",
+            "upgradeTrial": "Tingkatkan paket Anda untuk mendapatkan lebih banyak dan terus berlanjut",
+            "upgradePaid": "Tingkatkan paket Anda untuk akses lebih banyak, atau tunggu hingga batas Anda diatur ulang bulan depan.",
+            "selectAsset": "Pilih Aset",
+            "disableTokenMessage": "Pembayaran massal untuk token ini akan segera hadir.",
+            "providePaymentData": "Berikan Data Pembayaran",
+            "uploadFile": "Unggah File",
+            "provideData": "Berikan Data",
+            "chooseFile": "Pilih File",
+            "orDragDrop": "atau seret dan lepas",
+            "maxFileSize": "maks 1 file hingga 1.5 MB, hanya file CSV",
+            "noFilePrompt": "Tidak punya file untuk diunggah?",
+            "downloadTemplate": "Unduh templat",
+            "requirements": "Persyaratan Pembayaran Massal",
+            "maxTransactions": "Maks {max} transaksi per impor",
+            "singleTokenNetwork": "Token dan jaringan tunggal",
+            "limitsUsed": "Anda telah menggunakan semua batas Anda",
+            "selectAndProvide": "Pilih aset dan berikan data pembayaran",
+            "continueToReview": "Lanjutkan ke Tinjauan",
+            "selectTokenError": "Silakan pilih token",
+            "providePaymentDataError": "Silakan berikan data pembayaran"
+        },
+        "editStep": {
+            "title": "Ubah Pembayaran",
+            "saveChanges": "Simpan Perubahan"
+        },
+        "parsing": {
+            "rowPrefix": "Baris {row}: {message}",
+            "missingRecipientFirstColumn": "Alamat penerima hilang. Silakan tambahkan alamat di kolom pertama.",
+            "invalidNearAddress": "Alamat \"{address}\" bukan akun NEAR yang valid.",
+            "invalidChainAddress": "Alamat \"{address}\" bukan akun {chain} yang valid.",
+            "rowNeedsAmountRecipient": "Setiap baris memerlukan jumlah dan penerima yang dipisahkan dengan koma. Contoh: 100, alice.near",
+            "missingRecipientBeforeComma": "Alamat penerima hilang. Silakan tambahkan alamat sebelum koma.",
+            "missingAmountAfterComma": "Jumlah hilang. Silakan tambahkan angka setelah koma. Contoh: {recipient}, 100",
+            "invalidAmountNumber": "Jumlah \"{amountStr}\" bukan angka yang valid. Silakan gunakan hanya angka dan desimal (mis. 100 atau 100.50).",
+            "amountGreaterThanZero": "Jumlah harus lebih besar dari 0. Anda memasukkan \"{amountStr}\".",
+            "amountTooLarge": "Jumlah \"{amountStr}\" terlalu besar. Silakan gunakan angka yang lebih kecil.",
+            "invalidAmountFallback": "Jumlah tidak valid. Silakan gunakan hanya angka dan desimal (mis. 100 atau 100.50).",
+            "pleaseRemoveChars": "Silakan hapus karakter ini: {chars}. Hanya angka, koma, dan titik yang diperbolehkan.",
+            "amountCannotBeEmpty": "Jumlah tidak boleh kosong.",
+            "tokenMismatch": "Anda memasukkan \"{provided}\" tetapi {expected} dipilih di atas. Hapus simbol token atau pilih {suggested} dari menu drop-down.",
+            "multipleTokenSymbols": "Anda menggunakan beberapa simbol token ({symbols}). Silakan gunakan hanya satu jenis token di seluruh file Anda, atau hapus simbol token dan biarkan pilihan di atas yang menentukan token.",
+            "noPaymentDataFound": "Tidak ada data pembayaran ditemukan. Silakan tambahkan pembayaran Anda dalam format ini: recipient, amount",
+            "exceedsRecipientLimit": "Anda memiliki {count} penerima, tetapi batasnya adalah {limit} per batch. Silakan hapus {excess, plural, other {# penerima}} atau bagi menjadi beberapa batch.",
+            "noPaymentDataProvided": "Tidak ada data pembayaran yang diberikan. Silakan masukkan pembayaran Anda dalam format ini: recipient, amount",
+            "headerColumnsNotFound": "Kami mendeteksi baris header, tetapi tidak dapat menemukan kolom 'Recipient' dan 'Amount'. Silakan gunakan nama kolom ini, atau hapus baris header.",
+            "failedToParseCsv": "Gagal mengurai data CSV",
+            "failedToParsePaste": "Gagal mengurai data tempel",
+            "failedToValidateAccount": "Gagal memvalidasi akun",
+            "feeEstimationFailed": "Tidak dapat memperkirakan biaya jaringan untuk jumlah ini. Silakan verifikasi dan coba lagi.",
+            "feeEstimationFailedRow": "Baris {row} ({recipient}): Tidak dapat memperkirakan biaya jaringan untuk jumlah ini. Silakan verifikasi dan coba lagi."
+        },
+        "recipients": "Penerima",
+        "insufficientTokens": "Token tidak mencukupi. Anda dapat mengirim permintaan dan menambah saldo sebelum persetujuan.",
+        "removeRecipient": "Hapus Penerima",
+        "removeRecipientConfirm": "Apakah Anda yakin ingin menghapus pembayaran ke <strong>{recipient}</strong>? Tindakan ini tidak dapat dibatalkan.",
+        "remove": "Hapus",
+        "edit": "Ubah"
+    },
+    "bulkPaymentCredits": {
+        "title": "Pembayaran Massal",
+        "unlimited": "Tidak Terbatas",
+        "creditsPerPeriod": "{amount} / {period}",
+        "oneTimeTrial": "uji coba sekali",
+        "month": "bulan",
+        "moreFlexibility": "Mencari fleksibilitas lebih?",
+        "contactUs": "Hubungi Kami"
+    },
+    "exchange": {
+        "validation": {
+            "amountPositive": "Jumlah harus lebih besar dari 0"
+        },
+        "requestSubmitted": "Permintaan pertukaran telah dikirim",
+        "heading": "Tukar",
+        "sell": "Jual",
+        "receive": "Terima",
+        "slippageTolerance": "Toleransi Slippage",
+        "disabled": {
+            "differentTokens": "Token harus berbeda",
+            "enterAmount": "Masukkan jumlah untuk ditukar"
+        },
+        "review": "Tinjau Pertukaran",
+        "poweredBy": "Didukung oleh",
+        "info": {
+            "priceDifference": "Selisih Harga",
+            "priceDifferenceTooltip": "Selisih antara nilai tukar kuotasi dan nilai tukar pasar saat ini. Nilai positif menunjukkan nilai tukar yang lebih baik dari pasar.",
+            "estimatedTime": "Estimasi Waktu",
+            "estimatedTimeValue": "{seconds} detik",
+            "estimatedTimeTooltip": "Waktu perkiraan untuk menyelesaikan pertukaran.",
+            "minimumReceived": "Minimum Diterima",
+            "minimumReceivedTooltip": "Ini adalah jumlah minimum yang akan Anda terima dari pertukaran ini, berdasarkan batas slippage yang ditetapkan untuk permintaan.",
+            "depositAddress": "Alamat Deposit",
+            "depositAddressCopied": "Alamat deposit disalin",
+            "quoteExpires": "Kuotasi Berakhir",
+            "exchangeFee": "Biaya Pertukaran",
+            "exchangeFeeTooltip": "Biaya 0,70% yang dikenakan di sini menutupi biaya protokol NEAR Intents untuk memfasilitasi perdagangan Anda dan biaya widget Trezu. Jumlah ini secara otomatis dihitung ke dalam nilai tukar yang dikutip Anda."
+        },
+        "approveWithin24h": "Silakan setujui permintaan ini dalam 24 jam, jika tidak akan kedaluwarsa. Kami sarankan untuk mengonfirmasi sesegera mungkin.",
+        "confirmSubmit": "Konfirmasi dan Kirim Permintaan",
+        "refreshingIn": "Nilai tukar akan diperbarui dalam {seconds}d"
+    },
+    "vesting": {
+        "validation": {
+            "amountMin": "Jumlah harus lebih besar atau sama dengan 3.5",
+            "startBeforeEnd": "Tanggal mulai harus sebelum tanggal berakhir",
+            "cliffBetween": "Tanggal cliff harus antara"
+        },
+        "stepTitles": {
+            "details": "Detail",
+            "settings": "Pengaturan",
+            "review": "Tinjau"
+        },
+        "proposalTitle": "Buat jadwal vesting untuk {address}",
+        "scheduleSubmitted": "Permintaan untuk membuat jadwal vesting telah dikirim",
+        "heading": "Jadwal Vesting Baru",
+        "amount": "Jumlah",
+        "startDate": "Tanggal Mulai",
+        "endDate": "Tanggal Berakhir",
+        "noteOptional": "Catatan (opsional)",
+        "continue": "Lanjutkan",
+        "advancedSettings": "Pengaturan Lanjutan",
+        "allowCancellation": "Izinkan Pembatalan",
+        "allowCancellationDescription": "Memungkinkan NEAR Foundation untuk membatalkan lockup kapan saja. Lockup yang tidak dapat dibatalkan tidak kompatibel dengan tanggal cliff.",
+        "cliffDate": "Tanggal Cliff",
+        "allowEarn": "Izinkan Pendapatan",
+        "allowEarnDescription": "Memungkinkan pemilik lockup untuk mengstaking jumlah penuh token dalam lockup (bahkan sebelum tanggal cliff).",
+        "commentPlaceholder": "Tambahkan komentar untuk jadwal vesting ini (opsional)...",
+        "reviewRequest": "Tinjau Permintaan",
+        "reviewHeading": "Tinjau Jadwal Vesting Anda",
+        "confirmSubmit": "Konfirmasi dan Kirim Permintaan",
+        "review": {
+            "recipient": "Penerima",
+            "startDate": "Tanggal Mulai",
+            "endDate": "Tanggal Berakhir",
+            "cliffDate": "Tanggal Cliff",
+            "cancelable": "Dapat Dibatalkan",
+            "allowEarn": "Izinkan Pendapatan",
+            "na": "T/A"
+        }
+    },
+    "earn": {
+        "placeholder": "Jelajahi peluang pendapatan dan imbalan staking."
+    },
+    "createTreasury": {
+        "validation": {
+            "nameMin": "Nama treasury harus minimal 2 karakter",
+            "nameMax": "Nama treasury harus kurang dari 64 karakter",
+            "accountMin": "Nama akun harus minimal 2 karakter",
+            "accountMax": "Nama akun harus kurang dari 64 karakter",
+            "accountChars": "Nama akun hanya dapat berisi huruf Latin, angka, dan tanda hubung",
+            "accountTaken": "Nama akun ini sudah digunakan"
+        },
+        "votingNote": "Anda memerlukan lebih banyak anggota untuk memodifikasi pengaturan pemungutan suara. Tambahkan anggota lain untuk mengonfigurasi pemungutan suara.",
+        "minimumVoteNote": "Minimal satu suara persetujuan diperlukan.",
+        "heading": "Buat Treasury",
+        "addMembers": "Tambah Anggota",
+        "addMembersInfo": "Anda dapat menambahkan atau memperbarui anggota sekarang dan mengubahnya nanti kapan saja.",
+        "treasuryName": "Nama Treasury",
+        "treasuryNamePlaceholder": "Treasury Saya",
+        "accountName": "Nama Akun",
+        "accountNameInfo": "Ini adalah nama unik akun Anda. Akan digunakan dalam URL Treasury Anda dan ditampilkan dalam transaksi untuk mengidentifikasi siapa yang mengirim pembayaran. Pilih nama yang singkat dan mudah dikenali untuk akun Anda.",
+        "accountPlaceholder": "treasury-saya",
+        "continue": "Lanjutkan",
+        "votingThreshold": "Ambang Pemungutan Suara",
+        "thresholdDescription": "Atur berapa banyak suara yang diperlukan untuk menyetujui permintaan:",
+        "financial": "Finansial",
+        "financialDescription": "Menyetujui permintaan pembayaran & pertukaran.",
+        "governance": "Governance",
+        "governanceDescription": "Menyetujui pengaturan, anggota, dan konfigurasi pemungutan suara.",
+        "confidential": "Rahasia",
+        "public": "Publik",
+        "anyone": "Siapa Saja",
+        "teamOnly": "Hanya Tim",
+        "soon": "Segera",
+        "publicDescription": "Semua saldo, aktivitas, dan transaksi terlihat oleh siapa pun di blockchain. Opsi ini terbaik untuk organisasi transparan dan DAO publik.",
+        "balanceTransactions": "Saldo, Transaksi",
+        "membersVoting": "Anggota, Pemungutan Suara",
+        "allFeatures": "Semua fitur tersedia",
+        "confidentialDescription": "Semua saldo, aktivitas, dan transfer bersifat pribadi di blockchain. Hanya tim Anda yang dapat melihat informasi ini. Terbaik untuk perusahaan swasta, family office, atau tim yang menginginkan privasi finansial.",
+        "recentTransactionsExport": "Ekspor Transaksi Terbaru",
+        "bulkPayment": "Pembayaran Massal",
+        "treasuryType": "Tipe Treasury",
+        "treasuryTypeWarning": "Anda hanya dapat memilih satu kali per treasury dan tidak dapat mengubahnya nanti.",
+        "select": "Pilih",
+        "visibleOnChain": "Terlihat di rantai",
+        "featuresAvailable": "Fitur tersedia",
+        "mostFeaturesSupported": "Sebagian besar fitur didukung",
+        "reviewTreasury": "Tinjau Treasury",
+        "membersLabel": "Anggota",
+        "financialThreshold": "Ambang Finansial",
+        "governanceThreshold": "Ambang Governance",
+        "noDeploymentFee": "🎉 Tanpa biaya deployment",
+        "noDeploymentFeeDescription": "Untuk mendukung proyek baru, TREZU menanggung semua biaya deployment dan penyimpanan jaringan satu kali.",
+        "createButton": "Buat Treasury",
+        "connectWalletCreate": "Hubungkan Dompet Untuk Membuat Treasury",
+        "unexpectedError": "Terjadi kesalahan tak terduga",
+        "creationFailed": "Gagal membuat treasury. Silakan coba lagi.",
+        "stepTitles": {
+            "aboutYou": "Tentang Anda",
+            "details": "Detail",
+            "members": "Anggota",
+            "treasuryType": "Tipe Treasury",
+            "review": "Tinjau"
+        },
+        "steps": {
+            "creatingNear": "Membuat treasury Anda di NEAR",
+            "registeringKey": "Mendaftarkan kunci publik",
+            "settingUpConfidential": "Menyiapkan transaksi rahasia",
+            "configuringMembers": "Mengonfigurasi anggota treasury",
+            "finalizingSetup": "Menyelesaikan pengaturan"
+        }
+    },
+    "manageTreasuries": {
+        "warningOne": "Setidaknya satu treasury harus tetap tersedia",
+        "warningOnePeriod": "Setidaknya satu treasury harus tetap tersedia.",
+        "activeHeading": "Treasury Aktif",
+        "activeDescription": "Treasury yang saat ini terlihat di daftar akun Anda.",
+        "activeEmpty": "Tidak ada treasury aktif.",
+        "hiddenHeading": "Treasury Tersembunyi",
+        "hiddenDescription": "Treasury yang disembunyikan dari daftar akun Anda.",
+        "removeGuestTitle": "Hapus Treasury Tamu",
+        "removeDialog": "Anda akan menghapus <bold>{name}</bold>. Setelah dikonfirmasi, tindakan ini tidak dapat dibatalkan.",
+        "tooltips": {
+            "removeFromList": "Hapus dari daftar Anda",
+            "viewTreasury": "Lihat treasury",
+            "hideFromList": "Sembunyikan dari daftar Anda",
+            "showInList": "Tampilkan di daftar Anda"
+        }
+    },
+    "wallet": {
+        "proposal": {
+            "transfer": "Usulan dari dApp eksternal: Transfer NEAR ke {receiverId}",
+            "functionCall": "Usulan dari dApp eksternal: {methods} pada {receiverId}",
+            "unsupportedAction": "Tipe tindakan tidak didukung \"{type}\". Hanya tindakan Transfer dan FunctionCall yang dapat dikonversi menjadi usulan Trezu."
+        },
+        "loading": "Memuat...",
+        "connectPrompt": "Hubungkan dompet NEAR Anda untuk melanjutkan. Anda kemudian akan memilih treasury untuk bertindak atas nama.",
+        "connectWallet": "Hubungkan Dompet",
+        "cancel": "Batal",
+        "connectedAs": "Terhubung sebagai <strong>{account}</strong>",
+        "loadingTreasuries": "Memuat treasury...",
+        "selectSignIn": "Pilih treasury untuk masuk sebagai:",
+        "selectSignTx": "Pilih treasury untuk membuat usulan pada:",
+        "notMember": "Anda bukan anggota dari treasury mana pun.",
+        "actingAs": "Bertindak sebagai",
+        "signedBy": "Ditandatangani oleh {account}",
+        "createsNProposals": "Ini akan membuat {count, plural, other {# usulan Trezu}} untuk:",
+        "proposalDescriptionLabel": "Deskripsi usulan (opsional)",
+        "proposalDescriptionPlaceholder": "Jelaskan usulan ini...",
+        "createProposal": "Buat Usulan",
+        "creatingProposal": "Membuat usulan...",
+        "confirmInWallet": "Silakan konfirmasi di dompet Anda",
+        "proposalSubmitted": "Usulan Telah Dikirim",
+        "shareProposal": "Usulan Anda telah dibuat. Bagikan tautan di bawah dengan anggota treasury untuk memilih.",
+        "proposalLink": "{daoId} — Usulan #{id}",
+        "checking": "Memeriksa...",
+        "proposalApprovedProceed": "Usulan Disetujui. Lanjutkan",
+        "signedInSuccess": "Berhasil masuk",
+        "proposalCreatedSuccess": "Usulan berhasil dibuat",
+        "closeWindow": "Anda dapat menutup jendela ini.",
+        "errorGeneric": "Terjadi kesalahan",
+        "tryAgain": "Coba lagi",
+        "errors": {
+            "parseTx": "Gagal mengurai permintaan transaksi. Silakan coba lagi.",
+            "fetchTreasuries": "Gagal mengambil treasury Anda. Silakan coba lagi.",
+            "connectFailed": "Gagal menghubungkan dompet",
+            "createProposalFailed": "Gagal membuat usulan",
+            "stillPending": "Usulan masih menunggu persetujuan. Silakan tunggu anggota treasury memilih.",
+            "wasStatus": "Usulan #{id} adalah {status}",
+            "awaitIndex": "Usulan disetujui tetapi transaksi eksekusi belum terindeks. Silakan coba lagi sebentar lagi.",
+            "checkStatusFailed": "Gagal memeriksa status usulan",
+            "userCancelled": "Pengguna membatalkan",
+            "proposalWasStatus": "Usulan adalah {status}"
+        }
+    },
+    "telegram": {
+        "tagPill": "Telegram",
+        "invalidLinkTitle": "Tautan tidak valid",
+        "invalidLinkDescription": "Tautan koneksi Telegram ini tidak memiliki token. Klik kembali Connect Treasury di Telegram untuk membuat tautan baru.",
+        "successTitle": "Berhasil terhubung",
+        "successDescription": "Treasury telah ditautkan ke chat Telegram ini.",
+        "successToast": "Treasury berhasil terhubung",
+        "goToApp": "Ke Aplikasi",
+        "linkExpiredTitle": "Tautan kedaluwarsa",
+        "linkExpiredDescription": "Tautan ini telah kedaluwarsa atau telah digunakan. Di Telegram, ketik perintah di bawah untuk memulai ulang alur koneksi.",
+        "commandCopied": "Perintah disalin",
+        "copy": "Salin",
+        "unableToLoadTitle": "Tidak dapat memuat chat",
+        "unableToLoadDescription": "Detail chat tidak dapat dimuat saat ini. Silakan coba lagi dari Telegram.",
+        "signInTitle": "Masuk untuk melanjutkan",
+        "signInDescription": "Hubungkan dompet NEAR Anda terlebih dahulu, lalu pilih treasury mana yang akan ditautkan ke chat Telegram ini.",
+        "connectWallet": "Hubungkan Dompet",
+        "selectTreasuriesTitle": "Pilih Treasury",
+        "selectTreasuriesDescription": "Pilih treasury mana yang akan dihubungkan ke chat Telegram ini.",
+        "telegramChat": "Chat Telegram",
+        "chatIdFallback": "Chat #{id}",
+        "failedToConnect": "Gagal menghubungkan treasury. Silakan coba lagi.",
+        "relinking": "{count, plural, other {# treasury yang dipilih ditautkan ke chat Telegram lain. Menghubungkan akan menautkan ulang dan mengubah tautan ID chat-nya ke chat ini.}}",
+        "alreadyConnected": "Sudah terhubung ke chat ini",
+        "connectedToAnother": "Terhubung ke chat lain",
+        "notMember": "Anda bukan anggota kebijakan dari treasury mana pun.",
+        "connecting": "Menghubungkan…",
+        "connect": "Hubungkan"
+    },
+    "systemStatus": {
+        "underMaintenance": "Dalam Pemeliharaan",
+        "maintenanceMessage": "Kami sedang melakukan pemeliharaan. Beberapa fitur mungkin tidak tersedia sementara. Silakan periksa kembali sebentar lagi."
+    },
+    "creditsQuota": {
+        "available": "{count} Tersedia",
+        "used": "{count} Terpakai",
+        "resetOn": "Batas akan diatur ulang pada {date}"
+    },
+    "approvalInfo": {
+        "infoText": "Suara diperlukan untuk menyetujui permintaan terkait pembayaran. Dapat diubah di pengaturan Pemungutan Suara.",
+        "thresholdPill": "Ambang {required} dari {total}",
+        "alertBody": "Pembayaran ini akan memerlukan persetujuan dari <bold>{required}</bold> anggota treasury sebelum dieksekusi."
+    },
+    "guestBadge": {
+        "title": "Tamu",
+        "tooltip": "Anda adalah tamu treasury ini. Anda hanya dapat melihat data."
+    },
+    "exportButton": {
+        "confidentialTooltip": "Ekspor belum tersedia dalam mode rahasia. Fitur ini akan segera hadir!"
+    },
+    "sponsoredActions": {
+        "titleExhausted": "Tindakan Tersponsor Terpakai",
+        "titleAlmost": "Tim Anda hampir kehabisan tindakan tersponsor",
+        "closeNotice": "Tutup pemberitahuan",
+        "teamUsage": "Penggunaan tim: {total} tindakan per bulan",
+        "available": "{count} Tersedia",
+        "used": "{count} Terpakai",
+        "exhaustedBody": "Tim Anda telah mencapai tindakan tersponsor bulanan. Anda dapat melanjutkan setelah {date} atau hubungi kami",
+        "almostBody": "TREZU saat ini mensponsori biaya penyimpanan untuk semua tindakan tim, seperti membuat permintaan dan memilih atasnya. Tim Anda hampir mencapai batas tersponsor bulanan.",
+        "contactUs": "Hubungi Kami",
+        "nextMonthlyReset": "pengaturan ulang bulanan berikutnya",
+        "sidebarBody": "Tim Anda telah mencapai tindakan tersponsor bulanan. Anda dapat melanjutkan setelah {date} atau ⬇️"
+    },
+    "acceptTerms": {
+        "title": "Terima Ketentuan untuk Melanjutkan",
+        "privacyTitle": "Privasi Anda di Trezu",
+        "privacyBody": "Trezu adalah antarmuka non-kustodian. Kami memprioritaskan privasi Anda sambil memastikan platform tetap aman dan fungsional.",
+        "minimalTitle": "Data Minimal",
+        "minimalBody": "Kami mengumpulkan informasi terbatas, seperti alamat dompet publik, alamat IP, dan analitik penggunaan, untuk mengoperasikan dan meningkatkan Antarmuka.",
+        "noCustodyTitle": "Tanpa Kustodi",
+        "noCustodyBody": "Kami tidak pernah memiliki akses ke kunci pribadi, frasa pemulihan, atau aset digital Anda.",
+        "publicTitle": "Catatan Publik",
+        "publicBody": "Ingatlah bahwa semua transaksi blockchain pada dasarnya bersifat publik dan tidak dikendalikan oleh kami.",
+        "responsibilityTitle": "Tanggung Jawab Anda",
+        "responsibilityBody": "Anda sepenuhnya bertanggung jawab untuk memantau aktivitas dompet Anda dan mengamankan kredensial Anda.",
+        "futureTitle": "Pembaruan Mendatang",
+        "futureBody": "Jika Anda memilih untuk menerima notifikasi mendatang (seperti email atau Telegram), kami hanya akan menggunakan data tersebut untuk memberi tahu Anda.",
+        "agreement": "Saya telah membaca dan menyetujui <terms>Ketentuan Layanan</terms> dan <privacy>Kebijakan Privasi</privacy>",
+        "accepting": "Menerima...",
+        "continue": "Lanjutkan"
+    },
+    "confidentialBanner": {
+        "label": "Rahasia",
+        "description": "Saldo, aktivitas, dan transfer hanya terlihat oleh tim Anda — bukan blockchain publik."
+    },
+    "supportCenter": {
+        "title": "Pusat Dukungan",
+        "resources": "Sumber Daya",
+        "support": "Dukungan",
+        "websiteTitle": "Situs Web Trezu",
+        "websiteDescription": "Pelajari lebih lanjut tentang Trezu dan baca blog kami.",
+        "demo": "Demo Trezu",
+        "demoTitle": "Jelajahi Versi Publik",
+        "demoDescription": "Lihat akun publik langsung beraksi.",
+        "confidentialDemoTitle": "Jelajahi Versi Rahasia",
+        "confidentialDemoDescription": "Jelajahi akun rahasia langsung beraksi.",
+        "videoTitle": "Tonton Demo",
+        "videoDescription": "Tonton video singkat yang menunjukkan cara kerja Trezu.",
+        "xTitle": "Ikuti Kami di X",
+        "xDescription": "Tetap dapatkan informasi rilis dan wawasan terbaru kami.",
+        "statsTitle": "Statistik",
+        "statsDescription": "Lihat total aset di bawah pengelolaan di semua sputnik DAO.",
+        "docsTitle": "Dokumentasi",
+        "docsDescription": "Pelajari semua fitur di dokumen.",
+        "productSupportTitle": "Dukungan Produk",
+        "productSupportDescription": "Hubungi tim dukungan kami untuk bantuan."
+    },
+    "progressModal": {
+        "titleCreating": "Membuat Treasury...",
+        "titleDone": "Treasury Dibuat",
+        "titleFailed": "Pembuatan Treasury Gagal",
+        "viewTreasury": "Lihat Treasury"
+    },
+    "memberValidation": {
+        "noManagePermission": "Anda tidak memiliki izin untuk mengelola anggota",
+        "pendingRequest": "Anda tidak dapat mengelola anggota saat ada permintaan aktif",
+        "rolesAnd": "{first} dan {second}",
+        "rolesMany": "{list}, dan {last}",
+        "cannotRemoveMember": "Tidak dapat menghapus anggota ini. Mereka adalah satu-satunya orang yang ditugaskan ke {count, plural, other {peran}} {roles}.",
+        "cannotRemoveMemberGov": "Tidak dapat menghapus anggota ini. Mereka adalah satu-satunya orang yang ditugaskan ke {count, plural, other {peran}} {roles}, yang diperlukan untuk mengelola anggota tim dan mengonfigurasi pemungutan suara.",
+        "cannotBulkRemove": "Tidak dapat menghapus anggota ini. Ini akan membuat {count, plural, other {peran}} {roles} kosong.",
+        "cannotBulkRemoveGov": "Tidak dapat menghapus anggota ini. Ini akan membuat {count, plural, other {peran}} {roles} kosong, yang diperlukan untuk mengelola anggota tim dan mengonfigurasi pemungutan suara.",
+        "cannotRemoveRole": "Anda tidak dapat menghapus peran {role} dari anggota ini. Mereka adalah satu-satunya orang yang ditugaskan ke peran ini.",
+        "cannotRemoveRoleGov": "Anda tidak dapat menghapus peran {role} dari anggota ini. Mereka adalah satu-satunya anggota {role}, dan tanpa peran ini Anda tidak akan dapat mengelola anggota tim atau mengonfigurasi pemungutan suara."
+    },
+    "roleSelector": {
+        "setRole": "Atur Peran",
+        "allRoles": "Semua Peran",
+        "roles": {
+            "governance": {
+                "title": "Governance",
+                "description": "Governance dapat membuat dan memilih pengaturan treasury terkait tim, termasuk anggota, izin, dan tampilan treasury."
+            },
+            "requestor": {
+                "title": "Requestor",
+                "description": "Requestor dapat membuat permintaan transaksi terkait pembayaran, tanpa hak suara atau persetujuan."
+            },
+            "financial": {
+                "title": "Financial",
+                "description": "Financial dapat memilih pada permintaan transaksi terkait pembayaran tetapi tidak dapat membuatnya."
+            }
+        }
+    },
+    "memberInput": {
+        "creatorYou": "Pembuat (Anda)",
+        "memberAddress": "Alamat Anggota",
+        "addNewMember": "Tambah Anggota Baru",
+        "validation": {
+            "rolesRequired": "Setidaknya satu peran diperlukan",
+            "duplicateAddress": "Alamat sudah menjadi anggota"
+        }
+    },
+    "recipientInput": {
+        "title": "Ke",
+        "placeholder": "Alamat penerima"
+    },
+    "accountInput": {
+        "failedValidation": "Gagal memvalidasi alamat",
+        "invalidNearFormat": "Format akun NEAR tidak valid",
+        "invalidChainAddress": "Silakan masukkan alamat {chain} yang valid.",
+        "validating": "Memvalidasi alamat...",
+        "validAddress": "Alamat valid",
+        "placeholderWithExample": "Alamat penerima (mis.: {example})",
+        "placeholderNoExample": "Alamat penerima",
+        "nearExample": "alice.near, 0x..., atau hex 64 karakter",
+        "near": {
+            "required": "Alamat diperlukan",
+            "length": "Alamat harus antara 2 dan 64 karakter",
+            "missingTld": "Akun bernama harus berakhir dengan .near, .aurora, atau .tg",
+            "invalidChars": "Alamat hanya dapat berisi huruf kecil, angka, dan pemisah (., -, _)",
+            "accountMissing": "Akun tidak ada di blockchain NEAR",
+            "verifyFailed": "Gagal memverifikasi keberadaan akun"
+        }
+    },
+    "csvUpload": {
+        "uploadFile": "Unggah File",
+        "provideData": "Berikan Data",
+        "chooseFile": "Pilih File",
+        "orDragDrop": "atau seret dan lepas",
+        "maxFileSize": "maks 1 file hingga {maxSize} MB, hanya file CSV",
+        "noFilePrompt": "Tidak punya file untuk diunggah?",
+        "downloadTemplate": "Unduh templat"
+    },
+    "tokenSelect": {
+        "selectToken": "Pilih token",
+        "searchPlaceholder": "Cari token...",
+        "noTokensFound": "Tidak ada token ditemukan"
+    },
+    "filterOperations": {
+        "is": "Adalah",
+        "isNot": "Bukan",
+        "before": "Sebelum",
+        "after": "Setelah",
+        "between": "Antara",
+        "equal": "Sama",
+        "moreThan": "Lebih Dari",
+        "lessThan": "Kurang Dari",
+        "contains": "Mengandung"
+    },
+    "copyButton": {
+        "copied": "Disalin ke papan klip",
+        "failed": "Gagal menyalin"
+    },
+    "recipientForm": {
+        "validation": {
+            "nameRequired": "Nama diperlukan",
+            "nameMax": "Penerima harus kurang dari {max} karakter",
+            "addressRequired": "Alamat diperlukan",
+            "networksRequired": "Pilih setidaknya satu jaringan"
+        }
+    },
+    "paymentForm": {
+        "validation": {
+            "recipientMin": "Penerima harus minimal 2 karakter",
+            "recipientMax": "Penerima harus kurang dari 128 karakter",
+            "amountGreaterThanZero": "Jumlah harus lebih besar dari 0",
+            "recipientSameAsToken": "Alamat penerima dan token tidak boleh sama",
+            "selectToken": "Silakan pilih token",
+            "recipientMax64": "Penerima harus kurang dari 64 karakter",
+            "amountMinLockup": "Jumlah harus lebih besar atau sama dengan 3.5",
+            "startDateRequired": "Tanggal mulai diperlukan",
+            "endDateRequired": "Tanggal berakhir diperlukan",
+            "cliffDateRequired": "Tanggal cliff diperlukan",
+            "startBeforeEnd": "Tanggal mulai harus sebelum tanggal berakhir",
+            "cliffBetween": "Tanggal cliff harus antara {start} dan {end}"
+        }
+    },
+    "exportToasts": {
+        "downloadFailed": "Gagal mengunduh ekspor",
+        "invalidDateRange": "Rentang tanggal tidak valid",
+        "invalidDateRangeDescription": "Silakan pilih rentang tanggal yang valid untuk ekspor.",
+        "exportSuccess": "Ekspor berhasil!",
+        "exportSuccessDescription": "File {type} Anda telah diunduh. Periksa riwayat ekspor Anda untuk detail.",
+        "exportFailed": "Ekspor gagal",
+        "exportFailedFallback": "Gagal mengekspor data. Silakan coba lagi.",
+        "noDownloadPermission": "Anda tidak memiliki izin untuk mengunduh file.",
+        "noExportPermission": "Anda tidak memiliki izin untuk mengekspor",
+        "quotaUsed": "Anda telah menggunakan semua kuota Anda",
+        "exporting": "Mengekspor...",
+        "export": "Ekspor",
+        "columnSubmissionTime": "Waktu Pengiriman",
+        "columnDateRange": "Rentang Tanggal",
+        "columnGeneratedBy": "Dibuat Oleh",
+        "columnStatus": "Status",
+        "typeAll": "Semua Tipe",
+        "typeSent": "Terkirim",
+        "typeReceived": "Diterima",
+        "typeStakingRewards": "Imbalan Staking",
+        "allAssets": "Semua Aset",
+        "upgradeTrial": "Tingkatkan paket Anda untuk mendapatkan lebih banyak dan terus berlanjut",
+        "upgradePaid": "Tingkatkan paket Anda untuk akses lebih banyak, atau tunggu hingga batas Anda diatur ulang bulan depan.",
+        "selectDateRange": "Pilih rentang tanggal",
+        "noExportsTitle": "Belum ada ekspor",
+        "noExportsDescription": "File yang Anda ekspor dari bulan terakhir akan muncul di sini setelah dibuat.",
+        "quotaTitle": "Kuota Ekspor",
+        "unlimited": "Tidak Terbatas",
+        "creditsPerMonth": "{total} / bulan",
+        "requirementsTitle": "Persyaratan Ekspor",
+        "exportFromPeriod": "Anda dapat mengekspor data dari {period}.",
+        "availableFor48Hours": "File yang diekspor tersedia untuk diunduh selama 48 jam.",
+        "moreFlexibility": "Mencari fleksibilitas lebih?",
+        "contactUs": "Hubungi Kami",
+        "last1Year": "1 tahun terakhir",
+        "last2Years": "2 tahun terakhir",
+        "invalidEmail": "Silakan masukkan alamat email yang valid"
+    },
+    "proposalKinds": {
+        "Batch Payment Request": "Permintaan Pembayaran Batch",
+        "Payment Request": "Permintaan Pembayaran",
+        "Confidential Request": "Permintaan Rahasia",
+        "Exchange": "Tukar",
+        "Function Call": "Panggilan Fungsi",
+        "Change Policy": "Ubah Kebijakan",
+        "Update General Settings": "Perbarui Pengaturan Umum",
+        "Earn NEAR": "Dapatkan NEAR",
+        "Unstake NEAR": "Unstake NEAR",
+        "Vesting": "Vesting",
+        "Withdraw Earnings": "Tarik Pendapatan",
+        "Members": "Anggota",
+        "Upgrade": "Tingkatkan",
+        "Set Staking Contract": "Atur Kontrak Staking",
+        "Bounty": "Bounty",
+        "Vote": "Pilih",
+        "Factory Info Update": "Pembaruan Info Pabrik",
+        "Unsupported": "Tidak Didukung"
+    },
+    "paymentFormSection": {
+        "selectRecipient": "Pilih Penerima",
+        "searchByNameOrAddress": "Cari berdasarkan nama atau alamat",
+        "restrictedRecipientTitle": "Transaksi tidak diizinkan",
+        "restrictedRecipientMessage": "Alamat ini saat ini dibatasi karena pemeriksaan keamanan. Jika Anda yakin alamat ini harus diizinkan, Anda dapat <link>meminta untuk memasukkannya ke daftar putih</link>.",
+        "send": "Kirim",
+        "to": "Ke"
+    },
+    "recipientNetworkSelect": {
+        "label": "Jaringan Penerima",
+        "placeholder": "Pilih jaringan penerima",
+        "enterAddressFirst": "Masukkan alamat penerima terlebih dahulu",
+        "noCompatibleNetwork": "Tidak ada jaringan yang cocok dengan alamat ini",
+        "selectPlaceholder": "Pilih jaringan",
+        "title": "Pilih Jaringan",
+        "available": "Tersedia",
+        "fromAddressBook": "Dari Buku Alamat",
+        "otherAvailable": "Tersedia Lainnya",
+        "incompatible": "Tidak Kompatibel",
+        "comingSoon": "Segera Hadir",
+        "nearComName": "near.com",
+        "nearComDescription": "Jaringan Internal untuk near.com dan trezu"
+    },
+    "addressBookTable": {
+        "emptyTitle": "Belum ada penerima",
+        "emptyDescription": "Tambahkan penerima ke buku alamat ini untuk pembayaran lebih cepat.",
+        "selectAll": "Pilih semua penerima",
+        "selectEntry": "Pilih {name}",
+        "recipient": "Penerima",
+        "network": "Jaringan",
+        "addedBy": "Ditambahkan Oleh",
+        "note": "Catatan",
+        "added": "Ditambahkan",
+        "remove": "Hapus",
+        "send": "Kirim"
+    },
+    "publicDashboard": {
+        "updatesDaily": "Diperbarui setiap hari",
+        "noDataTitle": "Belum ada data",
+        "noDataDescription": "Statistik akan muncul setelah snapshot harian pertama dihitung.",
+        "assetsSecured": "Aset Diamankan Dengan Kontrak Sputnik DAO",
+        "acrossDaos": "Di <bold>{count, plural, other {# DAO}}</bold>",
+        "updatedOn": "Diperbarui {date}",
+        "topAssets": "20 Aset Teratas",
+        "noAssetsTitle": "Belum ada aset",
+        "noAssetsDescription": "Data token akan muncul setelah snapshot harian dihitung.",
+        "tableToken": "Token",
+        "tableTotalValue": "Nilai Total"
+    },
+    "telegramConnectInstructions": {
+        "title": "Hubungkan Telegram",
+        "subtitle": "Dapatkan notifikasi tentang usulan dan aktivitas di Telegram Anda.",
+        "step3": "Tekan Mulai dan ikuti instruksi.",
+        "success": "Anda sudah siap!",
+        "copyBotTooltip": "Salin handle bot",
+        "botCopiedToast": "Handle bot disalin",
+        "openInTelegram": "Buka {bot} di Telegram"
+    },
+    "transactionHashCell": {
+        "copyHash": "Salin hash",
+        "hashCopied": "Hash disalin",
+        "openInExplorer": "Buka di explorer"
+    },
+    "treasurySelector": {
+        "select": "Pilih treasury",
+        "connectWalletTooltip": "Hubungkan dompet untuk melihat treasury",
+        "manageTreasuries": "Kelola Treasury",
+        "createTreasury": "Buat Treasury",
+        "memberOf": "Anggota Dari",
+        "guestTreasuries": "Treasury Tamu"
+    },
+    "selectModal": {
+        "searchByName": "Cari berdasarkan nama",
+        "noResults": "Tidak ada hasil ditemukan"
+    },
+    "selectList": {
+        "noResults": "Tidak ada hasil ditemukan"
+    },
+    "datePicker": {
+        "pickDate": "Pilih tanggal",
+        "timezone": "Zona waktu"
+    },
+    "datePresets": {
+        "today": "Hari ini",
+        "yesterday": "Kemarin",
+        "last3Days": "3 hari terakhir",
+        "last7Days": "7 hari terakhir",
+        "last14Days": "14 hari terakhir",
+        "lastMonth": "Bulan lalu",
+        "last3Months": "3 bulan terakhir",
+        "last6Months": "6 bulan terakhir"
+    },
+    "input": {
+        "openSearch": "Buka pencarian"
+    },
+    "pagination": {
+        "previous": "Sebelumnya",
+        "next": "Berikutnya"
+    },
+    "confidentialState": {
+        "title": "Rahasia",
+        "description": "Hanya anggota treasury yang memiliki akses."
+    },
+    "exchangeRate": {
+        "rate": "Nilai Tukar",
+        "clickToReverse": "Klik untuk membalik nilai tukar"
+    },
+    "exchangeSettings": {
+        "title": "Pengaturan Pertukaran",
+        "slippageTolerance": "Toleransi Slippage",
+        "custom": "Kustom",
+        "customPlaceholder": "mis.: 2%",
+        "slippageRange": "Slippage harus antara 0,01% dan 100%",
+        "enterSlippage": "Silakan masukkan toleransi slippage",
+        "slippageHelp": "Jika harga berubah lebih dari persentase ini, transaksi akan dibatalkan untuk melindungi dana Anda.",
+        "save": "Simpan"
+    },
+    "assetsPage": {
+        "title": "Aset",
+        "noAssetsTitle": "Belum ada aset",
+        "noAssetsDescription": "Untuk memulai, tambahkan aset ke Treasury Anda dengan melakukan deposit."
+    },
+    "newBadge": {
+        "label": "Baru"
+    },
+    "numberBadge": {
+        "pendingRequests": "{count, plural, other {# permintaan tertunda}}"
+    },
+    "balanceWithGraph": {
+        "allTokens": "Semua Token",
+        "deposit": "Deposit",
+        "send": "Kirim",
+        "exchange": "Tukar",
+        "chartNow": "Sekarang",
+        "totalBalance": "Saldo Total",
+        "excludedTokens": "Token yang dikecualikan:",
+        "noPriceHistory": "Tidak ada riwayat harga. Pilih token untuk melihat perubahan saldonya.",
+        "bucketAvailable": "Tersedia",
+        "bucketLocked": "Terkunci",
+        "bucketEarning": "Pendapatan",
+        "period": {
+            "1W": "1Mg",
+            "1M": "1Bl",
+            "3M": "3Bl",
+            "1Y": "1Th"
+        }
+    },
+    "changePolicyExpanded": {
+        "proposalBond": "Bond Usulan",
+        "proposalPeriod": "Periode Usulan",
+        "bountyBond": "Bond Bounty",
+        "bountyForgivenessPeriod": "Periode Pengampunan Bounty",
+        "votesCount": "{count} Suara",
+        "weightKind": "Jenis Bobot",
+        "quorum": "Kuorum",
+        "threshold": "Ambang",
+        "defaultThreshold": "Ambang Default",
+        "roleThreshold": "Ambang {role}",
+        "member": "Anggota",
+        "members": "Anggota",
+        "permissions": "Izin",
+        "oldPermissions": "Izin Lama",
+        "newPermissions": "Izin Baru",
+        "category": "Kategori",
+        "transactionDetails": "Detail Transaksi",
+        "addNewMember": "Tambah Anggota Baru",
+        "addNewMembers": "Tambah Anggota Baru",
+        "removeMember": "Hapus Anggota",
+        "removeMembers": "Hapus Anggota",
+        "updateMemberPermissions": "Perbarui Izin Anggota",
+        "updateMembersPermissions": "Perbarui Izin Anggota",
+        "memberIndex": "Anggota {index}",
+        "membersCount": "{count} anggota",
+        "collapseAll": "Tutup semua",
+        "expandAll": "Buka semua",
+        "loadingHistorical": "Memuat kebijakan historis...",
+        "unableToDiff": "Tidak dapat menghitung perbedaan untuk usulan ini.",
+        "noChangesCurrent": "Tidak ada perubahan terdeteksi - kebijakan yang diusulkan identik dengan kebijakan saat ini.",
+        "noChangesHistorical": "Tidak ada perubahan terdeteksi - kebijakan yang diusulkan identik dengan kebijakan historis."
+    },
+    "balanceChart": {
+        "usdValue": "Nilai USD",
+        "tokenBalance": "Saldo Token",
+        "emptyTitle": "Belum ada apa-apa untuk ditampilkan",
+        "emptyDescription": "Tambahkan aset untuk mulai melacak portofolio Anda."
+    },
+    "user": {
+        "saveToAddressBook": "Simpan ke Buku alamat",
+        "walletCopiedToast": "Alamat dompet disalin ke papan klip",
+        "copyWalletAddress": "Salin Alamat Dompet"
+    },
+    "infoDisplay": {
+        "viewLess": "Lihat Lebih Sedikit",
+        "viewAllDetails": "Lihat Semua Detail"
+    },
+    "amountSummary": {
+        "defaultTitle": "Anda mengirim total"
+    },
+    "residency": {
+        "vestedToken": "Token Tervesting",
+        "staked": "Di-staking",
+        "fungibleToken": "Token Fungible",
+        "intentsToken": "Token Intents",
+        "nativeToken": "Token Native"
+    },
+    "exchangeErrors": {
+        "noRoute": "Tidak ada pertukaran ditemukan. Coba jumlah lebih kecil atau token berbeda.",
+        "amountTooLow": "Jumlah terlalu rendah untuk swap. Swap lintas-rantai memerlukan minimum lebih tinggi untuk menutupi biaya jaringan.",
+        "insufficientBalance": "Saldo tidak mencukupi untuk swap ini.",
+        "networkError": "Kesalahan jaringan. Silakan periksa koneksi Anda dan coba lagi.",
+        "fetchFailed": "Gagal mengambil kuotasi"
+    },
+    "tokenSelectDialog": {
+        "selectToken": "Pilih token",
+        "selectAsset": "Pilih Aset",
+        "selectNetworkFor": "Pilih jaringan untuk {asset}",
+        "searchByName": "Cari berdasarkan nama",
+        "noTokensWithBalance": "Tidak ada token dengan saldo ditemukan",
+        "noTokensFound": "Tidak ada token ditemukan",
+        "yourAssets": "Aset Anda",
+        "otherAssets": "Aset Lainnya",
+        "networksWithAssets": "Jaringan dengan aset",
+        "supportedNetworks": "Jaringan yang Didukung",
+        "comingSoon": "Segera hadir"
+    },
+    "intentsQuote": {
+        "initializing": "Layanan kuotasi masih diinisialisasi. Silakan coba lagi.",
+        "noRoute": "Tidak dapat menyiapkan rute pembayaran sekarang. Silakan coba lagi.",
+        "fetchFailed": "Tidak dapat menyiapkan rute pembayaran sekarang. Silakan coba lagi.",
+        "amountTooLow": "Jumlah terlalu rendah untuk menutupi biaya jaringan. Masukkan jumlah lebih tinggi dan coba lagi.",
+        "amountTooLowWithMin": "Jumlah terlalu rendah untuk menutupi biaya jaringan. Masukkan minimal {min} {token}.",
+        "networkFeeTooltip": "Biaya ini digunakan untuk memproses transaksi pada rantai yang dipilih."
+    },
+    "pageTours": {
+        "paymentsBulk": "Pembuatan massal sudah hadir! Buat beberapa permintaan hanya dalam beberapa langkah.",
+        "paymentsPending": "Lihat permintaan yang menunggu persetujuan di sini.",
+        "exchangeSettings": "Di sini Anda dapat mengatur seberapa banyak perubahan harga yang bersedia Anda terima.",
+        "membersPending": "Klik untuk melihat permintaan aktif yang menunggu persetujuan.",
+        "guestSaveIntro": "Anda adalah tamu treasury ini. Anda hanya dapat melihat data.",
+        "guestSaveAction": "Anda dapat menyimpan treasury tamu ini ke daftar treasury Anda.",
+        "newFeatureRich": "Baru! 🎉 Simpan alamat yang sering digunakan untuk pembayaran lebih cepat dan bebas kesalahan.<br></br> Kontak Anda tetap pribadi dan hanya terlihat oleh tim Anda.",
+        "newFeatureCta": "Coba Sekarang"
+    },
+    "statusDate": {
+        "expires": "Kedaluwarsa",
+        "created": "Dibuat",
+        "expired": "Kedaluwarsa",
+        "removed": "Dihapus"
+    },
+    "relativeTime": {
+        "justNow": "Baru saja",
+        "moments": "beberapa saat"
+    },
+    "amount": {
+        "network": "Jaringan: {network}"
+    },
+    "activityLabels": {
+        "exchangePending": "Pertukaran Tertunda",
+        "exchangeRequest": "Permintaan Pertukaran",
+        "exchangeFulfillment": "Pemenuhan Pertukaran",
+        "stakingRewards": "Imbalan Staking",
+        "proposalAction": "Tindakan Usulan",
+        "deposit": "Deposit {symbol}",
+        "paymentSent": "Pembayaran Terkirim",
+        "transaction": "Transaksi",
+        "fallbackToken": "Token",
+        "viaIntents": "via NEAR Intents",
+        "from": "dari {account}",
+        "to": "ke {account}",
+        "viewAll": "Lihat semua riwayat transaksi Anda",
+        "sentReceived": "Transaksi terkirim dan diterima ({duration})",
+        "unlimitedHistory": "riwayat tidak terbatas",
+        "oneYear": "1 tahun",
+        "yearsCount": "{count} tahun",
+        "monthsCount": "{count} bulan",
+        "lastDuration": "{duration} terakhir"
+    },
+    "nearStore": {
+        "connectAndAcceptTerms": "Silakan hubungkan dompet dan terima ketentuan untuk melanjutkan.",
+        "transactionNotApproved": "Transaksi tidak disetujui di dompet Anda.",
+        "failedSubmitVote": "Gagal mengirim suara",
+        "failedSubmitVotes": "Gagal mengirim suara",
+        "viewRequest": "Lihat Permintaan",
+        "proposalRemoved": "Usulan Anda telah dihapus",
+        "voteSubmitted": "Suara Anda telah dikirim",
+        "votesSubmitted": "Suara Anda telah dikirim"
+    },
+    "tokenInput": {
+        "max": "MAX",
+        "insufficientTokens": "Token tidak mencukupi. Anda dapat mengirim permintaan dan menambah saldo sebelum persetujuan.",
+        "balance": "Saldo: {amount} {symbol}"
+    },
+    "createRequestButton": {
+        "idle": "Buat Permintaan",
+        "noPermission": "Anda tidak memiliki izin untuk membuat permintaan"
+    },
+    "address": {
+        "copied": "Alamat disalin ke papan klip"
+    },
+    "memberAvatars": {
+        "membersWhoCanVote": "Anggota yang dapat memilih",
+        "moreMembers": "+{count, plural, other {# anggota}}"
+    },
+    "accountIdInput": {
+        "minLength": "ID Akun harus minimal 2 karakter",
+        "maxLength": "ID Akun harus kurang dari 64 karakter",
+        "charset": "ID Akun hanya boleh berisi huruf kecil, angka, titik, tanda hubung, dan garis bawah, tanpa pemisah di awal atau akhir",
+        "doesNotExist": "ID Akun tidak ada"
+    },
+    "addressBookMutations": {
+        "addedToast": "{count, plural, other {# penerima ditambahkan}}",
+        "addedSingleToast": "Penerima ditambahkan",
+        "addFailedToast": "Gagal menambahkan penerima",
+        "addSingleFailedToast": "Gagal menambahkan penerima",
+        "removedToast": "{count, plural, other {# penerima dihapus}}",
+        "removeFailedToast": "Gagal menghapus penerima",
+        "exportFailedToast": "Gagal mengekspor penerima"
+    },
+    "treasuryMutations": {
+        "savedToast": "Treasury disimpan ke daftar Anda",
+        "saveFailedToast": "Gagal menyimpan treasury",
+        "hiddenToast": "Treasury disembunyikan dari daftar",
+        "hideFailedToast": "Gagal menyembunyikan treasury",
+        "unhiddenToast": "Treasury terlihat kembali",
+        "unhideFailedToast": "Gagal menampilkan treasury",
+        "removedToast": "Treasury dihapus dari daftar yang disimpan",
+        "removeFailedToast": "Gagal menghapus treasury dari daftar yang disimpan"
+    },
+    "telegramSettings": {
+        "title": "Telegram",
+        "connectedTo": "Terhubung ke {chat}",
+        "chatNumber": "Chat #{id}",
+        "fallbackChat": "chat Telegram",
+        "disconnect": "Putuskan",
+        "connect": "Hubungkan",
+        "connectDescription": "Tautkan treasury Anda ke chat Telegram untuk menerima notifikasi.",
+        "noTreasuryDescription": "Tautkan treasury Anda ke chat Telegram.",
+        "openSettingsHint": "Buka pengaturan dari treasury untuk mengelola integrasi.",
+        "disconnectedToast": "Telegram terputus untuk treasury ini",
+        "disconnectFailedToast": "Tidak dapat memutuskan Telegram. Coba lagi."
+    },
+    "assetsTable": {
+        "noAssetsFound": "Tidak ada aset ditemukan.",
+        "assetDetails": "Detail Aset",
+        "coinPrice": "Harga Koin",
+        "weight": "Bobot",
+        "balance": "Saldo",
+        "lockedBalance": "Saldo Terkunci",
+        "totalBalance": "Saldo Total",
+        "source": "Sumber",
+        "balanceByInvestors": "Saldo berdasarkan {count, plural, other {Investor}}",
+        "investors": "{count, plural, other {Investor}}",
+        "poolBreakdown": "Rincian Pool",
+        "unlockedToken": "Token Tidak Terkunci",
+        "lockupStakingPool": "Pool staking lockup",
+        "exchange": "Tukar",
+        "send": "Kirim",
+        "details": "Detail",
+        "columnToken": "Token",
+        "columnLocked": "Terkunci",
+        "columnUnlocked": "Tidak Terkunci",
+        "columnTotalAllocated": "Total Dialokasikan",
+        "columnAvailableToWithdraw": "Tersedia Untuk Ditarik",
+        "viewAvailable": "Tersedia",
+        "viewLocked": "Terkunci",
+        "viewEarning": "Pendapatan",
+        "fullAllocatedBalance": "Saldo penuh yang dialokasikan",
+        "partAllocatedBalance": "Bagian dari saldo yang dialokasikan",
+        "currentlyEarning": "({amount} {symbol}) saat ini menghasilkan.",
+        "willAppearHere": " Akan muncul di sini setelah Anda berhenti menghasilkan.",
+        "seeInEarningTab": "Lihat di tab Pendapatan",
+        "seeInEarning": "Lihat di Pendapatan"
+    },
+    "earningDetails": {
+        "title": "Detail Pendapatan",
+        "totalStaked": "Total Di-staking",
+        "earningOverview": "Ringkasan Pendapatan",
+        "poolBreakdown": "Rincian Pool ({count, plural, other {# pool}})",
+        "almostReady": "Earn hampir siap!",
+        "finalizingFeature": "Kami sedang menyelesaikan fitur ini<br></br>agar Anda dapat segera mulai menghasilkan token.",
+        "comingSoon": "Segera hadir",
+        "goToEarn": "Ke Earn",
+        "readyToWithdraw": "Siap ditarik",
+        "unstaking": "Unstaking",
+        "overview": {
+            "staked": "Di-staking",
+            "stakedInfo": "Token saat ini didelegasikan ke validator yang menghasilkan imbalan.",
+            "pendingRelease": "Menunggu Rilis",
+            "pendingReleaseInfo": "Token yang telah di-unstake tetapi masih dalam periode unbonding (biasanya 2-3 hari).",
+            "availableForWithdraw": "Tersedia untuk Ditarik",
+            "availableForWithdrawInfo": "Token yang di-unstake yang telah menyelesaikan periode unbonding dan dapat ditarik."
+        }
+    },
+    "lockupDetails": {
+        "title": "Detail Lockup",
+        "balance": "Saldo",
+        "reservedForStorage": "Dicadangkan Untuk Penyimpanan",
+        "reservedForStorageInfo": "NEAR yang dicadangkan oleh akun lockup untuk membayar biaya penyimpanan.",
+        "tokenBreakdown": "Rincian Token",
+        "allocatedAmount": "Jumlah Dialokasikan",
+        "earned": "Diperoleh",
+        "progress": "Kemajuan",
+        "unlocked": "Tidak Terkunci",
+        "locked": "Terkunci",
+        "schedule": "Jadwal",
+        "startDate": "Tanggal Mulai",
+        "endDate": "Tanggal Berakhir",
+        "rounds": "Putaran",
+        "releaseInterval": "Interval Rilis",
+        "nextUnlockDate": "Tanggal Pembukaan Berikutnya",
+        "allEarning": "Semua {amount} {symbol} dari lockup Anda saat ini menghasilkan.",
+        "partEarning": "Bagian dari lockup Anda ({amount} {symbol}) saat ini menghasilkan.",
+        "stopEarningFirst": "Untuk menggunakan token yang tidak terkunci, hentikan pendapatan terlebih dahulu dan tarik.",
+        "howGrantWorks": "Cara kerja hibah Anda",
+        "ftStep1": "Anda menerima hibah untuk periode waktu tertentu. Alih-alih mendapatkan jumlah penuh sekaligus, aset menjadi tersedia secara bertahap dari waktu ke waktu.",
+        "ftStep2": "Ketika tanggal rilis berikutnya tiba, bagian token tersebut otomatis dibuka dan dipindahkan ke saldo treasury Anda.",
+        "ftStep3": "Setelah muncul di saldo Anda, Anda dapat segera menggunakannya untuk pembayaran, transfer, atau transaksi lainnya.",
+        "nearStep1": "Anda menerima hibah untuk periode waktu tertentu dengan tanggal mulai dan berakhir yang ditentukan.",
+        "nearStep2": "Saat token terbuka, mereka otomatis tersedia di saldo treasury Anda.",
+        "nearStep3": "Anda dapat menggunakan token yang terbuka segera untuk pembayaran, transfer, atau transaksi lainnya.",
+        "notAvailable": "T/A",
+        "everyMonth": "Setiap bulan",
+        "everyQuarter": "Setiap kuartal",
+        "everyUnit": "Setiap {unit}",
+        "everyMultiple": "Setiap {text}",
+        "completed": "Selesai",
+        "unit": {
+            "year": "{count, plural, other {# tahun}}",
+            "day": "{count, plural, other {# hari}}",
+            "hour": "{count, plural, other {# jam}}",
+            "minute": "{count, plural, other {# menit}}",
+            "second": "{count, plural, other {# detik}}"
+        }
+    },
+    "vestingDetails": {
+        "title": "Detail Vesting",
+        "availableToUse": "Tersedia Untuk Digunakan",
+        "vestingPeriod": "Periode Vesting",
+        "vestingPeriodDescription": "Token terbuka setiap hari selama periode ini.",
+        "startDate": "Tanggal Mulai",
+        "endDate": "Tanggal Berakhir",
+        "tokenBreakdown": "Rincian Token",
+        "originalVestedAmount": "Jumlah Tervesting Asli",
+        "reservedForStorage": "Dicadangkan Untuk Penyimpanan",
+        "reservedForStorageInfo": "Sejumlah kecil token yang diperlukan untuk menjaga vesting tetap aktif dan menutupi biaya penyimpanan.",
+        "percentVested": "{percent}% Tervesting",
+        "vestedOf": "{vested} dari {total} {symbol}",
+        "send": "Kirim"
+    },
+    "earningPoolDetails": {
+        "balance": "Saldo",
+        "apy": "APY",
+        "fee": "Biaya",
+        "notAvailable": "T/A",
+        "lockupStakingPool": "Pool staking lockup",
+        "lockupAssetsNote": "Semua aset dalam posisi ini berasal dari lockup Anda. Setelah Anda berhenti menghasilkan, beberapa token mungkin masih terkunci dan tidak tersedia - periksa jadwal lockup Anda untuk melihat kapan terbuka."
+    },
+    "onboardingQuestions": {
+        "stepTitle": "Beberapa pertanyaan singkat untuk memulai.",
+        "other": "Lainnya",
+        "placeholders": {
+            "describeRole": "Jelaskan peran Anda (opsional)",
+            "describeUseCase": "Jelaskan kasus penggunaan Anda (opsional)",
+            "networkName": "Masukkan nama jaringan (opsional)",
+            "currentChallenge": "Masukkan tantangan Anda saat ini (opsional)",
+            "describeOther": "Jelaskan lainnya (opsional)"
+        },
+        "questions": {
+            "role": "Mana yang paling menggambarkan peran Anda?",
+            "useCases": "Untuk apa Anda berencana menggunakan Trezu?",
+            "teamSize": "Berapa banyak orang yang akan mengelola treasury?",
+            "networks": "Jaringan mana yang paling sering Anda gunakan?",
+            "multisigExperience": "Apa pengalaman Anda dengan multisig?",
+            "currentTools": "Alat apa yang saat ini Anda gunakan untuk mengelola keuangan?",
+            "monthlyVolume": "Perkiraan volume transaksi bulanan?",
+            "biggestChallenges": "Apa tantangan terbesar Anda saat ini?"
+        },
+        "options": {
+            "role": {
+                "founder": "Pendiri",
+                "co-founder": "Pendiri Bersama",
+                "cfo-finance-lead": "CFO / Pemimpin Keuangan",
+                "operations-manager": "Manajer Operasi",
+                "treasury-manager": "Manajer Treasury",
+                "other": "Lainnya"
+            },
+            "useCases": {
+                "team-payroll-grants": "Penggajian tim & hibah",
+                "company-assets-management": "Pengelolaan aset perusahaan",
+                "dao-treasury-management": "Pengelolaan treasury DAO",
+                "investment-portfolio": "Portofolio investasi",
+                "operational-spending": "Pengeluaran operasional",
+                "other": "Lainnya"
+            },
+            "teamSize": {
+                "just-me": "Hanya saya",
+                "2-5-people": "2-5 orang",
+                "6-15-people": "6-15 orang",
+                "15-plus-people": "15+"
+            },
+            "networks": {
+                "near": "NEAR",
+                "bitcoin": "Bitcoin",
+                "ethereum": "Ethereum",
+                "solana": "Solana",
+                "arbitrum": "Arbitrum",
+                "base": "Base",
+                "optimism": "Optimism",
+                "polygon": "Polygon",
+                "gnosis": "Gnosis",
+                "avalanche": "Avalanche",
+                "bnb-chain": "BNB Chain",
+                "other": "Lainnya"
+            },
+            "multisigExperience": {
+                "never-heard-of-it": "Belum pernah mendengarnya",
+                "heard-about-it": "Pernah mendengar tentangnya",
+                "never-used-it": "Belum pernah menggunakannya",
+                "used-gnosis-safe-or-similar": "Pernah menggunakan Gnosis Safe atau sejenisnya",
+                "experienced": "Berpengalaman",
+                "looking-for-a-better-option": "Mencari opsi yang lebih baik"
+            },
+            "currentTools": {
+                "gnosis-safe": "Gnosis Safe",
+                "fireblocks": "Fireblocks",
+                "tholos": "Tholos",
+                "squads-multisig": "Squads Multisig",
+                "mpc-vault": "MPC Vault",
+                "other": "Lainnya"
+            },
+            "monthlyVolume": {
+                "under-10k": "Di bawah $10K",
+                "10k-100k": "$10K - $100K",
+                "100k-1m": "$100K - $1M",
+                "1m-plus": "$1M+"
+            },
+            "biggestChallenges": {
+                "slow-approvals-and-signing": "Persetujuan dan penandatanganan yang lambat",
+                "lack-of-transparency-in-the-team": "Kurangnya transparansi dalam tim",
+                "hard-to-track-spending-and-balances": "Sulit melacak pengeluaran dan saldo",
+                "security-and-access-control": "Keamanan dan kontrol akses",
+                "no-good-web3-tool-yet": "Belum ada alat Web3 yang baik",
+                "looking-for-crypto-earnings": "Saya mencari pendapatan kripto",
+                "other": "Lainnya"
+            }
+        }
+    },
+    "onboarding": {
+        "tour": {
+            "addAssets": "Tambah aset ke Treasury Anda dengan melakukan deposit.",
+            "makeRequests": "Buat permintaan pembayaran kapan pun Anda perlu mengirim aset.",
+            "exchangeAssets": "Di sini Anda dapat menukar aset Anda.",
+            "addMembers": "Tambah anggota ke Treasury Anda dan tetapkan peran mereka.",
+            "newTreasury": "Ingin menyiapkan Treasury baru? Anda dapat melakukannya di sini hanya dalam beberapa klik.",
+            "helpSupport": "Dapatkan bantuan dan dukungan kapan pun Anda butuhkan."
+        },
+        "tourCard": {
+            "close": "Tutup",
+            "stepProgress": "{current} dari {total}",
+            "gotIt": "Mengerti",
+            "done": "Selesai",
+            "next": "Berikutnya"
+        },
+        "progress": {
+            "title": "Ikuti Langkah Cepat untuk Menjelajahi Treasury",
+            "createTreasuryTitle": "Buat akun Treasury",
+            "createTreasuryDescription": "Anda telah berhasil menyiapkan akun Anda. Awal yang bagus!",
+            "addAssetsTitle": "Tambah Aset Anda",
+            "addAssetsDescription": "Mulailah dengan menambahkan aset untuk melihatnya beraksi.",
+            "deposit": "Deposit",
+            "createPaymentTitle": "Buat Permintaan Pembayaran",
+            "createPaymentDescription": "Buat permintaan pembayaran untuk menyelesaikan pengaturan Anda.",
+            "send": "Kirim"
+        },
+        "welcome": {
+            "heading": "🎉 Selamat datang!",
+            "subheading": "Tur singkat Treasury",
+            "body": "Hai! Trezu Anda siap - mulai bangun portofolio Anda dengan menambahkan aset dari jaringan yang didukung.",
+            "progress": "{current} dari {total}",
+            "next": "Berikutnya",
+            "body2": "Lihat cara melakukan deposit, membuat permintaan, dan menyiapkan akun baru.",
+            "noThanks": "Tidak, terima kasih",
+            "letsGo": "Ayo mulai"
+        },
+        "congrats": {
+            "heading": "🎉 Selamat!",
+            "body": "Anda telah menyelesaikan pengaturan Treasury Anda. Nikmati pengelolaan aset Anda dengan mudah.",
+            "letsGo": "Ayo mulai!"
+        },
+        "createBanner": {
+            "close": "Tutup",
+            "title": "Jelajahi Trezu",
+            "description": "Buat akun untuk membuka izin ke semua fitur dan manfaat Trezu.",
+            "cta": "Buat Treasury"
+        },
+        "questionnaire": {
+            "continue": "Lanjutkan",
+            "skip": "Lewati"
+        },
+        "createPrompt": {
+            "title": "Anda hampir siap",
+            "description": "Dompet Anda terhubung, tetapi Anda belum membuat treasury. Buat akun untuk mulai menggunakan Trezu, atau {suffix}",
+            "suffixDemo": "lihat demo.",
+            "suffixExploring": "terus menjelajah.",
+            "createCta": "Buat Treasury",
+            "viewDemo": "Lihat Demo",
+            "keepExploring": "Terus Menjelajah"
+        },
+        "infoBox": {
+            "title": "Dapatkan lebih banyak dari Trezu",
+            "close": "Tutup",
+            "description": "Temukan bagaimana orang lain menggunakan Treasury, coba demo, dan periksa dokumen untuk mempelajari fiturnya.",
+            "demoTitle": "Jelajahi Demo Trezu",
+            "demoDescription": "Lihat akun demo langsung beraksi.",
+            "docsTitle": "Dokumentasi",
+            "docsDescription": "Pelajari semua fitur di dokumen.",
+            "videoTitle": "Tonton Demo",
+            "videoDescription": "Tonton video singkat yang menunjukkan cara kerja Trezu."
+        }
+    }
+}

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -1,0 +1,2101 @@
+{
+    "common": {
+        "loading": "読み込み中...",
+        "notAvailable": "該当なし",
+        "connecting": "接続中...",
+        "save": "保存",
+        "cancel": "キャンセル",
+        "submit": "送信",
+        "close": "閉じる",
+        "back": "戻る",
+        "seeDemo": "Trezuのデモを見る",
+        "search": "検索",
+        "filter": "フィルター",
+        "filterActive": "フィルター(有効)",
+        "export": "エクスポート",
+        "exporting": "エクスポート中",
+        "import": "インポート",
+        "remove": "削除",
+        "removing": "削除中...",
+        "edit": "編集",
+        "continue": "続ける",
+        "select": "選択",
+        "all": "すべて",
+        "none": "なし",
+        "retry": "再試行",
+        "tryAgain": "もう一度お試しください。",
+        "confirm": "確認",
+        "next": "次へ",
+        "previous": "前へ",
+        "yes": "はい",
+        "no": "いいえ",
+        "approve": "承認",
+        "reject": "却下",
+        "copy": "コピー",
+        "copied": "コピーしました",
+        "viewAll": "すべて表示",
+        "viewDetails": "詳細を表示",
+        "noResults": "結果が見つかりませんでした",
+        "add": "追加"
+    },
+    "languageSwitcher": {
+        "label": "言語",
+        "select": "言語を選択",
+        "english": "English",
+        "spanish": "Español",
+        "ukrainian": "Українська",
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
+    },
+    "header": {
+        "toggleSidebar": "サイドバーを切り替え",
+        "toggleTheme": "テーマを切り替え"
+    },
+    "nav": {
+        "dashboard": "ダッシュボード",
+        "requests": "リクエスト",
+        "payments": "支払い",
+        "exchange": "交換",
+        "addressBook": "アドレス帳",
+        "members": "メンバー",
+        "settings": "設定",
+        "helpSupport": "ヘルプとサポート",
+        "saveGuestTreasury": "このゲストトレジャリーをトレジャリー一覧に保存します。"
+    },
+    "signIn": {
+        "connect": "接続",
+        "connectWallet": "ウォレットを接続",
+        "wallet": "ウォレット",
+        "termsOfService": "利用規約",
+        "privacyPolicy": "プライバシーポリシー",
+        "disconnect": "切断"
+    },
+    "auth": {
+        "noWallet": "ウォレットを接続してください",
+        "noPermission": "このアクションを実行する権限がありません",
+        "noVote": "この提案にはすでに投票済みです",
+        "noSponsoredTransactions": "スポンサー付きトランザクションの残数がありません"
+    },
+    "landing": {
+        "welcome": "Trezuへようこそ",
+        "chooseOption": "下のオプションを選んで開始してください。",
+        "newUserTitle": "Trezuは初めてです",
+        "newUserDescription": "Trezuのことは聞いたことがありますが、まだトレジャリーは持っていません。",
+        "existingUserTitle": "すでにTrezuを利用しています",
+        "existingUserDescription": "アカウントを持っていてトレジャリーを管理しています。",
+        "gradientTagline": "デジタル資産を管理するためのクロスチェーンマルチシグセキュリティ",
+        "waitlistTitle": "Trezuのウェイトリストに参加",
+        "waitlistSubmittedTitle": "登録が完了しました 🎉",
+        "waitlistSubmittedDescription": "ありがとうございます!トレジャリー作成が利用可能になり次第、お知らせします。",
+        "waitlistDescription": "本日のトレジャリー作成上限に達しました。後ほど再度お試しいただくか、連絡先を残してウェイトリストに参加してください。空きが出次第ご連絡します。",
+        "waitlistInputPlaceholder": "メールアドレスまたはTelegram(例: @username)",
+        "waitlistPrivacyNote": "通知のためだけに使用します",
+        "waitlistSubmit": "ウェイトリストに参加",
+        "waitlistSubmitFailed": "送信に失敗しました。もう一度お試しください。",
+        "welcomeAlt": "ようこそ"
+    },
+    "blocked": {
+        "title": "お住まいの国ではご利用いただけません",
+        "description": "規制により、現在お住まいの地域ではこのサービスをご利用いただけません。"
+    },
+    "notFound": {
+        "title": "おっと、このページは存在しません...",
+        "description": "リンクが無効になっているようです。前のページに戻るか、ダッシュボードへお戻りください。",
+        "backToDashboard": "ダッシュボードに戻る"
+    },
+    "treasuryInfo": {
+        "logoAlt": "トレジャリーロゴ"
+    },
+    "dateInput": {
+        "placeholder": "yyyy/mm/dd"
+    },
+    "thresholdSlider": {
+        "warningSingleMember": "1/{memberCount}のしきい値では、メンバーの誰か一人でもトランザクションを実行できます。これはセキュリティを低下させます。",
+        "infoBalanced": "{currentThreshold}/{memberCount}のしきい値は、セキュリティと運用上の柔軟性のバランスが取れています。"
+    },
+    "intentsFee": {
+        "amountTooLowForFee": "{prefix}金額がネットワーク手数料({fee} {symbol})より低すぎます。少なくとも{addMore} {symbol}追加してください。"
+    },
+    "metadata": {
+        "treasuryTitle": "ダッシュボード | Trezu",
+        "landingTitle": "Trezu | クロスチェーン・トレジャリー管理",
+        "description": "鍵を手放すことなく、単一のダッシュボードからチームの資金を数分で管理できます。",
+        "ogTitle": "Trezu | 一つのマルチシグ。あらゆる暗号資産。完全なコントロール。"
+    },
+    "pages": {
+        "dashboard": {
+            "title": "ダッシュボード",
+            "description": "トレジャリー資産とアクティビティの概要",
+            "descriptionLong": "トレジャリー資産を管理し、アクティビティを追跡"
+        },
+        "activity": {
+            "title": "最近のトランザクション",
+            "descriptionDetails": "リクエストの詳細",
+            "descriptionList": "すべての資産にわたる最近のトランザクション"
+        },
+        "requests": {
+            "title": "リクエスト",
+            "description": "保留中のすべてのマルチシグリクエストを表示・管理",
+            "detailDescription": "リクエストの詳細",
+            "detailTitle": "リクエスト #{id}"
+        },
+        "members": {
+            "title": "メンバー",
+            "description": "チームメンバーと権限を管理"
+        },
+        "settings": {
+            "title": "設定",
+            "description": "アプリケーションの設定を調整"
+        },
+        "addressBook": {
+            "title": "アドレス帳",
+            "description": "保存した受取人を管理"
+        },
+        "payments": {
+            "title": "支払い",
+            "description": "資金を安全に送受信"
+        },
+        "exchange": {
+            "title": "交換",
+            "description": "トークンを安全かつ効率的に交換"
+        },
+        "vesting": {
+            "title": "ベスティング",
+            "description": "ベスティングスケジュールを素早く簡単に作成"
+        },
+        "earn": {
+            "title": "収益",
+            "description": "資産から報酬を得る",
+            "placeholder": "収益機会とステーキング報酬を確認できます。"
+        },
+        "createTreasury": {
+            "title": "トレジャリーを作成",
+            "description": "チーム用の新しいマルチシグトレジャリーをセットアップ"
+        },
+        "manageTreasuries": {
+            "title": "トレジャリーの管理",
+            "description": "アカウントに表示するトレジャリーを管理"
+        },
+        "stats": {
+            "title": "統計",
+            "description": "すべてのSputnik DAOトレジャリーで管理されている資産のリアルタイム表示。"
+        },
+        "telegram": {
+            "title": "トレジャリーを接続",
+            "description": "トレジャリーをTelegramチャットにリンク",
+            "metaTitle": "Trezu — Telegramを接続",
+            "metaDescription": "TrezuトレジャリーをTelegramチャットに接続"
+        },
+        "wallet": {
+            "title": "Trezuウォレット",
+            "description": "Trezu経由でトレジャリー提案に署名"
+        }
+    },
+    "depositModal": {
+        "validation": {
+            "selectAsset": "資産を選択してください",
+            "selectNetwork": "ネットワークを選択してください"
+        },
+        "sections": {
+            "supportedNetworks": "対応ネットワーク",
+            "networksWithAssets": "資産のあるネットワーク",
+            "yourAssets": "あなたの資産",
+            "otherAssets": "その他の資産"
+        },
+        "errors": {
+            "addressUnavailable": "選択した資産とネットワークの入金アドレスを取得できませんでした。",
+            "fetchFailed": "入金アドレスの取得に失敗しました。もう一度お試しください。"
+        },
+        "title": "入金",
+        "subtitle": "資産とネットワークを選択して入金アドレスを表示",
+        "assetLabel": "資産",
+        "networkLabel": "ネットワーク",
+        "selectAsset": "資産を選択",
+        "selectNetwork": "ネットワークを選択",
+        "otherAssetName": "その他",
+        "otherNetworkInfo": "資産一覧にないトークンも入金できますが、NEARネットワーク経由のみとなります。",
+        "depositAddressHeading": "入金アドレス",
+        "depositAddressSubtitle": "入金アドレスは必ず再確認してください。",
+        "addressLabel": "アドレス",
+        "addressCopied": "アドレスをクリップボードにコピーしました",
+        "memoLabel": "メモ",
+        "memoCopied": "メモをクリップボードにコピーしました",
+        "memoWarning": "このアドレスに資金を送る際は<bold>必ず</bold>メモを含めてください。メモなしで送信すると資金が永久に失われる可能性があります。",
+        "onlyDeposit": "<networkTag>{network}</networkTag>ネットワークから<symbolTag>{symbol}</symbolTag>のみを入金してください。全額を送る前に、まず少額のテストトランザクションで動作を確認することをおすすめします。",
+        "minimumDeposit": "最小入金額は<amountTag>{amount} {symbol}</amountTag>です",
+        "searchByName": "名前で検索"
+    },
+    "assetDetails": {
+        "coinPrice": "コイン価格",
+        "weight": "ウェイト",
+        "source": "ソース",
+        "send": "送金",
+        "exchange": "交換",
+        "comingSoon": "近日公開",
+        "vesting": "ベスティング",
+        "vestedPercent": "{percent}% ベスト済み",
+        "frozen": "凍結",
+        "frozenTooltip": "凍結されたトークンはロックされており使用できません。ストレージ用、ステーキング中、またはまだベスト前である可能性があります。",
+        "vested": "ベスト済み"
+    },
+    "dashboard": {
+        "overview": "トレジャリー資産とアクティビティの概要",
+        "assets": "資産",
+        "balance": "残高",
+        "totalBalance": "総残高",
+        "deposit": "入金",
+        "addAssets": "資産を追加",
+        "hidden": "非表示",
+        "confidentialHidden": "機密トレジャリーの残高は非表示です",
+        "recentActivity": "最近のアクティビティ",
+        "viewAllTransactions": "すべてのトランザクションを表示"
+    },
+    "activity": {
+        "filters": {
+            "createdDate": "作成日",
+            "token": "トークン",
+            "from": "送信元",
+            "to": "送信先"
+        },
+        "tabs": {
+            "all": "すべて",
+            "sent": "送信済み",
+            "received": "受信済み",
+            "stakingRewards": "ステーキング報酬",
+            "exchange": "交換"
+        },
+        "searchPlaceholder": "トランザクションハッシュで検索",
+        "searchPlaceholderShort": "トランザクションハッシュ",
+        "fromPool": "{pool}より",
+        "table": {
+            "type": "タイプ",
+            "transaction": "トランザクション",
+            "from": "送信元",
+            "to": "送信先",
+            "transactionHash": "トランザクションハッシュ",
+            "hashTooltip": "このトランザクションの一意な識別子(ハッシュ)"
+        },
+        "empty": {
+            "title": "トランザクションが見つかりません",
+            "description": "トランザクションが発生するとここに表示されます"
+        },
+        "emptyDashboard": {
+            "title": "まだ表示するものはありません",
+            "description": "トランザクションやアクションが発生するとここに表示されます"
+        },
+        "recentTitle": "最近のトランザクション",
+        "details": {
+            "title": "トランザクションの詳細",
+            "copyAddress": "アドレスをコピー",
+            "addressCopied": "アドレスをクリップボードにコピーしました",
+            "sell": "売却",
+            "receive": "受取",
+            "pending": "保留中",
+            "type": "タイプ",
+            "date": "日付",
+            "from": "送信元",
+            "to": "送信先",
+            "method": "メソッド",
+            "contract": "コントラクト",
+            "transaction": "トランザクション"
+        }
+    },
+    "export": {
+        "types": {
+            "csv": ".CSV",
+            "json": ".JSON",
+            "xlsx": ".XLSX"
+        },
+        "transactionTypes": {
+            "all": "すべてのタイプ",
+            "sent": "送信済み",
+            "received": "受信済み",
+            "stakingRewards": "ステーキング報酬"
+        },
+        "validation": {
+            "invalidEmail": "有効なメールアドレスを入力してください"
+        },
+        "columns": {
+            "submissionTime": "送信時刻",
+            "dateRange": "期間",
+            "generatedBy": "生成者",
+            "status": "ステータス"
+        },
+        "status": {
+            "generating": "生成中",
+            "expired": "期限切れ",
+            "failed": "失敗"
+        },
+        "noPermission": "ファイルをダウンロードする権限がありません。",
+        "download": "ダウンロード",
+        "heading": "最近のトランザクションをエクスポート",
+        "teamOnly": "エクスポートの生成とダウンロードはチームメンバーのみ利用できます。",
+        "creditsUsed": "クレジットをすべて使い切りました",
+        "exportsUsed": "エクスポート枠をすべて使い切りました",
+        "upgradePrompt": "プランをアップグレードして利用を続けてください",
+        "resetPrompt": "プランをアップグレードしてさらにアクセスを得るか、来月の上限リセットをお待ちください。",
+        "tabs": {
+            "generate": "エクスポートを生成",
+            "history": "履歴"
+        },
+        "fields": {
+            "documentType": "ドキュメントタイプ",
+            "timeRange": "期間",
+            "selectDateRange": "期間を選択",
+            "asset": "資産",
+            "allAssets": "すべての資産",
+            "transactionType": "トランザクションタイプ"
+        },
+        "buttons": {
+            "noPermissionExport": "エクスポートする権限がありません",
+            "quotaExhausted": "上限をすべて使い切りました",
+            "exporting": "エクスポート中...",
+            "export": "エクスポート"
+        },
+        "empty": {
+            "title": "エクスポートはまだありません",
+            "description": "過去1ヶ月間のエクスポートファイルが生成されるとここに表示されます。"
+        },
+        "requirements": {
+            "heading": "エクスポートの要件",
+            "canExportFrom": "次の期間のデータをエクスポートできます:",
+            "availability": "エクスポートしたファイルは48時間ダウンロード可能です。"
+        },
+        "quota": {
+            "heading": "エクスポート上限",
+            "unlimited": "無制限",
+            "perMonth": "{count} / 月",
+            "flexibilityPrompt": "もっと柔軟な利用をお探しですか?",
+            "contactUs": "お問い合わせ"
+        }
+    },
+    "requests": {
+        "filters": {
+            "proposalTypes": {
+                "Payments": "支払い",
+                "Exchange": "交換",
+                "Earn": "収益",
+                "Vesting": "ベスティング",
+                "Function Call": "関数呼び出し",
+                "Change Policy": "ポリシー変更",
+                "Settings": "設定",
+                "Confidential": "機密"
+            },
+            "voteStatus": {
+                "Approved": "承認済み",
+                "Rejected": "却下済み",
+                "No Voted": "未投票"
+            },
+            "requestsType": "リクエストタイプ",
+            "createdDate": "作成日",
+            "recipient": "受取人",
+            "token": "トークン",
+            "requester": "依頼者",
+            "approver": "承認者",
+            "myVoteStatus": "自分の投票状況",
+            "all": "すべて",
+            "amount": "金額",
+            "from": "送信元",
+            "to": "送信先",
+            "min": "最小",
+            "max": "最大",
+            "invalidDate": "無効な日付",
+            "operationIsNot": " ではない",
+            "operationBefore": " より前",
+            "operationAfter": " より後",
+            "operationContains": " を含む",
+            "searchByAddress": "アドレスで検索",
+            "loadingMembers": "メンバーを読み込み中...",
+            "noMembersFound": "メンバーが見つかりません。Enterキーで「{query}」を追加します",
+            "noMembersAvailable": "利用可能なメンバーはいません",
+            "reset": "リセット",
+            "clear": "クリア",
+            "addFilter": "フィルターを追加"
+        },
+        "tabs": {
+            "all": "すべて",
+            "pending": "保留中",
+            "executed": "実行済み",
+            "rejected": "却下済み",
+            "expired": "期限切れ",
+            "failed": "失敗"
+        },
+        "searchPlaceholder": "名前またはIDでリクエストを検索",
+        "searchPlaceholderShort": "名前またはIDで検索",
+        "errorLoading": "提案の読み込みに失敗しました。もう一度お試しください。",
+        "empty": {
+            "title": "最初のリクエストを作成しましょう",
+            "description": "支払い、交換などのリクエストは作成されるとここに表示されます。",
+            "send": "送金",
+            "exchange": "交換"
+        },
+        "actions": {
+            "approve": "承認",
+            "reject": "却下",
+            "deposit": "入金",
+            "viewRequest": "リクエストを表示"
+        },
+        "table": {
+            "selectAll": "すべて選択",
+            "selectRow": "行を選択",
+            "request": "リクエスト",
+            "transaction": "トランザクション",
+            "requester": "依頼者",
+            "voting": "投票",
+            "votingTooltip": "最初の数字は受け取った承認数を示し、2つ目の数字は実行に必要な承認数を示します。",
+            "status": "ステータス",
+            "notPending": "提案は保留中ではありません。",
+            "noPermissionVote": "このリクエストに投票する権限がありません。",
+            "alreadyVoted": "このリクエストにはすでに投票済みです。",
+            "noResults": "フィルターに一致するリクエストが見つかりません。",
+            "allCaughtUp": "すべて対応済みです!",
+            "noPending": "保留中のリクエストはありません。",
+            "send": "送金",
+            "exchange": "交換",
+            "requestsSelected": "{count, plural, other {# 件のリクエストを選択}}",
+            "bulkApproveDisabled": "トレジャリーの残高が不足しているため、このリクエストは承認できません。"
+        },
+        "pending": {
+            "title": "保留中のリクエスト",
+            "viewAll": "すべて表示",
+            "emptyTitle": "すべて対応済みです!",
+            "emptyDescription": "保留中のリクエストはありません。"
+        }
+    },
+    "proposals": {
+        "status": {
+            "pending": "保留中",
+            "approved": "承認済み",
+            "rejected": "却下済み",
+            "executed": "実行済み",
+            "expired": "期限切れ",
+            "failed": "失敗",
+            "removed": "削除済み",
+            "inProgress": "進行中"
+        },
+        "statusTooltip": {
+            "pending": "このリクエストはまだ保留中で、実行に必要な投票数に達していません。",
+            "executed": "{required}人中{approved}人のメンバーがリクエストを承認したため実行されました。",
+            "rejected": "{required}人中{rejected}人のメンバーがリクエストを却下したため拒否されました。",
+            "expired": "実行に必要な投票数を獲得できなかったため期限切れとなりました。",
+            "failed": "リクエストの完了に失敗しました。トランザクションの詳細は<link>こちら</link>で確認してください。",
+            "failedPlain": "リクエストの完了に失敗しました。トランザクションの詳細はこちらで確認してください。"
+        },
+        "votes": {
+            "approved": "承認済み",
+            "rejected": "却下済み",
+            "pending": "保留中"
+        },
+        "voteModal": {
+            "confirmTitle": "投票を確認",
+            "removeTitle": "リクエストを削除",
+            "bulkBody": "複数のリクエストを{action}しようとしています。一度送信すると、この決定は変更できません。",
+            "singleBody": "このリクエストを{action}しようとしています。一度確認すると、このアクションは取り消せません。",
+            "actionApprove": "承認",
+            "actionReject": "却下",
+            "actionRemove": "削除",
+            "insufficientBalance": "残高不足のため、リクエスト<highlight>{ids}</highlight>は承認できません。承認は残りのリクエストにのみ適用されます。",
+            "remove": "削除",
+            "confirm": "確認"
+        },
+        "expanded": {
+            "recipient": "受取人",
+            "amount": "金額",
+            "networkFee": "ネットワーク手数料",
+            "notes": "メモ",
+            "sent": "送信済み",
+            "received": "受信済み",
+            "priceDifference": "価格差",
+            "priceDifferenceTooltip": "見積りレートと現在の市場レートの差です。プラスの値は市場よりも有利なレートを示します。",
+            "slippageTolerance": "スリッページ許容範囲",
+            "estimatedTime": "予想時間",
+            "seconds": "{count}秒",
+            "description": "説明",
+            "methodName": "メソッド名",
+            "args": "引数",
+            "deposit": "デポジット",
+            "gas": "ガス",
+            "totalDeposit": "合計デポジット",
+            "totalGas": "合計ガス",
+            "receiverId": "受信者ID",
+            "contractId": "コントラクトID",
+            "actionsCount": "{count, plural, other {# 件のアクション}}",
+            "functionCallsCount": "{count, plural, other {# 件の関数呼び出し}}",
+            "showLess": "表示を減らす",
+            "showMore": "もっと表示",
+            "stakingPool": "ステーキングプール",
+            "validator": "バリデータ",
+            "action": "アクション",
+            "stake": "ステーク",
+            "unstake": "アンステーク",
+            "withdraw": "出金",
+            "lockupOwner": "ロックアップ所有者",
+            "lockupDuration": "ロックアップ期間",
+            "cliff": "クリフ",
+            "releaseDuration": "リリース期間",
+            "vestingSchedule": "ベスティングスケジュール",
+            "cancellable": "キャンセル可能",
+            "allowEarn": "ステーキングを許可",
+            "yes": "はい",
+            "no": "いいえ",
+            "notSet": "未設定",
+            "from": "送信元",
+            "to": "送信先",
+            "paymentsCount": "{count, plural, other {# 件の支払い}}",
+            "sourceWallet": "送信元ウォレット",
+            "allNear": "すべてのNEAR",
+            "startDate": "開始日",
+            "endDate": "終了日",
+            "cliffDate": "クリフ日",
+            "allowCancellation": "キャンセルを許可",
+            "allowStaking": "ステーキングを許可",
+            "loadingHistorical": "過去の設定を読み込み中...",
+            "name": "名前",
+            "purpose": "目的",
+            "logo": "ロゴ",
+            "logoAlt": "ロゴ",
+            "primaryColor": "メインカラー",
+            "noChangesCurrent": "現在の状態と比較して設定に変更は検出されませんでした。",
+            "noChangesHistorical": "過去の状態と比較して設定に変更は検出されませんでした。",
+            "method": "メソッド",
+            "arguments": "引数",
+            "contract": "コントラクト",
+            "actionNumber": "アクション {number}",
+            "actions": "アクション",
+            "collapseAll": "すべて折りたたむ",
+            "expandAll": "すべて展開",
+            "send": "送金",
+            "receive": "受取",
+            "rate": "レート",
+            "priceSlippageLimit": "価格スリッページ上限",
+            "slippageTooltip": "このリクエストに設定されたスリッページ上限です。実行中に市場レートがこの閾値を超えて変動した場合、リクエストは自動的に失敗します。",
+            "estimatedTimeTooltip": "入金トランザクションが確認された後、スワップが実行されるまでの予想時間です。",
+            "minReceive": "最小受取額",
+            "minimumReceived": "最小受取額",
+            "minReceiveTooltip": "リクエストに設定されたスリッページ上限に基づき、この交換で受け取る最小額です。",
+            "depositAddress": "入金アドレス",
+            "depositAddressTooltip": "クロスチェーンスワップ実行のためにトークンが送られる1Click入金アドレスです。",
+            "quoteSignature": "見積り署名",
+            "quoteSignatureTooltip": "この見積りを検証する1Click APIからの暗号署名です。",
+            "quoteDeadline": "1-Click見積り期限",
+            "quoteDeadlineTooltip": "入金アドレスが無効になり、資金が失われる可能性のある時刻です。",
+            "status": "ステータス",
+            "transactionLink": "トランザクションリンク",
+            "viewTransaction": "トランザクションを表示",
+            "recipientNumber": "受取人 {number}",
+            "oopsTitle": "おっと、問題が発生しました",
+            "oopsDescription": "ここに表示するデータが見つかりませんでした。",
+            "totalAmount": "合計金額",
+            "recipients": "受取人",
+            "recipientsCount": "{count, plural, other {# 人の受取人}}",
+            "unsupportedProposal": "未対応の提案タイプ",
+            "requestDetails": "リクエストの詳細",
+            "linkCopied": "リンクをクリップボードにコピーしました",
+            "copyLink": "リンクをコピー",
+            "openRequestPage": "リクエストページを開く",
+            "deleteRequest": "リクエストを削除",
+            "unknownRecipients": "不明な受取人",
+            "loadingConfig": "設定を読み込み中...",
+            "historicalData": "過去のデータ...",
+            "generalUpdate": "一般更新",
+            "detailsUnavailable": "詳細は利用できません",
+            "changesCount": "{count, plural, other {# 件の変更}}",
+            "policyUpdate": "ポリシー更新",
+            "noChangesDetected": "変更は検出されませんでした",
+            "loadingPolicy": "ポリシーを読み込み中...",
+            "roleChanges": "ロールの変更",
+            "policyParameters": "ポリシーパラメータ",
+            "defaultVotePolicy": "デフォルト投票ポリシー",
+            "policyRoleChanges": "ポリシーとロールの変更",
+            "membersAdded": "{count, plural, other {# 名のメンバーを追加}}",
+            "membersRemoved": "{count, plural, other {# 名のメンバーを削除}}",
+            "membersUpdated": "{count, plural, other {# 名のメンバーを更新}}",
+            "rolesModified": "{count, plural, other {# 件のロールを変更}}",
+            "parametersChanged": "{count, plural, other {# 件のパラメータを変更}}",
+            "defaultVotePolicyPart": "デフォルト投票ポリシー",
+            "onReceiver": "{receiver}に対して",
+            "toPrefix": "宛先:",
+            "validatorPrefix": "バリデータ:",
+            "validatorSubtitle": "バリデータ: {address}",
+            "impactTitle": "投票期間変更の影響",
+            "impactBody": "投票期間を更新しようとしています。これは以下の既存リクエストに影響します。",
+            "activeRequestsBullet": "{count, plural, other {# 件のリクエストはこの変更後も投票可能で、有効期限が更新されます。}}",
+            "expiringRequestsBullet": "{count, plural, other {# 件のリクエストは新しい投票期間の下で「期限切れ」と見なされます。}}",
+            "remainActiveHeading": "新しい有効期限で投票可能なリクエスト",
+            "willExpireHeading": "「期限切れ」となるリクエスト",
+            "tableRequest": "リクエスト",
+            "tableTransaction": "トランザクション",
+            "tableNewExpiry": "新しい有効期限",
+            "expireInDays": "{count, plural, other {あと # 日で期限切れ}}",
+            "today": "今日",
+            "uponApproval": "承認時",
+            "yesContinue": "はい、続行します",
+            "transactionCreated": "トランザクションを作成しました",
+            "voting": "投票",
+            "approvalsReceived": "{received}/{required}件の承認を受領",
+            "expiresAt": "有効期限",
+            "expiredAt": "失効日時",
+            "exchangingTokens": "トークンを交換中",
+            "exchangingTokensBody": "このリクエストはチームに承認されました。トークン交換が進行中で、しばらく時間がかかる場合があります。",
+            "requestFailed": "リクエストが失敗しました",
+            "requestFailedBody": "チームはこのリクエストを承認しましたが、レート変動により失敗しました。新しいリクエストを作成して、もう一度お試しください。",
+            "votingPeriod24h": "投票期間: 24時間",
+            "votingPeriod24hBody": "この交換リクエストの投票期間は24時間です。この時間内に承認しないと、リクエストは期限切れとなります。",
+            "reject": "却下",
+            "approve": "承認"
+        },
+        "insufficientBalance": {
+            "noAsset": "必要なトークンがトレジャリーにないため、このリクエストは承認できません。",
+            "bond": "トレジャリーの<token>{symbol}</token>残高が不足しているため、このリクエストは承認できません。提案ボンドを賄うために<token>{amount} {symbol}</token>を追加してください。",
+            "continue": "トレジャリーの<token>{symbol}</token>残高が不足しているため、このリクエストは承認できません。続行するには<token>{amount} {symbol}</token>を追加してください。",
+            "modalTitle": "NEAR残高が不足しています",
+            "modalBodyVote": "ウォレットにこの投票を行うのに十分なNEARがありません。投票には最低<amount>{required} NEAR</amount>の残高が必要です。ウォレットにNEARを追加してから、もう一度お試しください。",
+            "modalBodyProposal": "ウォレットにこのリクエストを作成するのに十分なNEARがありません。リクエスト作成には最低<amount>{required} NEAR</amount>の残高が必要です。ウォレットにNEARを追加してから、もう一度お試しください。",
+            "gotIt": "了解"
+        }
+    },
+    "members": {
+        "title": "メンバー",
+        "description": "チームメンバーと権限を管理",
+        "permissions": "権限",
+        "member": "メンバー",
+        "activeMembers": "アクティブなメンバー",
+        "noActiveMembers": "アクティブなメンバーは見つかりませんでした。",
+        "addNewMember": "新しいメンバーを追加",
+        "membersSelected": "{count, plural, =0 {メンバーが選択されていません} other {# 名のメンバーを選択中}}",
+        "remove": "削除",
+        "edit": "編集",
+        "requestorOnlyTooltip": "このメンバーはNEARNからの支払いリクエスト作成を担当するため、Requestorロールのみ追加できます。",
+        "memberModal": {
+            "editRoles": "ロールを編集",
+            "addNewMember": "新しいメンバーを追加",
+            "validatingAddresses": "アドレスを検証中...",
+            "creatingProposal": "提案を作成中...",
+            "reviewRequest": "リクエストを確認",
+            "noChanges": "メンバーロールに変更はありません"
+        },
+        "previewModal": {
+            "title": "リクエストを確認",
+            "youAreEditing": "編集対象:",
+            "youAreAdding": "追加対象:",
+            "membersCount": "{count, plural, other {# 名のメンバー}}",
+            "newMembersCount": "{count, plural, other {# 名の新しいメンバー}}",
+            "updatedMembers": "更新されたメンバー",
+            "newMembers": "新しいメンバー",
+            "creatingProposal": "提案を作成中...",
+            "confirmSubmit": "確認してリクエストを送信"
+        },
+        "removeDialog": {
+            "title": "リクエストを削除",
+            "nearnBody": "承認されると、{account}はトレジャリーから永久に削除され、関連するすべての権限が取り消されます。削除後、このアカウントはNEARNからリクエストを作成できなくなります。",
+            "genericBody": "承認されると、このアクションにより<bold>{accounts}</bold>がトレジャリーから永久に削除され、割り当てられたすべての権限が取り消されます。",
+            "creatingProposal": "提案を作成中..."
+        },
+        "validation": {
+            "accountIdRequired": "アカウントIDは必須です",
+            "invalidNearAddress": "無効なNEARアドレスです。",
+            "atLeastOneRole": "少なくとも1つのロールを選択する必要があります",
+            "atLeastOneMember": "少なくとも1名のメンバーが必要です",
+            "alreadyAdded": "このメンバーはすでに上記に追加されています",
+            "alreadyInTreasury": "このメンバーはすでにトレジャリーに存在します",
+            "cannotRemoveRoleAfter": "このメンバーから{role}ロールを削除できません。すべての変更後、このロールに割り当てられる唯一の人物となります。",
+            "cannotRemoveRoleAfterGov": "このメンバーから{role}ロールを削除できません。すべての変更後、唯一の{role}メンバーとなり、このロールがないとチームメンバーの管理や投票設定ができなくなります。"
+        },
+        "policy": {
+            "addMembers": "ポリシー更新 - 新しいメンバーを追加",
+            "addMembersSuccess": "新しいメンバーのリクエストが正常に作成されました",
+            "editMember": "ポリシー更新 - メンバー権限を編集",
+            "editMembers": "ポリシー更新 - 複数メンバーを編集",
+            "editMemberSuccess": "メンバーロール更新リクエストが正常に作成されました",
+            "editMembersSuccess": "一括メンバーロール更新リクエストが正常に作成されました",
+            "removeMember": "ポリシー更新 - メンバーを削除",
+            "removeMembers": "ポリシー更新 - メンバーを削除",
+            "removeMemberSuccess": "メンバー削除リクエストが正常に作成されました"
+        }
+    },
+    "settings": {
+        "tabs": {
+            "general": "一般",
+            "voting": "投票",
+            "preferences": "環境設定",
+            "integrations": "連携"
+        },
+        "general": {
+            "validation": {
+                "displayNameRequired": "表示名は必須です",
+                "displayNameMax": "表示名は100文字未満である必要があります"
+            },
+            "proposalDescriptionTitle": "設定の更新 - テーマとロゴ",
+            "proposalSubmitted": "設定更新のリクエストを送信しました",
+            "treasuryNotFound": "トレジャリーが見つかりません",
+            "treasuryName": "トレジャリー名",
+            "treasuryNameDescription": "トレジャリーの名前です。アプリ全体で表示されます。",
+            "displayName": "表示名",
+            "displayNamePlaceholder": "表示名を入力",
+            "accountName": "アカウント名",
+            "logo": "ロゴ",
+            "logoDescription": "トレジャリーのロゴをアップロードしてください。SVG、PNG、またはJPG(256x256ピクセル)を推奨します。",
+            "treasuryLogoAlt": "トレジャリーロゴ",
+            "uploading": "アップロード中...",
+            "uploadLogo": "ロゴをアップロード",
+            "removeLogo": "ロゴを削除",
+            "logoUploaded": "ロゴが正常にアップロードされました",
+            "uploadError": "画像のアップロード中にエラーが発生しました。もう一度お試しください。",
+            "invalidLogo": "無効なロゴです。256x256ピクセルのPNG、JPG、またはSVGファイルをアップロードしてください",
+            "invalidImage": "無効な画像ファイルです。有効な画像をアップロードしてください。",
+            "fileReadError": "ファイルの読み込みエラーです。もう一度お試しください。",
+            "primaryColor": "メインカラー",
+            "primaryColorDescription": "トレジャリーのインターフェース要素のメインカラーを設定します。この色はライトモードとダークモードの両方で使われるため、ニュートラルな色を選ぶ際はコントラストに注意してください。",
+            "selectColorLabel": "色 {color} を選択"
+        },
+        "voting": {
+            "validation": {
+                "required": "投票期間は必須です",
+                "validNumber": "投票期間は有効な数字である必要があります",
+                "min": "投票期間は少なくとも1日必要です",
+                "max": "投票期間は1000日未満である必要があります",
+                "whole": "投票期間は整数の日数である必要があります"
+            },
+            "missingData": "必要なデータが不足しています",
+            "thresholdProposalTitle": "ポリシー更新 - 投票しきい値",
+            "thresholdProposalSummary": "{account}が投票しきい値を{oldValue}から{newValue}に変更するよう要求しました。",
+            "thresholdSubmitted": "投票しきい値更新のリクエストを送信しました",
+            "createProposalFailed": "提案の作成に失敗しました",
+            "durationProposalTitle": "ポリシー更新 - 投票期間",
+            "durationProposalSummary": "{account}が投票期間を{oldValue}から{newValue}に変更するよう要求しました。",
+            "durationSubmitted": "リクエストが正常に作成されました",
+            "pendingTitle": "アクティブな投票しきい値リクエスト",
+            "pendingBody": "競合を避けるため、続行する前に既存の保留中リクエストを完了または解決する必要があります。これらのリクエストは現在アクティブで、まず承認または却下する必要があります。",
+            "viewRequest": "リクエストを表示",
+            "thresholdHeading": "投票しきい値",
+            "thresholdDescriptionApprovers": "支払いやチーム関連のリクエストの承認に必要な票数を定義します。Approver(承認者)とGovernance(ガバナンス)で別々にしきい値を設定してください。",
+            "thresholdDescriptionGeneric": "リクエスト承認に必要な票数を定義します。各ロールの責任に応じてしきい値を設定してください。",
+            "membersWhoCanVote": "投票できるメンバー",
+            "votesRequired": "リクエスト承認に必要な票数",
+            "durationHeading": "投票期間",
+            "durationDescription": "提案が投票可能なまま残る期間(日数)です。この期間内に投票が完了しないと、決定は失効します。",
+            "durationApprovers": " この期間はGovernanceとApproverの両ロールに等しく適用されます。",
+            "durationGeneric": " この期間はすべてのトレジャリーロールに一貫して適用されます。",
+            "days": "日"
+        },
+        "preferences": {
+            "timeZone": "タイムゾーン",
+            "timeZoneDescription": "正確な日時表示のためにローカルタイムゾーンを設定してください。",
+            "timeFormat": "時刻形式",
+            "hour12": "12時間制 (1:00 PM)",
+            "hour24": "24時間制 (13:00)",
+            "autoTimezone": "現在地に基づいてタイムゾーンを自動設定",
+            "timezone": "タイムゾーン",
+            "loadingTimezones": "タイムゾーンを読み込み中...",
+            "selectTimezone": "タイムゾーンを選択",
+            "searchTimezones": "タイムゾーンを検索...",
+            "noTimezones": "タイムゾーンが見つかりません",
+            "save": "保存",
+            "savedToast": "環境設定が正常に保存されました",
+            "saveFailed": "環境設定の保存に失敗しました",
+            "loadFailed": "タイムゾーンの読み込みに失敗しました"
+        }
+    },
+    "addressBook": {
+        "emptyTitle": "最初の受取人を追加",
+        "emptyDescription": "頻繁に使用するアドレスを保存して、より速く、エラーのない支払いを実現します。連絡先は非公開で、チームのみが閲覧できます。",
+        "import": "インポート",
+        "addRecipient": "受取人を追加",
+        "recipientsHeading": "受取人",
+        "recipientsSelected": "{count, plural, =0 {受取人が選択されていません} other {# 人の受取人を選択中}}",
+        "sectionHeading": "受取人",
+        "privacyNote": "保存されたアドレスは非公開で、チームのみが閲覧できます。",
+        "searchPlaceholder": "名前で受取人を検索",
+        "searchPlaceholderShort": "検索",
+        "review": {
+            "header": "詳細を確認",
+            "youAreAdding": "追加対象:",
+            "newRecipients": "{count, plural, other {# 人の新しい受取人}}",
+            "onNetworks": "{count, plural, other {# 件のネットワーク}}上",
+            "recipients": "受取人",
+            "allDuplicates": "インポートされたすべての受取人はすでにアドレス帳に存在します。戻って別のリストをアップロードするか、このレビューから重複を削除してください。",
+            "someDuplicates": "合計{total}人中{duplicates}人が重複しています。続行すると新しい受取人のみがインポートされます。",
+            "duplicated": "重複",
+            "notePlaceholder": "この受取人を識別するためのメモを追加(例: 業務委託支払い、ベスティング配布)。",
+            "skipDuplicates": "重複をスキップして新しいもののみインポートします。",
+            "allDuplicatesTooltip": "インポートされたすべての受取人はすでにアドレス帳にあるため、新しくインポートするものはありません。",
+            "duplicateActionTooltip": "続行するには重複スキップを有効化するか、重複する受取人を削除してください。",
+            "adding": "追加中…",
+            "nothingNew": "新しくインポートするものはありません",
+            "addRecipientsButton": "{count, plural, other {受取人を追加}}"
+        },
+        "removeDialog": {
+            "title": "受取人を削除",
+            "bulk": "アドレス帳から<bold>{count, plural, other {# 人の受取人}}</bold>を削除します。いつでも再度追加できます。",
+            "single": "アドレス帳から<bold>{name}</bold>を削除します。この受取人はいつでも再度追加できます。"
+        },
+        "importFlow": {
+            "title": "受取人をインポート",
+            "description": "受取人アドレスのリストをアドレス帳にアップロードします。",
+            "foundSummary": "{networkCount, plural, other {# 件のネットワーク}}上で{count, plural, other {# 人の受取人}}を発見",
+            "uploadPrompt": "受取人データをアップロードまたは貼り付け",
+            "fixErrors": "続行するにはエラーを修正してください",
+            "continueReview": "確認に進む"
+        },
+        "form": {
+            "editRecipient": "受取人を編集",
+            "addRecipient": "受取人を追加",
+            "import": "インポート",
+            "recipientName": "受取人の名前",
+            "namePlaceholder": "Alice",
+            "recipientAddress": "受取人のアドレス",
+            "network": "ネットワーク",
+            "networkInfo": "このアドレスと互換性のあるネットワーク",
+            "enterAddressFirst": "先に受取人アドレスを入力してください",
+            "selectNetwork": "ネットワークを選択",
+            "selectNetworksTitle": "ネットワークを選択",
+            "searchNetworksPlaceholder": "ネットワークを検索…",
+            "done": "完了",
+            "edit": "編集",
+            "remove": "削除",
+            "incomplete": "未完了",
+            "addAnother": "別の受取人を追加",
+            "fillAllTooltip": "受取人を追加するにはすべての項目を入力する必要があります。",
+            "reviewDetails": "詳細を確認",
+            "reviewTooltip": "確認前にすべての受取人を完成させる必要があります。",
+            "invalidAddress": "無効なアドレス",
+            "noCompatibleNetworks": "このアドレスと互換性のあるネットワークはありません"
+        },
+        "parsing": {
+            "rowPrefix": "行 {row}: {message}",
+            "missingName": "受取人の名前がありません。名前を追加してください。",
+            "missingAddress": "受取人のアドレスがありません。ウォレットアドレスを追加してください。",
+            "invalidAddressFormat": "アドレス「{address}」は対応するどのネットワークでも有効な形式ではありません。",
+            "unknownNetwork": "不明なネットワーク「{network}」。対応ネットワーク: {available}。",
+            "incompatibleNetwork": "アドレス「{address}」は{network}と互換性がありません。互換性のあるネットワーク: {compatible}。",
+            "noDataFound": "データが見つかりません。受取人を次の形式で追加してください: 名前、アドレス、ネットワーク、メモ",
+            "headerColumnsNotFound": "ヘッダー行を検出しましたが、「Name」と「Address」の列が見つかりませんでした。これらの列名を使用するか、ヘッダー行を削除してください。",
+            "failedToParseCsv": "CSVデータの解析に失敗しました"
+        }
+    },
+    "payments": {
+        "validation": {
+            "recipientMin": "受取人は少なくとも2文字必要です",
+            "recipientMax": "受取人は128文字未満である必要があります",
+            "amountPositive": "金額は0より大きくなければなりません",
+            "recipientTokenSame": "受取人とトークンアドレスは同じであってはなりません"
+        },
+        "newPayment": "新しい支払い",
+        "reviewYourPayment": "支払いを確認",
+        "reviewButton": "支払いを確認",
+        "reviewButtonDisabled": "金額とアドレスを入力してください",
+        "comingSoon": "近日公開",
+        "bulkPayments": "一括支払い",
+        "summaryRecipients": "{count, plural, other {# 人の受取人}}へ",
+        "networkFee": "ネットワーク手数料",
+        "networkFeeInfo": "ネットワーク手数料情報",
+        "commentPlaceholder": "コメントを追加(任意)...",
+        "preparingRoute": "1Click送金ルートを準備中...",
+        "confirmSubmit": "確認してリクエストを送信",
+        "useDifferentAddress": "別のアドレスを使用",
+        "failed1ClickQuote": "1Click送金見積りの作成に失敗しました",
+        "paymentSubmitted": "支払い送信のリクエストを送信しました"
+    },
+    "bulkPayment": {
+        "comingSoonToast": "一括支払いは近日公開予定です!",
+        "submittingList": "一括支払いリストを送信中",
+        "submittingProposal": "提案を送信中",
+        "proposalSubmitted": "一括支払い提案が送信されました",
+        "submitListFailed": "支払いリストの送信に失敗しました",
+        "submitFailed": "一括支払いの送信に失敗しました",
+        "upload": {
+            "pleaseUploadCsv": "CSVファイルをアップロードしてください",
+            "fileSizeLimit": "ファイルサイズは1.5MB未満である必要があります",
+            "headerTitle": "一括支払いリクエスト",
+            "headerSubtitle": "1つの提案で複数の受取人に支払いを行います。",
+            "creditsUsed": "クレジットをすべて使い切りました",
+            "bulkPaymentsUsed": "一括支払い枠をすべて使い切りました",
+            "upgradeTrial": "プランをアップグレードして利用を続けてください",
+            "upgradePaid": "プランをアップグレードしてさらにアクセスを得るか、来月の上限リセットをお待ちください。",
+            "selectAsset": "資産を選択",
+            "disableTokenMessage": "これらのトークンの一括支払いは近日公開予定です。",
+            "providePaymentData": "支払いデータを提供",
+            "uploadFile": "ファイルをアップロード",
+            "provideData": "データを提供",
+            "chooseFile": "ファイルを選択",
+            "orDragDrop": "またはドラッグ&ドロップ",
+            "maxFileSize": "最大1ファイル、1.5MBまで、CSVファイルのみ",
+            "noFilePrompt": "アップロードするファイルがない場合は?",
+            "downloadTemplate": "テンプレートをダウンロード",
+            "requirements": "一括支払いの要件",
+            "maxTransactions": "1回のインポートで最大{max}件のトランザクション",
+            "singleTokenNetwork": "単一のトークンとネットワーク",
+            "limitsUsed": "上限をすべて使い切りました",
+            "selectAndProvide": "資産を選択し、支払いデータを提供してください",
+            "continueToReview": "確認に進む",
+            "selectTokenError": "トークンを選択してください",
+            "providePaymentDataError": "支払いデータを提供してください"
+        },
+        "editStep": {
+            "title": "支払いを編集",
+            "saveChanges": "変更を保存"
+        },
+        "parsing": {
+            "rowPrefix": "行 {row}: {message}",
+            "missingRecipientFirstColumn": "受取人アドレスがありません。最初の列にアドレスを追加してください。",
+            "invalidNearAddress": "アドレス「{address}」は有効なNEARアカウントではありません。",
+            "invalidChainAddress": "アドレス「{address}」は有効な{chain}アカウントではありません。",
+            "rowNeedsAmountRecipient": "各行にはカンマで区切られた金額と受取人が必要です。例: 100, alice.near",
+            "missingRecipientBeforeComma": "受取人アドレスがありません。カンマの前にアドレスを追加してください。",
+            "missingAmountAfterComma": "金額がありません。カンマの後に数字を追加してください。例: {recipient}, 100",
+            "invalidAmountNumber": "金額「{amountStr}」は有効な数字ではありません。数字と小数のみを使用してください(例: 100または100.50)。",
+            "amountGreaterThanZero": "金額は0より大きくなければなりません。「{amountStr}」が入力されました。",
+            "amountTooLarge": "金額「{amountStr}」が大きすぎます。より小さい数字を使用してください。",
+            "invalidAmountFallback": "無効な金額です。数字と小数のみを使用してください(例: 100または100.50)。",
+            "pleaseRemoveChars": "次の文字を削除してください: {chars}。数字、カンマ、ドットのみが使用可能です。",
+            "amountCannotBeEmpty": "金額は空にできません。",
+            "tokenMismatch": "「{provided}」が入力されましたが、上で{expected}が選択されています。トークンシンボルを削除するか、ドロップダウンから{suggested}を選択してください。",
+            "multipleTokenSymbols": "複数のトークンシンボル({symbols})が使用されています。ファイル全体で1種類のトークンのみを使用するか、トークンシンボルを削除して上の選択でトークンを決定してください。",
+            "noPaymentDataFound": "支払いデータが見つかりません。次の形式で支払いを追加してください: 受取人、金額",
+            "exceedsRecipientLimit": "{count}人の受取人がいますが、バッチあたりの上限は{limit}です。{excess, plural, other {# 人の受取人}}を削除するか、複数のバッチに分割してください。",
+            "noPaymentDataProvided": "支払いデータが提供されていません。次の形式で支払いを入力してください: 受取人、金額",
+            "headerColumnsNotFound": "ヘッダー行を検出しましたが、「Recipient」と「Amount」の列が見つかりませんでした。これらの列名を使用するか、ヘッダー行を削除してください。",
+            "failedToParseCsv": "CSVデータの解析に失敗しました",
+            "failedToParsePaste": "貼り付けデータの解析に失敗しました",
+            "failedToValidateAccount": "アカウントの検証に失敗しました",
+            "feeEstimationFailed": "この金額のネットワーク手数料を見積もれませんでした。確認してもう一度お試しください。",
+            "feeEstimationFailedRow": "行 {row} ({recipient}): この金額のネットワーク手数料を見積もれませんでした。確認してもう一度お試しください。"
+        },
+        "recipients": "受取人",
+        "insufficientTokens": "トークンが不足しています。リクエストを送信してから承認前に補充できます。",
+        "removeRecipient": "受取人を削除",
+        "removeRecipientConfirm": "<strong>{recipient}</strong>への支払いを削除してもよろしいですか?この操作は取り消せません。",
+        "remove": "削除",
+        "edit": "編集"
+    },
+    "bulkPaymentCredits": {
+        "title": "一括支払い",
+        "unlimited": "無制限",
+        "creditsPerPeriod": "{amount} / {period}",
+        "oneTimeTrial": "1回限りのトライアル",
+        "month": "月",
+        "moreFlexibility": "もっと柔軟な利用をお探しですか?",
+        "contactUs": "お問い合わせ"
+    },
+    "exchange": {
+        "validation": {
+            "amountPositive": "金額は0より大きくなければなりません"
+        },
+        "requestSubmitted": "交換リクエストを送信しました",
+        "heading": "交換",
+        "sell": "売却",
+        "receive": "受取",
+        "slippageTolerance": "スリッページ許容範囲",
+        "disabled": {
+            "differentTokens": "トークンは異なる必要があります",
+            "enterAmount": "交換する金額を入力してください"
+        },
+        "review": "交換を確認",
+        "poweredBy": "提供:",
+        "info": {
+            "priceDifference": "価格差",
+            "priceDifferenceTooltip": "見積りレートと現在の市場レートの差です。プラスの値は市場よりも有利なレートを示します。",
+            "estimatedTime": "予想時間",
+            "estimatedTimeValue": "{seconds}秒",
+            "estimatedTimeTooltip": "交換完了までのおおよその時間です。",
+            "minimumReceived": "最小受取額",
+            "minimumReceivedTooltip": "リクエストに設定されたスリッページ上限に基づき、この交換で受け取る最小額です。",
+            "depositAddress": "入金アドレス",
+            "depositAddressCopied": "入金アドレスをコピーしました",
+            "quoteExpires": "見積り有効期限",
+            "exchangeFee": "交換手数料",
+            "exchangeFeeTooltip": "ここで発生する0.70%の手数料は、取引を仲介するNEAR IntentsプロトコルのコストとTrezuウィジェット手数料を賄います。この金額は見積りレートに自動的に含まれています。"
+        },
+        "approveWithin24h": "このリクエストは24時間以内に承認してください。期限を過ぎると失効します。できるだけ早く確認することをおすすめします。",
+        "confirmSubmit": "確認してリクエストを送信",
+        "refreshingIn": "交換レートは{seconds}秒後に更新されます"
+    },
+    "vesting": {
+        "validation": {
+            "amountMin": "金額は3.5以上である必要があります",
+            "startBeforeEnd": "開始日は終了日より前である必要があります",
+            "cliffBetween": "クリフ日は次の範囲内である必要があります"
+        },
+        "stepTitles": {
+            "details": "詳細",
+            "settings": "設定",
+            "review": "確認"
+        },
+        "proposalTitle": "{address}のベスティングスケジュールを作成",
+        "scheduleSubmitted": "ベスティングスケジュール作成のリクエストを送信しました",
+        "heading": "新しいベスティングスケジュール",
+        "amount": "金額",
+        "startDate": "開始日",
+        "endDate": "終了日",
+        "noteOptional": "メモ(任意)",
+        "continue": "続ける",
+        "advancedSettings": "詳細設定",
+        "allowCancellation": "キャンセルを許可",
+        "allowCancellationDescription": "NEAR Foundationがいつでもロックアップをキャンセルできるようにします。キャンセル不可のロックアップはクリフ日と互換性がありません。",
+        "cliffDate": "クリフ日",
+        "allowEarn": "収益を許可",
+        "allowEarnDescription": "ロックアップの所有者が、ロックアップ内のすべてのトークンをステーキングすることを許可します(クリフ日より前でも可能)。",
+        "commentPlaceholder": "このベスティングスケジュールへのコメントを追加(任意)...",
+        "reviewRequest": "リクエストを確認",
+        "reviewHeading": "ベスティングスケジュールを確認",
+        "confirmSubmit": "確認してリクエストを送信",
+        "review": {
+            "recipient": "受取人",
+            "startDate": "開始日",
+            "endDate": "終了日",
+            "cliffDate": "クリフ日",
+            "cancelable": "キャンセル可能",
+            "allowEarn": "収益を許可",
+            "na": "該当なし"
+        }
+    },
+    "earn": {
+        "placeholder": "収益機会とステーキング報酬を確認できます。"
+    },
+    "createTreasury": {
+        "validation": {
+            "nameMin": "トレジャリー名は少なくとも2文字必要です",
+            "nameMax": "トレジャリー名は64文字未満である必要があります",
+            "accountMin": "アカウント名は少なくとも2文字必要です",
+            "accountMax": "アカウント名は64文字未満である必要があります",
+            "accountChars": "アカウント名にはラテン文字、数字、ハイフンのみ使用できます",
+            "accountTaken": "このアカウント名はすでに使用されています"
+        },
+        "votingNote": "投票設定を変更するにはより多くのメンバーが必要です。投票を設定するには別のメンバーを追加してください。",
+        "minimumVoteNote": "最低1票の承認が必要です。",
+        "heading": "トレジャリーを作成",
+        "addMembers": "メンバーを追加",
+        "addMembersInfo": "今メンバーを追加・更新できます。後でいつでも編集可能です。",
+        "treasuryName": "トレジャリー名",
+        "treasuryNamePlaceholder": "My Treasury",
+        "accountName": "アカウント名",
+        "accountNameInfo": "これはあなたのアカウントの一意の名前です。トレジャリーURLで使用され、トランザクションで送金者を識別するために表示されます。短くて認識しやすい名前を選んでください。",
+        "accountPlaceholder": "my-treasury",
+        "continue": "続ける",
+        "votingThreshold": "投票しきい値",
+        "thresholdDescription": "リクエストの承認に必要な票数を設定:",
+        "financial": "Financial",
+        "financialDescription": "支払いと交換のリクエストを承認します。",
+        "governance": "Governance",
+        "governanceDescription": "設定、メンバー、投票設定を承認します。",
+        "confidential": "機密",
+        "public": "公開",
+        "anyone": "誰でも",
+        "teamOnly": "チームのみ",
+        "soon": "もうすぐ",
+        "publicDescription": "残高、アクティビティ、トランザクションはすべてブロックチェーン上で誰でも閲覧可能です。透明性のある組織や公開DAOに最適です。",
+        "balanceTransactions": "残高、トランザクション",
+        "membersVoting": "メンバー、投票",
+        "allFeatures": "すべての機能が利用可能",
+        "confidentialDescription": "残高、アクティビティ、送金はすべてブロックチェーン上で非公開です。チームのみがこの情報を閲覧できます。プライベート企業、ファミリーオフィス、財務プライバシーを求めるチームに最適です。",
+        "recentTransactionsExport": "最近のトランザクションのエクスポート",
+        "bulkPayment": "一括支払い",
+        "treasuryType": "トレジャリーの種類",
+        "treasuryTypeWarning": "トレジャリーごとに1回のみ選択でき、後から変更できません。",
+        "select": "選択",
+        "visibleOnChain": "オンチェーンで可視",
+        "featuresAvailable": "利用可能な機能",
+        "mostFeaturesSupported": "ほとんどの機能をサポート",
+        "reviewTreasury": "トレジャリーを確認",
+        "membersLabel": "メンバー",
+        "financialThreshold": "Financialしきい値",
+        "governanceThreshold": "Governanceしきい値",
+        "noDeploymentFee": "🎉 デプロイ手数料無料",
+        "noDeploymentFeeDescription": "新しいプロジェクトを支援するため、TREZUは1回限りのデプロイとネットワークストレージ手数料をすべて負担します。",
+        "createButton": "トレジャリーを作成",
+        "connectWalletCreate": "トレジャリー作成のためにウォレットを接続",
+        "unexpectedError": "予期しないエラーが発生しました",
+        "creationFailed": "トレジャリーの作成に失敗しました。もう一度お試しください。",
+        "stepTitles": {
+            "aboutYou": "あなたについて",
+            "details": "詳細",
+            "members": "メンバー",
+            "treasuryType": "トレジャリーの種類",
+            "review": "確認"
+        },
+        "steps": {
+            "creatingNear": "NEAR上にトレジャリーを作成中",
+            "registeringKey": "公開鍵を登録中",
+            "settingUpConfidential": "機密トランザクションを設定中",
+            "configuringMembers": "トレジャリーのメンバーを設定中",
+            "finalizingSetup": "セットアップを完了中"
+        }
+    },
+    "manageTreasuries": {
+        "warningOne": "少なくとも1つのトレジャリーは利用可能なままにする必要があります",
+        "warningOnePeriod": "少なくとも1つのトレジャリーは利用可能なままにする必要があります。",
+        "activeHeading": "アクティブなトレジャリー",
+        "activeDescription": "現在アカウント一覧に表示されているトレジャリーです。",
+        "activeEmpty": "アクティブなトレジャリーはありません。",
+        "hiddenHeading": "非表示のトレジャリー",
+        "hiddenDescription": "アカウント一覧から非表示にされているトレジャリーです。",
+        "removeGuestTitle": "ゲストトレジャリーを削除",
+        "removeDialog": "<bold>{name}</bold>を削除しようとしています。確認後、この操作は取り消せません。",
+        "tooltips": {
+            "removeFromList": "一覧から削除",
+            "viewTreasury": "トレジャリーを表示",
+            "hideFromList": "一覧から非表示",
+            "showInList": "一覧に表示"
+        }
+    },
+    "wallet": {
+        "proposal": {
+            "transfer": "外部dAppからの提案: {receiverId}にNEARを送金",
+            "functionCall": "外部dAppからの提案: {receiverId}で{methods}",
+            "unsupportedAction": "未対応のアクションタイプ「{type}」。TransferとFunctionCallアクションのみTrezu提案に変換できます。"
+        },
+        "loading": "読み込み中...",
+        "connectPrompt": "続行するにはNEARウォレットを接続してください。その後、代理として動作するトレジャリーを選択します。",
+        "connectWallet": "ウォレットを接続",
+        "cancel": "キャンセル",
+        "connectedAs": "<strong>{account}</strong>として接続中",
+        "loadingTreasuries": "トレジャリーを読み込み中...",
+        "selectSignIn": "サインインするトレジャリーを選択:",
+        "selectSignTx": "提案を作成するトレジャリーを選択:",
+        "notMember": "あなたはどのトレジャリーのメンバーでもありません。",
+        "actingAs": "代理として動作中:",
+        "signedBy": "{account}が署名",
+        "createsNProposals": "次のために{count, plural, other {# 件のTrezu提案}}を作成します:",
+        "proposalDescriptionLabel": "提案の説明(任意)",
+        "proposalDescriptionPlaceholder": "この提案を説明してください...",
+        "createProposal": "提案を作成",
+        "creatingProposal": "提案を作成中...",
+        "confirmInWallet": "ウォレットで確認してください",
+        "proposalSubmitted": "提案を送信しました",
+        "shareProposal": "提案が作成されました。下のリンクをトレジャリーメンバーと共有して投票してもらってください。",
+        "proposalLink": "{daoId} — 提案 #{id}",
+        "checking": "確認中...",
+        "proposalApprovedProceed": "提案が承認されました。続行してください",
+        "signedInSuccess": "正常にサインインしました",
+        "proposalCreatedSuccess": "提案が正常に作成されました",
+        "closeWindow": "このウィンドウを閉じることができます。",
+        "errorGeneric": "エラーが発生しました",
+        "tryAgain": "もう一度お試しください",
+        "errors": {
+            "parseTx": "トランザクションリクエストの解析に失敗しました。もう一度お試しください。",
+            "fetchTreasuries": "トレジャリーの取得に失敗しました。もう一度お試しください。",
+            "connectFailed": "ウォレットの接続に失敗しました",
+            "createProposalFailed": "提案の作成に失敗しました",
+            "stillPending": "提案はまだ承認待ちです。トレジャリーメンバーの投票をお待ちください。",
+            "wasStatus": "提案 #{id} は{status}でした",
+            "awaitIndex": "提案は承認されましたが、実行トランザクションがまだインデックスされていません。少し時間を置いてからもう一度お試しください。",
+            "checkStatusFailed": "提案ステータスの確認に失敗しました",
+            "userCancelled": "ユーザーがキャンセルしました",
+            "proposalWasStatus": "提案は{status}でした"
+        }
+    },
+    "telegram": {
+        "tagPill": "Telegram",
+        "invalidLinkTitle": "無効なリンク",
+        "invalidLinkDescription": "このTelegram接続リンクにはトークンがありません。Telegramで「トレジャリーを接続」を再度クリックして新しいリンクを生成してください。",
+        "successTitle": "正常に接続されました",
+        "successDescription": "トレジャリーがこのTelegramチャットにリンクされました。",
+        "successToast": "トレジャリーが正常に接続されました",
+        "goToApp": "アプリへ移動",
+        "linkExpiredTitle": "リンクが期限切れです",
+        "linkExpiredDescription": "このリンクは期限切れか、すでに使用されています。Telegramで以下のコマンドを入力して接続フローを再開してください。",
+        "commandCopied": "コマンドをコピーしました",
+        "copy": "コピー",
+        "unableToLoadTitle": "チャットを読み込めません",
+        "unableToLoadDescription": "現在チャットの詳細を読み込めません。Telegramから再試行してください。",
+        "signInTitle": "続行するにはサインインしてください",
+        "signInDescription": "まずNEARウォレットを接続し、次にこのTelegramチャットにリンクするトレジャリーを選択してください。",
+        "connectWallet": "ウォレットを接続",
+        "selectTreasuriesTitle": "トレジャリーを選択",
+        "selectTreasuriesDescription": "このTelegramチャットに接続するトレジャリーを選択してください。",
+        "telegramChat": "Telegramチャット",
+        "chatIdFallback": "チャット #{id}",
+        "failedToConnect": "トレジャリーの接続に失敗しました。もう一度お試しください。",
+        "relinking": "{count, plural, other {# 件の選択されたトレジャリーは別のTelegramチャットにリンクされています。接続するとチャットIDのリンクがこのチャットに変更されます。}}",
+        "alreadyConnected": "このチャットにはすでに接続されています",
+        "connectedToAnother": "別のチャットに接続されています",
+        "notMember": "あなたはどのトレジャリーのポリシーメンバーでもありません。",
+        "connecting": "接続中…",
+        "connect": "接続"
+    },
+    "systemStatus": {
+        "underMaintenance": "メンテナンス中",
+        "maintenanceMessage": "現在メンテナンスを実施しています。一部の機能が一時的に利用できない場合があります。しばらくしてから再度ご確認ください。"
+    },
+    "creditsQuota": {
+        "available": "{count} 利用可能",
+        "used": "{count} 使用済み",
+        "resetOn": "上限は{date}にリセットされます"
+    },
+    "approvalInfo": {
+        "infoText": "支払い関連リクエストの承認に必要な票数。投票設定で編集可能です。",
+        "thresholdPill": "しきい値 {required}/{total}",
+        "alertBody": "この支払いの実行には、トレジャリーメンバー<bold>{required}</bold>名の承認が必要です。"
+    },
+    "guestBadge": {
+        "title": "ゲスト",
+        "tooltip": "あなたはこのトレジャリーのゲストです。データの閲覧のみ可能です。"
+    },
+    "exportButton": {
+        "confidentialTooltip": "機密モードではエクスポートはまだ利用できません。この機能は近日公開予定です!"
+    },
+    "sponsoredActions": {
+        "titleExhausted": "スポンサー付きアクションを使い切りました",
+        "titleAlmost": "チームのスポンサー付きアクションがもうすぐなくなります",
+        "closeNotice": "通知を閉じる",
+        "teamUsage": "チーム使用量: 月あたり{total}アクション",
+        "available": "{count} 利用可能",
+        "used": "{count} 使用済み",
+        "exhaustedBody": "チームは月のスポンサー付きアクション上限に達しました。{date}以降に再開できますが、お問い合わせも可能です",
+        "almostBody": "TREZUは現在、リクエスト作成や投票などすべてのチームアクションのストレージコストをスポンサーしています。チームは月間スポンサー上限に近づいています。",
+        "contactUs": "お問い合わせ",
+        "nextMonthlyReset": "次の月次リセット",
+        "sidebarBody": "チームは月のスポンサー付きアクション上限に達しました。{date}以降に再開できます ⬇️"
+    },
+    "acceptTerms": {
+        "title": "続行するには利用規約に同意してください",
+        "privacyTitle": "Trezuでのプライバシー",
+        "privacyBody": "Trezuはノンカストディアル(非保管型)インターフェースです。プラットフォームの安全性と機能性を保ちながら、プライバシーを最優先します。",
+        "minimalTitle": "最小限のデータ",
+        "minimalBody": "インターフェースの運営と改善のために、公開ウォレットアドレス、IPアドレス、利用分析など限られた情報を収集します。",
+        "noCustodyTitle": "非保管",
+        "noCustodyBody": "秘密鍵、リカバリーフレーズ、デジタル資産には一切アクセスしません。",
+        "publicTitle": "公開記録",
+        "publicBody": "すべてのブロックチェーントランザクションは本質的に公開されており、当社が制御するものではないことにご注意ください。",
+        "responsibilityTitle": "あなたの責任",
+        "responsibilityBody": "ウォレットのアクティビティの監視と認証情報の保護は、すべてあなたの責任となります。",
+        "futureTitle": "今後のアップデート",
+        "futureBody": "今後の通知(メールやTelegramなど)にオプトインする場合、そのデータは情報提供のためだけに使用します。",
+        "agreement": "<terms>利用規約</terms>と<privacy>プライバシーポリシー</privacy>を読み、同意します",
+        "accepting": "同意中...",
+        "continue": "続ける"
+    },
+    "confidentialBanner": {
+        "label": "機密",
+        "description": "残高、アクティビティ、送金はチームのみが閲覧でき、公開ブロックチェーンには表示されません。"
+    },
+    "supportCenter": {
+        "title": "サポートセンター",
+        "resources": "リソース",
+        "support": "サポート",
+        "websiteTitle": "Trezuウェブサイト",
+        "websiteDescription": "Trezuの詳細を確認し、ブログを読みましょう。",
+        "demo": "Trezuデモ",
+        "demoTitle": "公開バージョンを探索",
+        "demoDescription": "ライブの公開アカウントを実際に見てみましょう。",
+        "confidentialDemoTitle": "機密バージョンを探索",
+        "confidentialDemoDescription": "ライブの機密アカウントを実際に見てみましょう。",
+        "videoTitle": "デモを見る",
+        "videoDescription": "Trezuの動作を示す短い動画をご覧ください。",
+        "xTitle": "Xでフォロー",
+        "xDescription": "最新リリースやインサイトの最新情報を入手しましょう。",
+        "statsTitle": "統計",
+        "statsDescription": "すべてのSputnik DAOで管理されている総資産を表示します。",
+        "docsTitle": "ドキュメント",
+        "docsDescription": "ドキュメントですべての機能について学びましょう。",
+        "productSupportTitle": "製品サポート",
+        "productSupportDescription": "サポートチームに問い合わせてヘルプを受けましょう。"
+    },
+    "progressModal": {
+        "titleCreating": "トレジャリーを作成中...",
+        "titleDone": "トレジャリーが作成されました",
+        "titleFailed": "トレジャリーの作成に失敗しました",
+        "viewTreasury": "トレジャリーを表示"
+    },
+    "memberValidation": {
+        "noManagePermission": "メンバーを管理する権限がありません",
+        "pendingRequest": "アクティブなリクエストがある間はメンバーを管理できません",
+        "rolesAnd": "{first}と{second}",
+        "rolesMany": "{list}、および{last}",
+        "cannotRemoveMember": "このメンバーは削除できません。{roles}{count, plural, other {ロール}}に割り当てられている唯一の人物です。",
+        "cannotRemoveMemberGov": "このメンバーは削除できません。{roles}{count, plural, other {ロール}}に割り当てられている唯一の人物で、これはチームメンバーの管理と投票設定に必要です。",
+        "cannotBulkRemove": "これらのメンバーは削除できません。{roles}{count, plural, other {ロール}}が空になってしまいます。",
+        "cannotBulkRemoveGov": "これらのメンバーは削除できません。{roles}{count, plural, other {ロール}}が空になってしまい、これはチームメンバーの管理と投票設定に必要です。",
+        "cannotRemoveRole": "このメンバーから{role}ロールを削除できません。このロールに割り当てられている唯一の人物です。",
+        "cannotRemoveRoleGov": "このメンバーから{role}ロールを削除できません。唯一の{role}メンバーであり、このロールがないとチームメンバーの管理や投票設定ができなくなります。"
+    },
+    "roleSelector": {
+        "setRole": "ロールを設定",
+        "allRoles": "すべてのロール",
+        "roles": {
+            "governance": {
+                "title": "Governance",
+                "description": "Governanceは、メンバー、権限、トレジャリーの外観など、チーム関連のトレジャリー設定の作成と投票ができます。"
+            },
+            "requestor": {
+                "title": "Requestor",
+                "description": "Requestorは、投票や承認権限なしで、支払い関連のトランザクションリクエストを作成できます。"
+            },
+            "financial": {
+                "title": "Financial",
+                "description": "Financialは、支払い関連のトランザクションリクエストに投票できますが、作成はできません。"
+            }
+        }
+    },
+    "memberInput": {
+        "creatorYou": "作成者(あなた)",
+        "memberAddress": "メンバーアドレス",
+        "addNewMember": "新しいメンバーを追加",
+        "validation": {
+            "rolesRequired": "少なくとも1つのロールが必要です",
+            "duplicateAddress": "アドレスはすでにメンバーです"
+        }
+    },
+    "recipientInput": {
+        "title": "宛先",
+        "placeholder": "受取人のアドレス"
+    },
+    "accountInput": {
+        "failedValidation": "アドレスの検証に失敗しました",
+        "invalidNearFormat": "無効なNEARアカウント形式",
+        "invalidChainAddress": "有効な{chain}アドレスを入力してください。",
+        "validating": "アドレスを検証中...",
+        "validAddress": "有効なアドレス",
+        "placeholderWithExample": "受取人のアドレス(例: {example})",
+        "placeholderNoExample": "受取人のアドレス",
+        "nearExample": "alice.near、0x...、または64文字の16進数",
+        "near": {
+            "required": "アドレスは必須です",
+            "length": "アドレスは2文字以上64文字以下である必要があります",
+            "missingTld": "名前付きアカウントは.near、.aurora、または.tgで終わる必要があります",
+            "invalidChars": "アドレスには小文字、数字、区切り文字(.、-、_)のみ使用できます",
+            "accountMissing": "アカウントはNEARブロックチェーン上に存在しません",
+            "verifyFailed": "アカウントの存在確認に失敗しました"
+        }
+    },
+    "csvUpload": {
+        "uploadFile": "ファイルをアップロード",
+        "provideData": "データを提供",
+        "chooseFile": "ファイルを選択",
+        "orDragDrop": "またはドラッグ&ドロップ",
+        "maxFileSize": "最大1ファイル、{maxSize}MBまで、CSVファイルのみ",
+        "noFilePrompt": "アップロードするファイルがない場合は?",
+        "downloadTemplate": "テンプレートをダウンロード"
+    },
+    "tokenSelect": {
+        "selectToken": "トークンを選択",
+        "searchPlaceholder": "トークンを検索...",
+        "noTokensFound": "トークンが見つかりません"
+    },
+    "filterOperations": {
+        "is": "次と一致",
+        "isNot": "次と一致しない",
+        "before": "より前",
+        "after": "より後",
+        "between": "範囲内",
+        "equal": "等しい",
+        "moreThan": "より大きい",
+        "lessThan": "より小さい",
+        "contains": "含む"
+    },
+    "copyButton": {
+        "copied": "クリップボードにコピーしました",
+        "failed": "コピーに失敗しました"
+    },
+    "recipientForm": {
+        "validation": {
+            "nameRequired": "名前は必須です",
+            "nameMax": "受取人は{max}文字未満である必要があります",
+            "addressRequired": "アドレスは必須です",
+            "networksRequired": "少なくとも1つのネットワークを選択してください"
+        }
+    },
+    "paymentForm": {
+        "validation": {
+            "recipientMin": "受取人は少なくとも2文字必要です",
+            "recipientMax": "受取人は128文字未満である必要があります",
+            "amountGreaterThanZero": "金額は0より大きくなければなりません",
+            "recipientSameAsToken": "受取人とトークンアドレスは同じであってはなりません",
+            "selectToken": "トークンを選択してください",
+            "recipientMax64": "受取人は64文字未満である必要があります",
+            "amountMinLockup": "金額は3.5以上である必要があります",
+            "startDateRequired": "開始日は必須です",
+            "endDateRequired": "終了日は必須です",
+            "cliffDateRequired": "クリフ日は必須です",
+            "startBeforeEnd": "開始日は終了日より前である必要があります",
+            "cliffBetween": "クリフ日は{start}から{end}の間である必要があります"
+        }
+    },
+    "exportToasts": {
+        "downloadFailed": "エクスポートのダウンロードに失敗しました",
+        "invalidDateRange": "無効な期間",
+        "invalidDateRangeDescription": "エクスポートに有効な期間を選択してください。",
+        "exportSuccess": "エクスポートに成功しました!",
+        "exportSuccessDescription": "{type}ファイルがダウンロードされました。詳細はエクスポート履歴を確認してください。",
+        "exportFailed": "エクスポートに失敗しました",
+        "exportFailedFallback": "データのエクスポートに失敗しました。もう一度お試しください。",
+        "noDownloadPermission": "ファイルをダウンロードする権限がありません。",
+        "noExportPermission": "エクスポートする権限がありません",
+        "quotaUsed": "上限をすべて使い切りました",
+        "exporting": "エクスポート中...",
+        "export": "エクスポート",
+        "columnSubmissionTime": "送信時刻",
+        "columnDateRange": "期間",
+        "columnGeneratedBy": "生成者",
+        "columnStatus": "ステータス",
+        "typeAll": "すべてのタイプ",
+        "typeSent": "送信済み",
+        "typeReceived": "受信済み",
+        "typeStakingRewards": "ステーキング報酬",
+        "allAssets": "すべての資産",
+        "upgradeTrial": "プランをアップグレードして利用を続けてください",
+        "upgradePaid": "プランをアップグレードしてさらにアクセスを得るか、来月の上限リセットをお待ちください。",
+        "selectDateRange": "期間を選択",
+        "noExportsTitle": "エクスポートはまだありません",
+        "noExportsDescription": "過去1ヶ月間のエクスポートファイルが生成されるとここに表示されます。",
+        "quotaTitle": "エクスポート上限",
+        "unlimited": "無制限",
+        "creditsPerMonth": "{total} / 月",
+        "requirementsTitle": "エクスポートの要件",
+        "exportFromPeriod": "次の期間のデータをエクスポートできます: {period}。",
+        "availableFor48Hours": "エクスポートしたファイルは48時間ダウンロード可能です。",
+        "moreFlexibility": "もっと柔軟な利用をお探しですか?",
+        "contactUs": "お問い合わせ",
+        "last1Year": "過去1年",
+        "last2Years": "過去2年",
+        "invalidEmail": "有効なメールアドレスを入力してください"
+    },
+    "proposalKinds": {
+        "Batch Payment Request": "一括支払いリクエスト",
+        "Payment Request": "支払いリクエスト",
+        "Confidential Request": "機密リクエスト",
+        "Exchange": "交換",
+        "Function Call": "関数呼び出し",
+        "Change Policy": "ポリシー変更",
+        "Update General Settings": "一般設定を更新",
+        "Earn NEAR": "NEARで収益",
+        "Unstake NEAR": "NEARをアンステーク",
+        "Vesting": "ベスティング",
+        "Withdraw Earnings": "収益を引き出す",
+        "Members": "メンバー",
+        "Upgrade": "アップグレード",
+        "Set Staking Contract": "ステーキングコントラクトを設定",
+        "Bounty": "バウンティ",
+        "Vote": "投票",
+        "Factory Info Update": "ファクトリー情報を更新",
+        "Unsupported": "未対応"
+    },
+    "paymentFormSection": {
+        "selectRecipient": "受取人を選択",
+        "searchByNameOrAddress": "名前またはアドレスで検索",
+        "restrictedRecipientTitle": "トランザクションは許可されていません",
+        "restrictedRecipientMessage": "このアドレスは現在、セキュリティチェックにより制限されています。このアドレスを許可すべきだとお考えの場合は、<link>ホワイトリスト追加をリクエスト</link>できます。",
+        "send": "送金",
+        "to": "宛先"
+    },
+    "recipientNetworkSelect": {
+        "label": "受取人のネットワーク",
+        "placeholder": "受取人のネットワークを選択",
+        "enterAddressFirst": "先に受取人アドレスを入力してください",
+        "noCompatibleNetwork": "このアドレスに一致するネットワークはありません",
+        "selectPlaceholder": "ネットワークを選択",
+        "title": "ネットワークを選択",
+        "available": "利用可能",
+        "fromAddressBook": "アドレス帳から",
+        "otherAvailable": "その他の利用可能",
+        "incompatible": "非互換",
+        "comingSoon": "近日公開",
+        "nearComName": "near.com",
+        "nearComDescription": "near.comとtrezuの内部ネットワーク"
+    },
+    "addressBookTable": {
+        "emptyTitle": "受取人はまだいません",
+        "emptyDescription": "より速く支払うために、このアドレス帳に受取人を追加してください。",
+        "selectAll": "すべての受取人を選択",
+        "selectEntry": "{name}を選択",
+        "recipient": "受取人",
+        "network": "ネットワーク",
+        "addedBy": "追加者",
+        "note": "メモ",
+        "added": "追加日",
+        "remove": "削除",
+        "send": "送金"
+    },
+    "publicDashboard": {
+        "updatesDaily": "毎日更新",
+        "noDataTitle": "データはまだありません",
+        "noDataDescription": "最初の日次スナップショットが計算されると統計が表示されます。",
+        "assetsSecured": "Sputnik DAOコントラクトで保護された資産",
+        "acrossDaos": "<bold>{count, plural, other {# 件のDAO}}</bold>にわたる",
+        "updatedOn": "{date}に更新",
+        "topAssets": "トップ20の資産",
+        "noAssetsTitle": "資産はまだありません",
+        "noAssetsDescription": "日次スナップショットが計算されるとトークンデータが表示されます。",
+        "tableToken": "トークン",
+        "tableTotalValue": "合計価値"
+    },
+    "telegramConnectInstructions": {
+        "title": "Telegramを接続",
+        "subtitle": "Telegramで提案やアクティビティの通知を受け取ります。",
+        "step3": "「開始」を押して指示に従ってください。",
+        "success": "準備完了です!",
+        "copyBotTooltip": "ボットハンドルをコピー",
+        "botCopiedToast": "ボットハンドルをコピーしました",
+        "openInTelegram": "Telegramで{bot}を開く"
+    },
+    "transactionHashCell": {
+        "copyHash": "ハッシュをコピー",
+        "hashCopied": "ハッシュをコピーしました",
+        "openInExplorer": "エクスプローラーで開く"
+    },
+    "treasurySelector": {
+        "select": "トレジャリーを選択",
+        "connectWalletTooltip": "トレジャリーを表示するにはウォレットを接続してください",
+        "manageTreasuries": "トレジャリーを管理",
+        "createTreasury": "トレジャリーを作成",
+        "memberOf": "メンバーであるトレジャリー",
+        "guestTreasuries": "ゲストトレジャリー"
+    },
+    "selectModal": {
+        "searchByName": "名前で検索",
+        "noResults": "結果が見つかりません"
+    },
+    "selectList": {
+        "noResults": "結果が見つかりません"
+    },
+    "datePicker": {
+        "pickDate": "日付を選択",
+        "timezone": "タイムゾーン"
+    },
+    "datePresets": {
+        "today": "今日",
+        "yesterday": "昨日",
+        "last3Days": "過去3日間",
+        "last7Days": "過去7日間",
+        "last14Days": "過去14日間",
+        "lastMonth": "過去1ヶ月",
+        "last3Months": "過去3ヶ月",
+        "last6Months": "過去6ヶ月"
+    },
+    "input": {
+        "openSearch": "検索を開く"
+    },
+    "pagination": {
+        "previous": "前へ",
+        "next": "次へ"
+    },
+    "confidentialState": {
+        "title": "機密",
+        "description": "トレジャリーメンバーのみがアクセスできます。"
+    },
+    "exchangeRate": {
+        "rate": "レート",
+        "clickToReverse": "クリックでレートを反転"
+    },
+    "exchangeSettings": {
+        "title": "交換設定",
+        "slippageTolerance": "スリッページ許容範囲",
+        "custom": "カスタム",
+        "customPlaceholder": "例: 2%",
+        "slippageRange": "スリッページは0.01%から100%の間である必要があります",
+        "enterSlippage": "スリッページ許容範囲を入力してください",
+        "slippageHelp": "価格がこの割合以上変動した場合、資金を保護するためにトランザクションがキャンセルされます。",
+        "save": "保存"
+    },
+    "assetsPage": {
+        "title": "資産",
+        "noAssetsTitle": "資産はまだありません",
+        "noAssetsDescription": "始めるには、入金してトレジャリーに資産を追加してください。"
+    },
+    "newBadge": {
+        "label": "新着"
+    },
+    "numberBadge": {
+        "pendingRequests": "{count, plural, other {# 件の保留中リクエスト}}"
+    },
+    "balanceWithGraph": {
+        "allTokens": "すべてのトークン",
+        "deposit": "入金",
+        "send": "送金",
+        "exchange": "交換",
+        "chartNow": "現在",
+        "totalBalance": "総残高",
+        "excludedTokens": "除外トークン:",
+        "noPriceHistory": "価格履歴がありません。トークンを選択して残高変動を確認してください。",
+        "bucketAvailable": "利用可能",
+        "bucketLocked": "ロック",
+        "bucketEarning": "収益中",
+        "period": {
+            "1W": "1週",
+            "1M": "1ヶ月",
+            "3M": "3ヶ月",
+            "1Y": "1年"
+        }
+    },
+    "changePolicyExpanded": {
+        "proposalBond": "提案ボンド",
+        "proposalPeriod": "提案期間",
+        "bountyBond": "バウンティボンド",
+        "bountyForgivenessPeriod": "バウンティ免除期間",
+        "votesCount": "{count}票",
+        "weightKind": "ウェイト種別",
+        "quorum": "クォーラム",
+        "threshold": "しきい値",
+        "defaultThreshold": "デフォルトしきい値",
+        "roleThreshold": "{role}しきい値",
+        "member": "メンバー",
+        "members": "メンバー",
+        "permissions": "権限",
+        "oldPermissions": "旧権限",
+        "newPermissions": "新権限",
+        "category": "カテゴリ",
+        "transactionDetails": "トランザクションの詳細",
+        "addNewMember": "新しいメンバーを追加",
+        "addNewMembers": "新しいメンバーを追加",
+        "removeMember": "メンバーを削除",
+        "removeMembers": "メンバーを削除",
+        "updateMemberPermissions": "メンバー権限を更新",
+        "updateMembersPermissions": "複数メンバーの権限を更新",
+        "memberIndex": "メンバー {index}",
+        "membersCount": "{count}名のメンバー",
+        "collapseAll": "すべて折りたたむ",
+        "expandAll": "すべて展開",
+        "loadingHistorical": "過去のポリシーを読み込み中...",
+        "unableToDiff": "この提案の差分を計算できません。",
+        "noChangesCurrent": "変更は検出されませんでした - 提案されたポリシーは現在のポリシーと同一です。",
+        "noChangesHistorical": "変更は検出されませんでした - 提案されたポリシーは過去のポリシーと同一です。"
+    },
+    "balanceChart": {
+        "usdValue": "USD価値",
+        "tokenBalance": "トークン残高",
+        "emptyTitle": "まだ表示するものはありません",
+        "emptyDescription": "資産を追加してポートフォリオの追跡を開始してください。"
+    },
+    "user": {
+        "saveToAddressBook": "アドレス帳に保存",
+        "walletCopiedToast": "ウォレットアドレスをクリップボードにコピーしました",
+        "copyWalletAddress": "ウォレットアドレスをコピー"
+    },
+    "infoDisplay": {
+        "viewLess": "表示を減らす",
+        "viewAllDetails": "すべての詳細を表示"
+    },
+    "amountSummary": {
+        "defaultTitle": "送金合計"
+    },
+    "residency": {
+        "vestedToken": "ベスト済みトークン",
+        "staked": "ステーキング中",
+        "fungibleToken": "代替性トークン",
+        "intentsToken": "Intentsトークン",
+        "nativeToken": "ネイティブトークン"
+    },
+    "exchangeErrors": {
+        "noRoute": "交換が見つかりません。より少ない金額または別のトークンをお試しください。",
+        "amountTooLow": "金額がスワップに低すぎます。クロスチェーンスワップではネットワーク手数料を賄うために高い最小額が必要です。",
+        "insufficientBalance": "このスワップに対して残高が不足しています。",
+        "networkError": "ネットワークエラーです。接続を確認してもう一度お試しください。",
+        "fetchFailed": "見積りの取得に失敗しました"
+    },
+    "tokenSelectDialog": {
+        "selectToken": "トークンを選択",
+        "selectAsset": "資産を選択",
+        "selectNetworkFor": "{asset}のネットワークを選択",
+        "searchByName": "名前で検索",
+        "noTokensWithBalance": "残高のあるトークンが見つかりません",
+        "noTokensFound": "トークンが見つかりません",
+        "yourAssets": "あなたの資産",
+        "otherAssets": "その他の資産",
+        "networksWithAssets": "資産のあるネットワーク",
+        "supportedNetworks": "対応ネットワーク",
+        "comingSoon": "近日公開"
+    },
+    "intentsQuote": {
+        "initializing": "見積りサービスはまだ初期化中です。もう一度お試しください。",
+        "noRoute": "現在支払いルートを準備できません。再度お試しください。",
+        "fetchFailed": "現在支払いルートを準備できません。再度お試しください。",
+        "amountTooLow": "金額がネットワーク手数料を賄うのに低すぎます。より高い金額を入力してもう一度お試しください。",
+        "amountTooLowWithMin": "金額がネットワーク手数料を賄うのに低すぎます。少なくとも{min} {token}を入力してください。",
+        "networkFeeTooltip": "この手数料は選択したチェーン上でトランザクションを処理するために使用されます。"
+    },
+    "pageTours": {
+        "paymentsBulk": "一括作成が登場!複数のリクエストをわずか数ステップで作成できます。",
+        "paymentsPending": "承認待ちのリクエストはここで確認できます。",
+        "exchangeSettings": "ここで許容できる価格変動の幅を設定できます。",
+        "membersPending": "クリックして承認待ちのアクティブなリクエストを確認してください。",
+        "guestSaveIntro": "あなたはこのトレジャリーのゲストです。データの閲覧のみ可能です。",
+        "guestSaveAction": "このゲストトレジャリーをトレジャリー一覧に保存できます。",
+        "newFeatureRich": "新機能!🎉 頻繁に使用するアドレスを保存して、より速く、エラーのない支払いを実現します。<br></br>連絡先は非公開で、チームのみが閲覧できます。",
+        "newFeatureCta": "試してみる"
+    },
+    "statusDate": {
+        "expires": "有効期限",
+        "created": "作成日",
+        "expired": "失効",
+        "removed": "削除済み"
+    },
+    "relativeTime": {
+        "justNow": "たった今",
+        "moments": "わずか前"
+    },
+    "amount": {
+        "network": "ネットワーク: {network}"
+    },
+    "activityLabels": {
+        "exchangePending": "交換保留中",
+        "exchangeRequest": "交換リクエスト",
+        "exchangeFulfillment": "交換完了",
+        "stakingRewards": "ステーキング報酬",
+        "proposalAction": "提案アクション",
+        "deposit": "{symbol}を入金",
+        "paymentSent": "支払い送信",
+        "transaction": "トランザクション",
+        "fallbackToken": "トークン",
+        "viaIntents": "NEAR Intents経由",
+        "from": "{account}から",
+        "to": "{account}へ",
+        "viewAll": "すべてのトランザクション履歴を表示",
+        "sentReceived": "送受信したトランザクション({duration})",
+        "unlimitedHistory": "無制限の履歴",
+        "oneYear": "1年",
+        "yearsCount": "{count}年",
+        "monthsCount": "{count}ヶ月",
+        "lastDuration": "過去{duration}"
+    },
+    "nearStore": {
+        "connectAndAcceptTerms": "続行するにはウォレットを接続して利用規約に同意してください。",
+        "transactionNotApproved": "ウォレットでトランザクションが承認されませんでした。",
+        "failedSubmitVote": "投票の送信に失敗しました",
+        "failedSubmitVotes": "投票の送信に失敗しました",
+        "viewRequest": "リクエストを表示",
+        "proposalRemoved": "提案が削除されました",
+        "voteSubmitted": "投票を送信しました",
+        "votesSubmitted": "投票を送信しました"
+    },
+    "tokenInput": {
+        "max": "MAX",
+        "insufficientTokens": "トークンが不足しています。リクエストを送信してから承認前に補充できます。",
+        "balance": "残高: {amount} {symbol}"
+    },
+    "createRequestButton": {
+        "idle": "リクエストを作成",
+        "noPermission": "リクエストを作成する権限がありません"
+    },
+    "address": {
+        "copied": "アドレスをクリップボードにコピーしました"
+    },
+    "memberAvatars": {
+        "membersWhoCanVote": "投票できるメンバー",
+        "moreMembers": "+{count, plural, other {# 名のメンバー}}"
+    },
+    "accountIdInput": {
+        "minLength": "アカウントIDは少なくとも2文字必要です",
+        "maxLength": "アカウントIDは64文字未満である必要があります",
+        "charset": "アカウントIDには小文字、数字、ドット、ハイフン、アンダースコアのみ使用でき、先頭または末尾に区切り文字を含めることはできません",
+        "doesNotExist": "アカウントIDが存在しません"
+    },
+    "addressBookMutations": {
+        "addedToast": "{count, plural, other {# 名の受取人を追加しました}}",
+        "addedSingleToast": "受取人を追加しました",
+        "addFailedToast": "受取人の追加に失敗しました",
+        "addSingleFailedToast": "受取人の追加に失敗しました",
+        "removedToast": "{count, plural, other {# 名の受取人を削除しました}}",
+        "removeFailedToast": "受取人の削除に失敗しました",
+        "exportFailedToast": "受取人のエクスポートに失敗しました"
+    },
+    "treasuryMutations": {
+        "savedToast": "トレジャリーを一覧に保存しました",
+        "saveFailedToast": "トレジャリーの保存に失敗しました",
+        "hiddenToast": "トレジャリーを一覧から非表示にしました",
+        "hideFailedToast": "トレジャリーの非表示に失敗しました",
+        "unhiddenToast": "トレジャリーが再び表示されます",
+        "unhideFailedToast": "トレジャリーの再表示に失敗しました",
+        "removedToast": "保存済み一覧からトレジャリーを削除しました",
+        "removeFailedToast": "保存済み一覧からトレジャリーの削除に失敗しました"
+    },
+    "telegramSettings": {
+        "title": "Telegram",
+        "connectedTo": "{chat}に接続中",
+        "chatNumber": "チャット #{id}",
+        "fallbackChat": "Telegramチャット",
+        "disconnect": "切断",
+        "connect": "接続",
+        "connectDescription": "通知を受け取るためにトレジャリーをTelegramチャットにリンクします。",
+        "noTreasuryDescription": "トレジャリーをTelegramチャットにリンクします。",
+        "openSettingsHint": "連携を管理するにはトレジャリーから設定を開いてください。",
+        "disconnectedToast": "このトレジャリーのTelegram接続を切断しました",
+        "disconnectFailedToast": "Telegramの切断に失敗しました。もう一度お試しください。"
+    },
+    "assetsTable": {
+        "noAssetsFound": "資産が見つかりません。",
+        "assetDetails": "資産の詳細",
+        "coinPrice": "コイン価格",
+        "weight": "ウェイト",
+        "balance": "残高",
+        "lockedBalance": "ロック残高",
+        "totalBalance": "総残高",
+        "source": "ソース",
+        "balanceByInvestors": "{count, plural, other {投資家別}}残高",
+        "investors": "{count, plural, other {投資家}}",
+        "poolBreakdown": "プール内訳",
+        "unlockedToken": "アンロック済みトークン",
+        "lockupStakingPool": "ロックアップステーキングプール",
+        "exchange": "交換",
+        "send": "送金",
+        "details": "詳細",
+        "columnToken": "トークン",
+        "columnLocked": "ロック",
+        "columnUnlocked": "アンロック",
+        "columnTotalAllocated": "割り当て合計",
+        "columnAvailableToWithdraw": "出金可能",
+        "viewAvailable": "利用可能",
+        "viewLocked": "ロック",
+        "viewEarning": "収益中",
+        "fullAllocatedBalance": "割り当て残高の全額",
+        "partAllocatedBalance": "割り当て残高の一部",
+        "currentlyEarning": "({amount} {symbol})が現在収益中です。",
+        "willAppearHere": " 収益を停止するとここに表示されます。",
+        "seeInEarningTab": "収益タブで確認",
+        "seeInEarning": "収益で確認"
+    },
+    "earningDetails": {
+        "title": "収益の詳細",
+        "totalStaked": "ステーキング合計",
+        "earningOverview": "収益の概要",
+        "poolBreakdown": "プール内訳({count, plural, other {# プール}})",
+        "almostReady": "収益機能は間もなく利用可能になります!",
+        "finalizingFeature": "この機能を仕上げ中ですので、<br></br>まもなくトークンの収益を開始できます。",
+        "comingSoon": "近日公開",
+        "goToEarn": "収益へ移動",
+        "readyToWithdraw": "出金可能",
+        "unstaking": "アンステーキング中",
+        "overview": {
+            "staked": "ステーキング中",
+            "stakedInfo": "現在バリデータに委任され報酬を獲得しているトークン。",
+            "pendingRelease": "リリース待ち",
+            "pendingReleaseInfo": "アンステーキング済みですがアンボンディング期間中(通常2〜3日)のトークン。",
+            "availableForWithdraw": "出金可能",
+            "availableForWithdrawInfo": "アンボンディング期間を完了し出金可能なアンステーキング済みトークン。"
+        }
+    },
+    "lockupDetails": {
+        "title": "ロックアップの詳細",
+        "balance": "残高",
+        "reservedForStorage": "ストレージ用予約",
+        "reservedForStorageInfo": "ストレージ料金を支払うためにロックアップアカウントが予約しているNEAR。",
+        "tokenBreakdown": "トークン内訳",
+        "allocatedAmount": "割り当て金額",
+        "earned": "獲得済み",
+        "progress": "進捗",
+        "unlocked": "アンロック済み",
+        "locked": "ロック",
+        "schedule": "スケジュール",
+        "startDate": "開始日",
+        "endDate": "終了日",
+        "rounds": "ラウンド",
+        "releaseInterval": "リリース間隔",
+        "nextUnlockDate": "次のアンロック日",
+        "allEarning": "ロックアップからの{amount} {symbol}すべてが現在収益中です。",
+        "partEarning": "ロックアップの一部({amount} {symbol})が現在収益中です。",
+        "stopEarningFirst": "アンロック済みトークンを使用するには、まず収益を停止して引き出してください。",
+        "howGrantWorks": "あなたのグラントの仕組み",
+        "ftStep1": "特定の期間のグラントを受け取ります。一度に全額を受け取るのではなく、資産は時間をかけて少しずつ利用可能になります。",
+        "ftStep2": "次のリリース日が来ると、その分のトークンが自動的にアンロックされ、トレジャリー残高に移されます。",
+        "ftStep3": "残高に表示されると、すぐに支払い、送金、その他のトランザクションに使用できます。",
+        "nearStep1": "開始日と終了日が定められた期間のグラントを受け取ります。",
+        "nearStep2": "トークンがアンロックされると、自動的にトレジャリー残高で利用可能になります。",
+        "nearStep3": "アンロックされたトークンは、すぐに支払い、送金、その他のトランザクションに使用できます。",
+        "notAvailable": "該当なし",
+        "everyMonth": "毎月",
+        "everyQuarter": "四半期ごと",
+        "everyUnit": "{unit}ごと",
+        "everyMultiple": "{text}ごと",
+        "completed": "完了",
+        "unit": {
+            "year": "{count, plural, other {# 年}}",
+            "day": "{count, plural, other {# 日}}",
+            "hour": "{count, plural, other {# 時間}}",
+            "minute": "{count, plural, other {# 分}}",
+            "second": "{count, plural, other {# 秒}}"
+        }
+    },
+    "vestingDetails": {
+        "title": "ベスティングの詳細",
+        "availableToUse": "利用可能",
+        "vestingPeriod": "ベスティング期間",
+        "vestingPeriodDescription": "この期間中にトークンは毎日アンロックされます。",
+        "startDate": "開始日",
+        "endDate": "終了日",
+        "tokenBreakdown": "トークン内訳",
+        "originalVestedAmount": "元のベスト金額",
+        "reservedForStorage": "ストレージ用予約",
+        "reservedForStorageInfo": "ベスティングをアクティブに保ち、ストレージ料金を賄うために必要な少量のトークン。",
+        "percentVested": "{percent}% ベスト済み",
+        "vestedOf": "{vested} / {total} {symbol}",
+        "send": "送金"
+    },
+    "earningPoolDetails": {
+        "balance": "残高",
+        "apy": "APY",
+        "fee": "手数料",
+        "notAvailable": "該当なし",
+        "lockupStakingPool": "ロックアップステーキングプール",
+        "lockupAssetsNote": "このポジションのすべての資産はロックアップから来ています。収益を停止した後も、一部のトークンはまだロックされていて利用できない可能性があります。アンロックされる時期はロックアップスケジュールを確認してください。"
+    },
+    "onboardingQuestions": {
+        "stepTitle": "始めるためのいくつかの簡単な質問。",
+        "other": "その他",
+        "placeholders": {
+            "describeRole": "あなたの役割を説明してください(任意)",
+            "describeUseCase": "ユースケースを説明してください(任意)",
+            "networkName": "ネットワーク名を入力(任意)",
+            "currentChallenge": "現在の課題を入力(任意)",
+            "describeOther": "その他を説明(任意)"
+        },
+        "questions": {
+            "role": "あなたの役割を最もよく表すものは?",
+            "useCases": "Trezuを何に使う予定ですか?",
+            "teamSize": "トレジャリーを管理するのは何人ですか?",
+            "networks": "最もよく使うネットワークは?",
+            "multisigExperience": "マルチシグの経験は?",
+            "currentTools": "現在財務管理に使っているツールは?",
+            "monthlyVolume": "おおよその月間トランザクション量は?",
+            "biggestChallenges": "現在の最大の課題は?"
+        },
+        "options": {
+            "role": {
+                "founder": "創業者",
+                "co-founder": "共同創業者",
+                "cfo-finance-lead": "CFO / 財務責任者",
+                "operations-manager": "オペレーションマネージャー",
+                "treasury-manager": "トレジャリーマネージャー",
+                "other": "その他"
+            },
+            "useCases": {
+                "team-payroll-grants": "チームの給与とグラント",
+                "company-assets-management": "企業資産管理",
+                "dao-treasury-management": "DAOトレジャリー管理",
+                "investment-portfolio": "投資ポートフォリオ",
+                "operational-spending": "運営費の支出",
+                "other": "その他"
+            },
+            "teamSize": {
+                "just-me": "自分だけ",
+                "2-5-people": "2〜5人",
+                "6-15-people": "6〜15人",
+                "15-plus-people": "15人以上"
+            },
+            "networks": {
+                "near": "NEAR",
+                "bitcoin": "Bitcoin",
+                "ethereum": "Ethereum",
+                "solana": "Solana",
+                "arbitrum": "Arbitrum",
+                "base": "Base",
+                "optimism": "Optimism",
+                "polygon": "Polygon",
+                "gnosis": "Gnosis",
+                "avalanche": "Avalanche",
+                "bnb-chain": "BNB Chain",
+                "other": "その他"
+            },
+            "multisigExperience": {
+                "never-heard-of-it": "聞いたことがない",
+                "heard-about-it": "聞いたことはある",
+                "never-used-it": "使ったことがない",
+                "used-gnosis-safe-or-similar": "Gnosis Safeなどを使用したことがある",
+                "experienced": "経験豊富",
+                "looking-for-a-better-option": "より良い選択肢を探している"
+            },
+            "currentTools": {
+                "gnosis-safe": "Gnosis Safe",
+                "fireblocks": "Fireblocks",
+                "tholos": "Tholos",
+                "squads-multisig": "Squads Multisig",
+                "mpc-vault": "MPC Vault",
+                "other": "その他"
+            },
+            "monthlyVolume": {
+                "under-10k": "$10K未満",
+                "10k-100k": "$10K〜$100K",
+                "100k-1m": "$100K〜$1M",
+                "1m-plus": "$1M以上"
+            },
+            "biggestChallenges": {
+                "slow-approvals-and-signing": "承認と署名が遅い",
+                "lack-of-transparency-in-the-team": "チーム内の透明性の欠如",
+                "hard-to-track-spending-and-balances": "支出と残高の追跡が困難",
+                "security-and-access-control": "セキュリティとアクセス制御",
+                "no-good-web3-tool-yet": "まだ良いWeb3ツールがない",
+                "looking-for-crypto-earnings": "暗号資産の収益を求めている",
+                "other": "その他"
+            }
+        }
+    },
+    "onboarding": {
+        "tour": {
+            "addAssets": "入金してトレジャリーに資産を追加します。",
+            "makeRequests": "資産を送る必要があるときはいつでも支払いリクエストを作成できます。",
+            "exchangeAssets": "ここで資産を交換できます。",
+            "addMembers": "トレジャリーにメンバーを追加し、ロールを割り当てます。",
+            "newTreasury": "新しいトレジャリーをセットアップしますか?ここで数クリックで作成できます。",
+            "helpSupport": "必要なときにいつでもヘルプとサポートを受けられます。"
+        },
+        "tourCard": {
+            "close": "閉じる",
+            "stepProgress": "{current} / {total}",
+            "gotIt": "了解",
+            "done": "完了",
+            "next": "次へ"
+        },
+        "progress": {
+            "title": "クイックステップに従ってトレジャリーを探索",
+            "createTreasuryTitle": "トレジャリーアカウントを作成",
+            "createTreasuryDescription": "アカウントが正常にセットアップされました。素晴らしいスタートです!",
+            "addAssetsTitle": "資産を追加",
+            "addAssetsDescription": "資産を追加して動きを確認しましょう。",
+            "deposit": "入金",
+            "createPaymentTitle": "支払いリクエストを作成",
+            "createPaymentDescription": "支払いリクエストを作成してセットアップを完了しましょう。",
+            "send": "送金"
+        },
+        "welcome": {
+            "heading": "🎉 ようこそ!",
+            "subheading": "トレジャリーを簡単にツアーしましょう",
+            "body": "こんにちは!Trezuの準備ができました - 対応ネットワークから資産を追加してポートフォリオの構築を始めましょう。",
+            "progress": "{current} / {total}",
+            "next": "次へ",
+            "body2": "入金、リクエスト作成、新しいアカウントのセットアップ方法を確認しましょう。",
+            "noThanks": "結構です",
+            "letsGo": "始めましょう"
+        },
+        "congrats": {
+            "heading": "🎉 おめでとうございます!",
+            "body": "トレジャリーのセットアップが完了しました。資産の簡単な管理をお楽しみください。",
+            "letsGo": "始めましょう!"
+        },
+        "createBanner": {
+            "close": "閉じる",
+            "title": "Trezuを探索",
+            "description": "アカウントを作成して、Trezuのすべての機能と特典の権限をアンロックしましょう。",
+            "cta": "トレジャリーを作成"
+        },
+        "questionnaire": {
+            "continue": "続ける",
+            "skip": "スキップ"
+        },
+        "createPrompt": {
+            "title": "あと少しで完了です",
+            "description": "ウォレットは接続されていますが、まだトレジャリーを作成していません。Trezuを使い始めるためにアカウントを作成するか、{suffix}",
+            "suffixDemo": "デモをチェックしてください。",
+            "suffixExploring": "引き続き探索してください。",
+            "createCta": "トレジャリーを作成",
+            "viewDemo": "デモを見る",
+            "keepExploring": "引き続き探索"
+        },
+        "infoBox": {
+            "title": "Trezuをもっと活用",
+            "close": "閉じる",
+            "description": "他のユーザーがどのようにトレジャリーを使っているかを発見し、デモを試し、ドキュメントで機能を学びましょう。",
+            "demoTitle": "Trezuデモを探索",
+            "demoDescription": "ライブのデモアカウントを実際に見てみましょう。",
+            "docsTitle": "ドキュメント",
+            "docsDescription": "ドキュメントですべての機能について学びましょう。",
+            "videoTitle": "デモを見る",
+            "videoDescription": "Trezuの動作を示す短い動画をご覧ください。"
+        }
+    }
+}

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -1,0 +1,2101 @@
+{
+    "common": {
+        "loading": "로딩 중...",
+        "notAvailable": "해당 없음",
+        "connecting": "연결 중...",
+        "save": "저장",
+        "cancel": "취소",
+        "submit": "제출",
+        "close": "닫기",
+        "back": "뒤로",
+        "seeDemo": "Trezu 데모 보기",
+        "search": "검색",
+        "filter": "필터",
+        "filterActive": "필터 (활성)",
+        "export": "내보내기",
+        "exporting": "내보내는 중",
+        "import": "가져오기",
+        "remove": "제거",
+        "removing": "제거 중...",
+        "edit": "편집",
+        "continue": "계속",
+        "select": "선택",
+        "all": "전체",
+        "none": "없음",
+        "retry": "다시 시도",
+        "tryAgain": "다시 시도해 주세요.",
+        "confirm": "확인",
+        "next": "다음",
+        "previous": "이전",
+        "yes": "예",
+        "no": "아니요",
+        "approve": "승인",
+        "reject": "거부",
+        "copy": "복사",
+        "copied": "복사됨",
+        "viewAll": "전체 보기",
+        "viewDetails": "상세 보기",
+        "noResults": "결과를 찾을 수 없습니다",
+        "add": "추가"
+    },
+    "languageSwitcher": {
+        "label": "언어",
+        "select": "언어 선택",
+        "english": "English",
+        "spanish": "Español",
+        "ukrainian": "Українська",
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
+    },
+    "header": {
+        "toggleSidebar": "사이드바 토글",
+        "toggleTheme": "테마 토글"
+    },
+    "nav": {
+        "dashboard": "대시보드",
+        "requests": "요청",
+        "payments": "결제",
+        "exchange": "교환",
+        "addressBook": "주소록",
+        "members": "멤버",
+        "settings": "설정",
+        "helpSupport": "도움말 및 지원",
+        "saveGuestTreasury": "이 게스트 트레저리를 트레저리 목록에 저장합니다."
+    },
+    "signIn": {
+        "connect": "연결",
+        "connectWallet": "지갑 연결",
+        "wallet": "지갑",
+        "termsOfService": "이용약관",
+        "privacyPolicy": "개인정보 처리방침",
+        "disconnect": "연결 해제"
+    },
+    "auth": {
+        "noWallet": "지갑을 연결하세요",
+        "noPermission": "이 작업을 수행할 권한이 없습니다",
+        "noVote": "이 제안에 이미 투표하셨습니다",
+        "noSponsoredTransactions": "남은 후원 트랜잭션이 없습니다"
+    },
+    "landing": {
+        "welcome": "Trezu에 오신 것을 환영합니다",
+        "chooseOption": "시작하려면 아래 옵션을 선택하세요.",
+        "newUserTitle": "Trezu가 처음입니다",
+        "newUserDescription": "Trezu에 대해 들어봤지만 아직 트레저리가 없습니다.",
+        "existingUserTitle": "이미 Trezu를 사용하고 있습니다",
+        "existingUserDescription": "계정이 있고 트레저리를 관리하고 있습니다.",
+        "gradientTagline": "디지털 자산 관리를 위한 크로스체인 멀티시그 보안",
+        "waitlistTitle": "Trezu 대기 명단에 등록하세요",
+        "waitlistSubmittedTitle": "등록이 완료되었습니다 🎉",
+        "waitlistSubmittedDescription": "감사합니다! 트레저리 생성이 가능해지면 즉시 알려드리겠습니다.",
+        "waitlistDescription": "오늘의 트레저리 생성 한도에 도달했습니다. 걱정 마세요 - 나중에 다시 시도하거나 연락처를 남겨 대기 명단에 등록하세요. 자리가 생기면 알려드리겠습니다.",
+        "waitlistInputPlaceholder": "이메일 주소 또는 Telegram (예: @username)",
+        "waitlistPrivacyNote": "알림 용도로만 사용됩니다",
+        "waitlistSubmit": "대기 명단 등록",
+        "waitlistSubmitFailed": "제출에 실패했습니다. 다시 시도해 주세요.",
+        "welcomeAlt": "환영합니다"
+    },
+    "blocked": {
+        "title": "해당 국가에서는 서비스를 이용할 수 없습니다",
+        "description": "제한 사항으로 인해 현재 해당 지역에서는 이 서비스를 이용할 수 없습니다."
+    },
+    "notFound": {
+        "title": "이런, 페이지를 찾을 수 없습니다...",
+        "description": "더 이상 작동하지 않는 링크를 따라온 것 같습니다. 뒤로 가거나 대시보드로 돌아가세요.",
+        "backToDashboard": "대시보드로 돌아가기"
+    },
+    "treasuryInfo": {
+        "logoAlt": "트레저리 로고"
+    },
+    "dateInput": {
+        "placeholder": "yyyy/mm/dd"
+    },
+    "thresholdSlider": {
+        "warningSingleMember": "{memberCount}명 중 1명 임계값은 단일 멤버가 트랜잭션을 실행할 수 있음을 의미합니다. 이는 보안을 약화시킵니다.",
+        "infoBalanced": "{memberCount}명 중 {currentThreshold}명 임계값은 보안과 운영 유연성 사이에 좋은 균형을 제공합니다."
+    },
+    "intentsFee": {
+        "amountTooLowForFee": "{prefix}금액이 네트워크 수수료({fee} {symbol})에 비해 너무 적습니다. 최소 {addMore} {symbol}을(를) 추가하세요."
+    },
+    "metadata": {
+        "treasuryTitle": "대시보드 | Trezu",
+        "landingTitle": "Trezu | 크로스체인 트레저리 관리",
+        "description": "키를 양도하지 않고 단일 대시보드에서 몇 분 만에 팀의 자본을 관리하세요.",
+        "ogTitle": "Trezu | 하나의 멀티시그. 모든 암호화폐. 완전한 통제."
+    },
+    "pages": {
+        "dashboard": {
+            "title": "대시보드",
+            "description": "트레저리 자산 및 활동 개요",
+            "descriptionLong": "트레저리 자산을 관리하고 활동을 추적하세요"
+        },
+        "activity": {
+            "title": "최근 트랜잭션",
+            "descriptionDetails": "요청 세부정보",
+            "descriptionList": "모든 자산의 최근 트랜잭션"
+        },
+        "requests": {
+            "title": "요청",
+            "description": "모든 대기 중인 멀티시그 요청을 보고 관리하세요",
+            "detailDescription": "요청 세부정보",
+            "detailTitle": "요청 #{id}"
+        },
+        "members": {
+            "title": "멤버",
+            "description": "팀 멤버 및 권한 관리"
+        },
+        "settings": {
+            "title": "설정",
+            "description": "애플리케이션 설정 조정"
+        },
+        "addressBook": {
+            "title": "주소록",
+            "description": "저장된 수신자 관리"
+        },
+        "payments": {
+            "title": "결제",
+            "description": "안전하게 자금을 송금하고 수신하세요"
+        },
+        "exchange": {
+            "title": "교환",
+            "description": "토큰을 안전하고 효율적으로 교환하세요"
+        },
+        "vesting": {
+            "title": "베스팅",
+            "description": "베스팅 일정을 빠르고 손쉽게 생성하세요"
+        },
+        "earn": {
+            "title": "수익",
+            "description": "자산으로 보상을 얻으세요",
+            "placeholder": "수익 기회와 스테이킹 보상을 살펴보세요."
+        },
+        "createTreasury": {
+            "title": "트레저리 생성",
+            "description": "팀을 위한 새 멀티시그 트레저리를 설정하세요"
+        },
+        "manageTreasuries": {
+            "title": "트레저리 관리",
+            "description": "계정에 표시되는 트레저리를 제어하세요"
+        },
+        "stats": {
+            "title": "통계",
+            "description": "모든 sputnik DAO 트레저리의 실시간 운용 자산."
+        },
+        "telegram": {
+            "title": "트레저리 연결",
+            "description": "트레저리를 Telegram 채팅에 연결하세요",
+            "metaTitle": "Trezu — Telegram 연결",
+            "metaDescription": "Trezu 트레저리를 Telegram 채팅에 연결하세요"
+        },
+        "wallet": {
+            "title": "Trezu Wallet",
+            "description": "Trezu를 통해 트레저리 제안에 서명하세요"
+        }
+    },
+    "depositModal": {
+        "validation": {
+            "selectAsset": "자산을 선택해 주세요",
+            "selectNetwork": "네트워크를 선택해 주세요"
+        },
+        "sections": {
+            "supportedNetworks": "지원 네트워크",
+            "networksWithAssets": "자산이 있는 네트워크",
+            "yourAssets": "내 자산",
+            "otherAssets": "기타 자산"
+        },
+        "errors": {
+            "addressUnavailable": "선택한 자산과 네트워크에 대한 입금 주소를 가져올 수 없습니다.",
+            "fetchFailed": "입금 주소를 가져오지 못했습니다. 다시 시도해 주세요."
+        },
+        "title": "입금",
+        "subtitle": "입금 주소를 보려면 자산과 네트워크를 선택하세요",
+        "assetLabel": "자산",
+        "networkLabel": "네트워크",
+        "selectAsset": "자산 선택",
+        "selectNetwork": "네트워크 선택",
+        "otherAssetName": "기타",
+        "otherNetworkInfo": "자산 목록에 없는 토큰도 입금할 수 있지만, NEAR 네트워크를 통해서만 가능합니다.",
+        "depositAddressHeading": "입금 주소",
+        "depositAddressSubtitle": "입금 주소는 항상 두 번 확인하세요.",
+        "addressLabel": "주소",
+        "addressCopied": "주소가 클립보드에 복사되었습니다",
+        "memoLabel": "메모",
+        "memoCopied": "메모가 클립보드에 복사되었습니다",
+        "memoWarning": "이 주소로 자금을 보낼 때 메모를 <bold>반드시</bold> 포함해야 합니다. 메모 없이 보내면 자금이 영구적으로 손실될 수 있습니다.",
+        "onlyDeposit": "<networkTag>{network}</networkTag> 네트워크에서 <symbolTag>{symbol}</symbolTag>만 입금하세요. 전체 금액을 보내기 전에 모든 것이 올바르게 작동하는지 확인하기 위해 소액 테스트 트랜잭션부터 시작하는 것을 권장합니다.",
+        "minimumDeposit": "최소 입금액은 <amountTag>{amount} {symbol}</amountTag>입니다",
+        "searchByName": "이름으로 검색"
+    },
+    "assetDetails": {
+        "coinPrice": "코인 가격",
+        "weight": "비중",
+        "source": "출처",
+        "send": "보내기",
+        "exchange": "교환",
+        "comingSoon": "출시 예정",
+        "vesting": "베스팅",
+        "vestedPercent": "{percent}% 베스팅됨",
+        "frozen": "동결됨",
+        "frozenTooltip": "동결된 토큰은 잠겨 있어 사용할 수 없습니다. 저장소에 사용 중이거나, 스테이킹 중이거나, 아직 베스팅되지 않아 잠겨 있을 수 있습니다.",
+        "vested": "베스팅됨"
+    },
+    "dashboard": {
+        "overview": "트레저리 자산 및 활동 개요",
+        "assets": "자산",
+        "balance": "잔액",
+        "totalBalance": "총 잔액",
+        "deposit": "입금",
+        "addAssets": "자산 추가",
+        "hidden": "숨김",
+        "confidentialHidden": "비공개 트레저리의 잔액 숨김",
+        "recentActivity": "최근 활동",
+        "viewAllTransactions": "모든 트랜잭션 보기"
+    },
+    "activity": {
+        "filters": {
+            "createdDate": "생성 날짜",
+            "token": "토큰",
+            "from": "보낸 사람",
+            "to": "받는 사람"
+        },
+        "tabs": {
+            "all": "전체",
+            "sent": "송금",
+            "received": "수신",
+            "stakingRewards": "스테이킹 보상",
+            "exchange": "교환"
+        },
+        "searchPlaceholder": "트랜잭션 해시로 검색",
+        "searchPlaceholderShort": "트랜잭션 해시",
+        "fromPool": "{pool}에서",
+        "table": {
+            "type": "유형",
+            "transaction": "트랜잭션",
+            "from": "보낸 사람",
+            "to": "받는 사람",
+            "transactionHash": "트랜잭션 해시",
+            "hashTooltip": "이 트랜잭션의 고유 식별자(해시)"
+        },
+        "empty": {
+            "title": "트랜잭션을 찾을 수 없습니다",
+            "description": "트랜잭션이 발생하면 여기에 표시됩니다"
+        },
+        "emptyDashboard": {
+            "title": "아직 표시할 내용이 없습니다",
+            "description": "트랜잭션과 작업이 발생하면 여기에 표시됩니다"
+        },
+        "recentTitle": "최근 트랜잭션",
+        "details": {
+            "title": "트랜잭션 세부정보",
+            "copyAddress": "주소 복사",
+            "addressCopied": "주소가 클립보드에 복사되었습니다",
+            "sell": "판매",
+            "receive": "수신",
+            "pending": "대기 중",
+            "type": "유형",
+            "date": "날짜",
+            "from": "보낸 사람",
+            "to": "받는 사람",
+            "method": "메서드",
+            "contract": "컨트랙트",
+            "transaction": "트랜잭션"
+        }
+    },
+    "export": {
+        "types": {
+            "csv": ".CSV",
+            "json": ".JSON",
+            "xlsx": ".XLSX"
+        },
+        "transactionTypes": {
+            "all": "모든 유형",
+            "sent": "송금",
+            "received": "수신",
+            "stakingRewards": "스테이킹 보상"
+        },
+        "validation": {
+            "invalidEmail": "유효한 이메일 주소를 입력해 주세요"
+        },
+        "columns": {
+            "submissionTime": "Submission Time",
+            "dateRange": "Date Range",
+            "generatedBy": "Generated By",
+            "status": "Status"
+        },
+        "status": {
+            "generating": "생성 중",
+            "expired": "만료됨",
+            "failed": "실패"
+        },
+        "noPermission": "파일을 다운로드할 권한이 없습니다.",
+        "download": "다운로드",
+        "heading": "최근 트랜잭션 내보내기",
+        "teamOnly": "내보내기 생성 및 다운로드는 팀 멤버에게만 제공됩니다.",
+        "creditsUsed": "모든 크레딧을 사용했습니다",
+        "exportsUsed": "모든 내보내기를 사용했습니다",
+        "upgradePrompt": "더 많이 사용하려면 플랜을 업그레이드하세요",
+        "resetPrompt": "더 많은 액세스를 위해 플랜을 업그레이드하거나 다음 달에 한도가 재설정될 때까지 기다리세요.",
+        "tabs": {
+            "generate": "내보내기 생성",
+            "history": "기록"
+        },
+        "fields": {
+            "documentType": "문서 유형",
+            "timeRange": "기간",
+            "selectDateRange": "날짜 범위 선택",
+            "asset": "자산",
+            "allAssets": "모든 자산",
+            "transactionType": "트랜잭션 유형"
+        },
+        "buttons": {
+            "noPermissionExport": "내보내기 권한이 없습니다",
+            "quotaExhausted": "할당량을 모두 사용했습니다",
+            "exporting": "내보내는 중...",
+            "export": "내보내기"
+        },
+        "empty": {
+            "title": "아직 내보낸 항목이 없습니다",
+            "description": "지난 한 달 동안 내보낸 파일이 생성되면 여기에 표시됩니다."
+        },
+        "requirements": {
+            "heading": "내보내기 요건",
+            "canExportFrom": "다음 기간의 데이터를 내보낼 수 있습니다:",
+            "availability": "내보낸 파일은 48시간 동안 다운로드할 수 있습니다."
+        },
+        "quota": {
+            "heading": "내보내기 할당량",
+            "unlimited": "무제한",
+            "perMonth": "월 {count}회",
+            "flexibilityPrompt": "더 많은 유연성을 찾고 계신가요?",
+            "contactUs": "문의하기"
+        }
+    },
+    "requests": {
+        "filters": {
+            "proposalTypes": {
+                "Payments": "결제",
+                "Exchange": "교환",
+                "Earn": "수익",
+                "Vesting": "베스팅",
+                "Function Call": "함수 호출",
+                "Change Policy": "정책 변경",
+                "Settings": "설정",
+                "Confidential": "비공개"
+            },
+            "voteStatus": {
+                "Approved": "승인됨",
+                "Rejected": "거부됨",
+                "No Voted": "투표하지 않음"
+            },
+            "requestsType": "요청 유형",
+            "createdDate": "생성 날짜",
+            "recipient": "수신자",
+            "token": "토큰",
+            "requester": "요청자",
+            "approver": "승인자",
+            "myVoteStatus": "내 투표 상태",
+            "all": "전체",
+            "amount": "금액",
+            "from": "시작",
+            "to": "종료",
+            "min": "최소",
+            "max": "최대",
+            "invalidDate": "잘못된 날짜",
+            "operationIsNot": " 아님",
+            "operationBefore": " 이전",
+            "operationAfter": " 이후",
+            "operationContains": " 포함",
+            "searchByAddress": "주소로 검색",
+            "loadingMembers": "멤버 로딩 중...",
+            "noMembersFound": "멤버를 찾을 수 없습니다. \"{query}\"을(를) 추가하려면 Enter를 누르세요",
+            "noMembersAvailable": "이용 가능한 멤버가 없습니다",
+            "reset": "재설정",
+            "clear": "지우기",
+            "addFilter": "필터 추가"
+        },
+        "tabs": {
+            "all": "전체",
+            "pending": "대기 중",
+            "executed": "실행됨",
+            "rejected": "거부됨",
+            "expired": "만료됨",
+            "failed": "실패"
+        },
+        "searchPlaceholder": "이름 또는 ID로 요청 검색",
+        "searchPlaceholderShort": "이름 또는 ID로 검색",
+        "errorLoading": "제안을 불러오는 중 오류가 발생했습니다. 다시 시도해 주세요.",
+        "empty": {
+            "title": "첫 요청을 생성하세요",
+            "description": "결제, 교환 및 기타 작업에 대한 요청은 생성되면 여기에 표시됩니다.",
+            "send": "보내기",
+            "exchange": "교환"
+        },
+        "actions": {
+            "approve": "승인",
+            "reject": "거부",
+            "deposit": "입금",
+            "viewRequest": "요청 보기"
+        },
+        "table": {
+            "selectAll": "모두 선택",
+            "selectRow": "행 선택",
+            "request": "요청",
+            "transaction": "트랜잭션",
+            "requester": "요청자",
+            "voting": "투표",
+            "votingTooltip": "첫 번째 숫자는 받은 승인 수입니다. 두 번째 숫자는 실행에 필요한 승인 수입니다.",
+            "status": "상태",
+            "notPending": "제안이 대기 상태가 아닙니다.",
+            "noPermissionVote": "이 요청에 투표할 권한이 없습니다.",
+            "alreadyVoted": "이 요청에 이미 투표하셨습니다.",
+            "noResults": "필터와 일치하는 요청을 찾을 수 없습니다.",
+            "allCaughtUp": "모두 처리되었습니다!",
+            "noPending": "대기 중인 요청이 없습니다.",
+            "send": "보내기",
+            "exchange": "교환",
+            "requestsSelected": "{count, plural, other {요청 #건 선택됨}}",
+            "bulkApproveDisabled": "트레저리 잔액이 부족하여 이 요청을 승인할 수 없습니다."
+        },
+        "pending": {
+            "title": "대기 중인 요청",
+            "viewAll": "전체 보기",
+            "emptyTitle": "모두 처리되었습니다!",
+            "emptyDescription": "대기 중인 요청이 없습니다."
+        }
+    },
+    "proposals": {
+        "status": {
+            "pending": "대기 중",
+            "approved": "승인됨",
+            "rejected": "거부됨",
+            "executed": "실행됨",
+            "expired": "만료됨",
+            "failed": "실패",
+            "removed": "제거됨",
+            "inProgress": "진행 중"
+        },
+        "statusTooltip": {
+            "pending": "이 요청은 아직 대기 중이며 실행에 필요한 투표 수에 도달하지 않았습니다.",
+            "executed": "{required}명 중 {approved}명이 요청을 승인한 후 실행되었습니다.",
+            "rejected": "{required}명 중 {rejected}명이 거부에 투표한 후 거부되었습니다.",
+            "expired": "실행에 필요한 충분한 표를 받지 못해 만료되었습니다.",
+            "failed": "요청을 완료하지 못했습니다. 트랜잭션 세부정보는 <link>여기</link>에서 확인하세요.",
+            "failedPlain": "요청을 완료하지 못했습니다. 여기에서 트랜잭션 세부정보를 확인하세요."
+        },
+        "votes": {
+            "approved": "승인됨",
+            "rejected": "거부됨",
+            "pending": "대기 중"
+        },
+        "voteModal": {
+            "confirmTitle": "투표 확인",
+            "removeTitle": "요청 제거",
+            "bulkBody": "여러 요청을 {action}하려고 합니다. 제출 후에는 이 결정을 변경할 수 없습니다.",
+            "singleBody": "이 요청을 {action}하려고 합니다. 확인 후에는 이 작업을 취소할 수 없습니다.",
+            "actionApprove": "승인",
+            "actionReject": "거부",
+            "actionRemove": "제거",
+            "insufficientBalance": "잔액 부족으로 인해 요청 <highlight>{ids}</highlight>은(는) 승인할 수 없습니다. 승인은 나머지 요청에만 적용됩니다.",
+            "remove": "제거",
+            "confirm": "확인"
+        },
+        "expanded": {
+            "recipient": "수신자",
+            "amount": "금액",
+            "networkFee": "네트워크 수수료",
+            "notes": "메모",
+            "sent": "송금됨",
+            "received": "수신됨",
+            "priceDifference": "가격 차이",
+            "priceDifferenceTooltip": "견적 환율과 현재 시장 환율 간의 차이입니다. 양수 값은 시장보다 더 나은 환율을 나타냅니다.",
+            "slippageTolerance": "슬리피지 허용치",
+            "estimatedTime": "예상 시간",
+            "seconds": "{count}초",
+            "description": "설명",
+            "methodName": "메서드 이름",
+            "args": "인수",
+            "deposit": "입금",
+            "gas": "가스",
+            "totalDeposit": "총 입금액",
+            "totalGas": "총 가스",
+            "receiverId": "수신자 ID",
+            "contractId": "컨트랙트 ID",
+            "actionsCount": "{count, plural, other {#개의 작업}}",
+            "functionCallsCount": "{count, plural, other {#개의 함수 호출}}",
+            "showLess": "간략히 보기",
+            "showMore": "더 보기",
+            "stakingPool": "스테이킹 풀",
+            "validator": "검증자",
+            "action": "작업",
+            "stake": "스테이크",
+            "unstake": "언스테이크",
+            "withdraw": "출금",
+            "lockupOwner": "락업 소유자",
+            "lockupDuration": "락업 기간",
+            "cliff": "클리프",
+            "releaseDuration": "릴리스 기간",
+            "vestingSchedule": "베스팅 일정",
+            "cancellable": "취소 가능",
+            "allowEarn": "스테이킹 허용",
+            "yes": "예",
+            "no": "아니요",
+            "notSet": "설정되지 않음",
+            "from": "보낸 사람",
+            "to": "받는 사람",
+            "paymentsCount": "{count, plural, other {#건의 결제}}",
+            "sourceWallet": "출처 지갑",
+            "allNear": "모든 NEAR",
+            "startDate": "시작 날짜",
+            "endDate": "종료 날짜",
+            "cliffDate": "클리프 날짜",
+            "allowCancellation": "취소 허용",
+            "allowStaking": "스테이킹 허용",
+            "loadingHistorical": "기록 구성 로딩 중...",
+            "name": "이름",
+            "purpose": "용도",
+            "logo": "로고",
+            "logoAlt": "로고",
+            "primaryColor": "기본 색상",
+            "noChangesCurrent": "현재 상태와 비교하여 구성에서 변경 사항이 감지되지 않았습니다.",
+            "noChangesHistorical": "기록 상태와 비교하여 구성에서 변경 사항이 감지되지 않았습니다.",
+            "method": "메서드",
+            "arguments": "인수",
+            "contract": "컨트랙트",
+            "actionNumber": "작업 {number}",
+            "actions": "작업",
+            "collapseAll": "모두 접기",
+            "expandAll": "모두 펼치기",
+            "send": "보내기",
+            "receive": "수신",
+            "rate": "환율",
+            "priceSlippageLimit": "가격 슬리피지 한도",
+            "slippageTooltip": "이 요청에 대해 정의된 슬리피지 한도입니다. 실행 중 시장 환율이 이 임계값을 초과하여 변동되면 요청이 자동으로 실패합니다.",
+            "estimatedTimeTooltip": "입금 트랜잭션이 확인된 후 스왑이 실행될 예상 시간입니다.",
+            "minReceive": "최소 수신",
+            "minimumReceived": "최소 수신액",
+            "minReceiveTooltip": "이 교환에서 받게 될 최소 금액으로, 요청에 설정된 슬리피지 한도를 기준으로 합니다.",
+            "depositAddress": "입금 주소",
+            "depositAddressTooltip": "크로스체인 스왑 실행을 위해 토큰이 전송되는 1Click 입금 주소입니다.",
+            "quoteSignature": "견적 서명",
+            "quoteSignatureTooltip": "이 견적의 유효성을 검증하는 1Click API의 암호화 서명입니다.",
+            "quoteDeadline": "1-Click 견적 마감 시간",
+            "quoteDeadlineTooltip": "입금 주소가 비활성화되고 자금이 손실될 수 있는 시간입니다.",
+            "status": "상태",
+            "transactionLink": "트랜잭션 링크",
+            "viewTransaction": "트랜잭션 보기",
+            "recipientNumber": "수신자 {number}",
+            "oopsTitle": "이런! 문제가 발생했습니다",
+            "oopsDescription": "여기에 표시할 데이터를 찾을 수 없습니다.",
+            "totalAmount": "총 금액",
+            "recipients": "수신자",
+            "recipientsCount": "{count, plural, other {#명의 수신자}}",
+            "unsupportedProposal": "지원되지 않는 제안 유형",
+            "requestDetails": "요청 세부정보",
+            "linkCopied": "링크가 클립보드에 복사되었습니다",
+            "copyLink": "링크 복사",
+            "openRequestPage": "요청 페이지 열기",
+            "deleteRequest": "요청 삭제",
+            "unknownRecipients": "알 수 없는 수신자",
+            "loadingConfig": "구성 로딩 중...",
+            "historicalData": "기록 데이터...",
+            "generalUpdate": "일반 업데이트",
+            "detailsUnavailable": "세부정보를 사용할 수 없음",
+            "changesCount": "{count, plural, other {#건의 변경}}",
+            "policyUpdate": "정책 업데이트",
+            "noChangesDetected": "변경 사항이 감지되지 않음",
+            "loadingPolicy": "정책 로딩 중...",
+            "roleChanges": "역할 변경",
+            "policyParameters": "정책 매개변수",
+            "defaultVotePolicy": "기본 투표 정책",
+            "policyRoleChanges": "정책 및 역할 변경",
+            "membersAdded": "{count, plural, other {멤버 #명 추가됨}}",
+            "membersRemoved": "{count, plural, other {멤버 #명 제거됨}}",
+            "membersUpdated": "{count, plural, other {멤버 #명 업데이트됨}}",
+            "rolesModified": "{count, plural, other {역할 #개 수정됨}}",
+            "parametersChanged": "{count, plural, other {매개변수 #개 변경됨}}",
+            "defaultVotePolicyPart": "기본 투표 정책",
+            "onReceiver": "{receiver}에서",
+            "toPrefix": "받는 사람:",
+            "validatorPrefix": "검증자:",
+            "validatorSubtitle": "검증자: {address}",
+            "impactTitle": "투표 기간 변경의 영향",
+            "impactBody": "투표 기간을 업데이트하려고 합니다. 이는 다음 기존 요청에 영향을 미칩니다.",
+            "activeRequestsBullet": "{count, plural, other {이 변경 후 #건의 요청이 업데이트된 만료 날짜로 투표를 위해 활성 상태가 됩니다.}}",
+            "expiringRequestsBullet": "{count, plural, other {새 투표 기간 하에서 #건의 요청이 \"만료됨\"으로 표시됩니다.}}",
+            "remainActiveHeading": "새 만료 날짜로 투표를 위해 활성 상태로 유지되는 요청",
+            "willExpireHeading": "\"만료\"로 표시될 요청",
+            "tableRequest": "요청",
+            "tableTransaction": "트랜잭션",
+            "tableNewExpiry": "새 만료일",
+            "expireInDays": "{count, plural, other {#일 후 만료}}",
+            "today": "오늘",
+            "uponApproval": "승인 시",
+            "yesContinue": "예, 계속",
+            "transactionCreated": "트랜잭션 생성됨",
+            "voting": "투표",
+            "approvalsReceived": "{required}명 중 {received}명 승인",
+            "expiresAt": "만료 시간",
+            "expiredAt": "만료됨",
+            "exchangingTokens": "토큰 교환 중",
+            "exchangingTokensBody": "이 요청은 팀에 의해 승인되었습니다. 토큰 교환이 진행 중이며 시간이 다소 걸릴 수 있습니다.",
+            "requestFailed": "요청 실패",
+            "requestFailedBody": "팀이 이 요청을 승인했지만 환율 변동으로 인해 실패했습니다. 새 요청을 생성하고 다시 시도해 주세요.",
+            "votingPeriod24h": "투표 기간: 24시간",
+            "votingPeriod24hBody": "이 교환 요청의 투표 기간은 24시간입니다. 이 시간 내에 요청을 승인하지 않으면 요청이 만료됩니다.",
+            "reject": "거부",
+            "approve": "승인"
+        },
+        "insufficientBalance": {
+            "noAsset": "필요한 토큰이 트레저리에 없으므로 이 요청을 승인할 수 없습니다.",
+            "bond": "트레저리의 <token>{symbol}</token> 잔액이 부족하여 이 요청을 승인할 수 없습니다. 제안 본드 비용을 충당하기 위해 <token>{amount} {symbol}</token>을(를) 추가하세요.",
+            "continue": "트레저리의 <token>{symbol}</token> 잔액이 부족하여 이 요청을 승인할 수 없습니다. 계속하려면 <token>{amount} {symbol}</token>을(를) 추가하세요.",
+            "modalTitle": "NEAR 잔액 부족",
+            "modalBodyVote": "이 투표를 하기에 지갑의 NEAR 토큰이 부족합니다. 투표하려면 최소 <amount>{required} NEAR</amount>의 잔액이 필요합니다. 지갑에 NEAR를 추가하고 다시 시도해 주세요.",
+            "modalBodyProposal": "이 요청을 생성하기에 지갑의 NEAR 토큰이 부족합니다. 요청을 생성하려면 최소 <amount>{required} NEAR</amount>의 잔액이 필요합니다. 지갑에 NEAR를 추가하고 다시 시도해 주세요.",
+            "gotIt": "확인"
+        }
+    },
+    "members": {
+        "title": "멤버",
+        "description": "팀 멤버 및 권한 관리",
+        "permissions": "권한",
+        "member": "멤버",
+        "activeMembers": "활성 멤버",
+        "noActiveMembers": "활성 멤버를 찾을 수 없습니다.",
+        "addNewMember": "새 멤버 추가",
+        "membersSelected": "{count, plural, =0 {멤버 없음} other {멤버 #명}} 선택됨",
+        "remove": "제거",
+        "edit": "편집",
+        "requestorOnlyTooltip": "이 멤버는 NEARN에서 결제 요청을 생성하는 역할을 담당하므로 Requestor 역할만 추가할 수 있습니다.",
+        "memberModal": {
+            "editRoles": "역할 편집",
+            "addNewMember": "새 멤버 추가",
+            "validatingAddresses": "주소 검증 중...",
+            "creatingProposal": "제안 생성 중...",
+            "reviewRequest": "요청 검토",
+            "noChanges": "멤버 역할에 변경 사항이 없습니다"
+        },
+        "previewModal": {
+            "title": "요청 검토",
+            "youAreEditing": "편집 중",
+            "youAreAdding": "추가 중",
+            "membersCount": "{count, plural, other {멤버 #명}}",
+            "newMembersCount": "{count, plural, other {신규 멤버 #명}}",
+            "updatedMembers": "업데이트된 멤버",
+            "newMembers": "신규 멤버",
+            "creatingProposal": "제안 생성 중...",
+            "confirmSubmit": "확인 및 요청 제출"
+        },
+        "removeDialog": {
+            "title": "요청 제거",
+            "nearnBody": "승인되면 {account}이(가) 트레저리에서 영구적으로 제거되고 모든 관련 권한이 취소됩니다. 제거 후에는 이 계정이 더 이상 NEARN에서 요청을 생성할 수 없습니다.",
+            "genericBody": "승인되면 이 작업은 트레저리에서 <bold>{accounts}</bold>을(를) 영구적으로 제거하고 할당된 모든 권한을 취소합니다.",
+            "creatingProposal": "제안 생성 중..."
+        },
+        "validation": {
+            "accountIdRequired": "계정 ID는 필수입니다",
+            "invalidNearAddress": "잘못된 NEAR 주소입니다.",
+            "atLeastOneRole": "최소 하나의 역할을 선택해야 합니다",
+            "atLeastOneMember": "최소 한 명의 멤버가 필요합니다",
+            "alreadyAdded": "이 멤버는 이미 위에 추가되었습니다",
+            "alreadyInTreasury": "이 멤버는 이미 트레저리에 존재합니다",
+            "cannotRemoveRoleAfter": "이 멤버에서 {role} 역할을 제거할 수 없습니다. 모든 변경 사항을 적용하면 이 역할이 할당된 유일한 사람이 됩니다.",
+            "cannotRemoveRoleAfterGov": "이 멤버에서 {role} 역할을 제거할 수 없습니다. 모든 변경 사항을 적용하면 유일한 {role} 멤버가 되며, 이 역할이 없으면 팀 멤버를 관리하거나 투표를 구성할 수 없습니다."
+        },
+        "policy": {
+            "addMembers": "정책 업데이트 - 새 멤버 추가",
+            "addMembersSuccess": "새 멤버 요청이 성공적으로 생성되었습니다",
+            "editMember": "정책 업데이트 - 멤버 권한 편집",
+            "editMembers": "정책 업데이트 - 여러 멤버 편집",
+            "editMemberSuccess": "멤버 역할 업데이트 요청이 성공적으로 생성되었습니다",
+            "editMembersSuccess": "일괄 멤버 역할 업데이트 요청이 성공적으로 생성되었습니다",
+            "removeMember": "정책 업데이트 - 멤버 제거",
+            "removeMembers": "정책 업데이트 - 멤버 제거",
+            "removeMemberSuccess": "멤버 제거 요청이 성공적으로 생성되었습니다"
+        }
+    },
+    "settings": {
+        "tabs": {
+            "general": "일반",
+            "voting": "투표",
+            "preferences": "환경설정",
+            "integrations": "통합"
+        },
+        "general": {
+            "validation": {
+                "displayNameRequired": "표시 이름은 필수입니다",
+                "displayNameMax": "표시 이름은 100자 미만이어야 합니다"
+            },
+            "proposalDescriptionTitle": "구성 업데이트 - 테마 및 로고",
+            "proposalSubmitted": "구성 업데이트 요청이 제출되었습니다",
+            "treasuryNotFound": "트레저리를 찾을 수 없습니다",
+            "treasuryName": "트레저리 이름",
+            "treasuryNameDescription": "트레저리의 이름입니다. 이 이름은 앱 전체에 표시됩니다.",
+            "displayName": "표시 이름",
+            "displayNamePlaceholder": "표시 이름 입력",
+            "accountName": "계정 이름",
+            "logo": "로고",
+            "logoDescription": "트레저리용 로고를 업로드하세요. SVG, PNG 또는 JPG (256x256 픽셀) 권장.",
+            "treasuryLogoAlt": "트레저리 로고",
+            "uploading": "업로드 중...",
+            "uploadLogo": "로고 업로드",
+            "removeLogo": "로고 제거",
+            "logoUploaded": "로고가 성공적으로 업로드되었습니다",
+            "uploadError": "이미지 업로드 중 오류가 발생했습니다. 다시 시도해 주세요.",
+            "invalidLogo": "잘못된 로고입니다. 정확히 256x256 픽셀의 PNG, JPG 또는 SVG 파일을 업로드해 주세요",
+            "invalidImage": "잘못된 이미지 파일입니다. 유효한 이미지를 업로드해 주세요.",
+            "fileReadError": "파일 읽기 오류입니다. 다시 시도해 주세요.",
+            "primaryColor": "기본 색상",
+            "primaryColorDescription": "트레저리의 인터페이스 요소에 대한 기본 색상을 설정하세요. 이 색상은 라이트 모드와 다크 모드 모두에서 사용되므로 중성 색조를 선택할 때 대비를 고려하세요.",
+            "selectColorLabel": "색상 {color} 선택"
+        },
+        "voting": {
+            "validation": {
+                "required": "투표 기간은 필수입니다",
+                "validNumber": "투표 기간은 유효한 숫자여야 합니다",
+                "min": "투표 기간은 최소 1일이어야 합니다",
+                "max": "투표 기간은 1000일 미만이어야 합니다",
+                "whole": "투표 기간은 일 단위 정수여야 합니다"
+            },
+            "missingData": "필수 데이터 누락",
+            "thresholdProposalTitle": "정책 업데이트 - 투표 임계값",
+            "thresholdProposalSummary": "{account}이(가) 투표 임계값을 {oldValue}에서 {newValue}(으)로 변경하도록 요청했습니다.",
+            "thresholdSubmitted": "투표 임계값 업데이트 요청이 제출되었습니다",
+            "createProposalFailed": "제안 생성에 실패했습니다",
+            "durationProposalTitle": "정책 업데이트 - 투표 기간",
+            "durationProposalSummary": "{account}이(가) 투표 기간을 {oldValue}에서 {newValue}(으)로 변경하도록 요청했습니다.",
+            "durationSubmitted": "요청이 성공적으로 생성되었습니다",
+            "pendingTitle": "활성 투표 임계값 요청",
+            "pendingBody": "충돌을 피하기 위해, 진행하기 전에 기존 대기 중인 요청을 완료하거나 해결해야 합니다. 이러한 요청은 현재 활성 상태이며 먼저 승인하거나 거부해야 합니다.",
+            "viewRequest": "요청 보기",
+            "thresholdHeading": "투표 임계값",
+            "thresholdDescriptionApprovers": "결제 및 팀 관련 요청을 승인하는 데 필요한 투표 수를 정의합니다. Approver와 Governance에 대해 임계값을 별도로 구성하세요.",
+            "thresholdDescriptionGeneric": "요청을 승인하는 데 필요한 투표 수를 정의합니다. 각 역할에 대해 책임에 따라 임계값을 구성하세요.",
+            "membersWhoCanVote": "투표할 수 있는 멤버",
+            "votesRequired": "요청을 승인하는 데 필요한 투표",
+            "durationHeading": "투표 기간",
+            "durationDescription": "제안이 투표를 위해 열려 있는 기간(일 단위)입니다. 이 기간 내에 투표가 완료되지 않으면 결정이 만료됩니다.",
+            "durationApprovers": " 이 기간은 Governance와 Approver 역할 모두에 동일하게 적용됩니다.",
+            "durationGeneric": " 이 기간은 모든 트레저리 역할에 일관되게 적용됩니다.",
+            "days": "일"
+        },
+        "preferences": {
+            "timeZone": "시간대",
+            "timeZoneDescription": "정확한 날짜 및 시간 표시를 위해 현지 시간대를 설정하세요.",
+            "timeFormat": "시간 형식",
+            "hour12": "12시간 (오후 1:00)",
+            "hour24": "24시간 (13:00)",
+            "autoTimezone": "위치를 사용하여 시간대를 자동으로 설정",
+            "timezone": "시간대",
+            "loadingTimezones": "시간대 로딩 중...",
+            "selectTimezone": "시간대 선택",
+            "searchTimezones": "시간대 검색...",
+            "noTimezones": "시간대를 찾을 수 없습니다",
+            "save": "저장",
+            "savedToast": "환경설정이 성공적으로 저장되었습니다",
+            "saveFailed": "환경설정 저장에 실패했습니다",
+            "loadFailed": "시간대를 불러오지 못했습니다"
+        }
+    },
+    "addressBook": {
+        "emptyTitle": "첫 수신자를 추가하세요",
+        "emptyDescription": "자주 사용하는 주소를 저장하여 더 빠르고 오류 없는 지급을 하세요. 연락처는 비공개로 유지되며 팀에게만 표시됩니다.",
+        "import": "가져오기",
+        "addRecipient": "수신자 추가",
+        "recipientsHeading": "수신자",
+        "recipientsSelected": "{count, plural, =0 {수신자 없음} other {수신자 #명}} 선택됨",
+        "sectionHeading": "수신자",
+        "privacyNote": "저장된 주소는 비공개이며 팀에게만 표시됩니다.",
+        "searchPlaceholder": "이름으로 수신자 검색",
+        "searchPlaceholderShort": "검색",
+        "review": {
+            "header": "세부정보 검토",
+            "youAreAdding": "추가 중",
+            "newRecipients": "{count, plural, other {신규 수신자 #명}}",
+            "onNetworks": "{count, plural, other {#개의 네트워크}}",
+            "recipients": "수신자",
+            "allDuplicates": "가져온 모든 수신자가 이미 주소록에 있습니다. 다른 목록을 업로드하려면 뒤로 가거나 이 검토에서 중복을 제거하세요.",
+            "someDuplicates": "총 {total}명의 수신자 중 {duplicates}명이 중복됩니다. 새 수신자만 업로드하려면 계속하세요.",
+            "duplicated": "중복됨",
+            "notePlaceholder": "이 수신자를 식별하는 데 도움이 되는 메모를 추가하세요 (예: 계약자 결제, 베스팅 분배).",
+            "skipDuplicates": "중복을 건너뛰고 새로운 항목만 가져오기.",
+            "allDuplicatesTooltip": "가져온 모든 수신자가 이미 주소록에 있으므로 새로 가져올 항목이 없습니다.",
+            "duplicateActionTooltip": "계속하려면 중복 건너뛰기를 활성화하거나 중복 수신자를 제거하세요.",
+            "adding": "추가 중…",
+            "nothingNew": "가져올 새 항목 없음",
+            "addRecipientsButton": "{count, plural, other {수신자 추가}}"
+        },
+        "removeDialog": {
+            "title": "수신자 제거",
+            "bulk": "주소록에서 <bold>{count, plural, other {수신자 #명}}</bold>을(를) 제거합니다. 언제든지 다시 추가할 수 있습니다.",
+            "single": "주소록에서 <bold>{name}</bold>을(를) 제거합니다. 언제든지 이 수신자를 다시 추가할 수 있습니다."
+        },
+        "importFlow": {
+            "title": "수신자 가져오기",
+            "description": "주소록에 수신자 주소 목록을 업로드하세요.",
+            "foundSummary": "{networkCount, plural, other {#개 네트워크}}에서 {count, plural, other {#명의 수신자}}을(를) 찾았습니다",
+            "uploadPrompt": "수신자 데이터 업로드 또는 붙여넣기",
+            "fixErrors": "계속하려면 오류를 수정하세요",
+            "continueReview": "검토로 계속"
+        },
+        "form": {
+            "editRecipient": "수신자 편집",
+            "addRecipient": "수신자 추가",
+            "import": "가져오기",
+            "recipientName": "수신자 이름",
+            "namePlaceholder": "Alice",
+            "recipientAddress": "수신자 주소",
+            "network": "네트워크",
+            "networkInfo": "이 주소와 호환되는 네트워크",
+            "enterAddressFirst": "먼저 수신자 주소를 입력하세요",
+            "selectNetwork": "네트워크 선택",
+            "selectNetworksTitle": "네트워크 선택",
+            "searchNetworksPlaceholder": "네트워크 검색…",
+            "done": "완료",
+            "edit": "편집",
+            "remove": "제거",
+            "incomplete": "미완료",
+            "addAnother": "수신자 추가",
+            "fillAllTooltip": "수신자를 추가하려면 모든 필드를 작성해야 합니다.",
+            "reviewDetails": "세부정보 검토",
+            "reviewTooltip": "검토하기 전에 모든 수신자가 완료되어야 합니다.",
+            "invalidAddress": "잘못된 주소",
+            "noCompatibleNetworks": "이 주소와 호환되는 네트워크가 없습니다"
+        },
+        "parsing": {
+            "rowPrefix": "{row}행: {message}",
+            "missingName": "수신자 이름이 누락되었습니다. 이름을 추가해 주세요.",
+            "missingAddress": "수신자 주소가 누락되었습니다. 지갑 주소를 추가해 주세요.",
+            "invalidAddressFormat": "주소 \"{address}\"은(는) 지원되는 어떤 네트워크에서도 유효한 형식이 아닙니다.",
+            "unknownNetwork": "알 수 없는 네트워크 \"{network}\"입니다. 지원되는 네트워크: {available}.",
+            "incompatibleNetwork": "주소 \"{address}\"은(는) {network}와(과) 호환되지 않습니다. 호환되는 네트워크: {compatible}.",
+            "noDataFound": "데이터를 찾을 수 없습니다. 다음 형식으로 수신자를 추가해 주세요: Name, Address, Network, Note",
+            "headerColumnsNotFound": "헤더 행이 감지되었지만 'Name' 및 'Address' 열을 찾을 수 없습니다. 이러한 열 이름을 사용하거나 헤더 행을 제거해 주세요.",
+            "failedToParseCsv": "CSV 데이터 구문 분석에 실패했습니다"
+        }
+    },
+    "payments": {
+        "validation": {
+            "recipientMin": "수신자는 최소 2자여야 합니다",
+            "recipientMax": "수신자는 128자 미만이어야 합니다",
+            "amountPositive": "금액은 0보다 커야 합니다",
+            "recipientTokenSame": "수신자와 토큰 주소는 같을 수 없습니다"
+        },
+        "newPayment": "새 결제",
+        "reviewYourPayment": "결제 검토",
+        "reviewButton": "결제 검토",
+        "reviewButtonDisabled": "금액과 주소를 입력하세요",
+        "comingSoon": "출시 예정",
+        "bulkPayments": "일괄 결제",
+        "summaryRecipients": "{count, plural, other {#명의 수신자}}에게",
+        "networkFee": "네트워크 수수료",
+        "networkFeeInfo": "네트워크 수수료 정보",
+        "commentPlaceholder": "댓글 추가 (선택사항)...",
+        "preparingRoute": "1Click 전송 경로 준비 중...",
+        "confirmSubmit": "확인 및 요청 제출",
+        "useDifferentAddress": "다른 주소 사용",
+        "failed1ClickQuote": "1Click 전송 견적 생성에 실패했습니다",
+        "paymentSubmitted": "결제 송금 요청이 제출되었습니다"
+    },
+    "bulkPayment": {
+        "comingSoonToast": "일괄 결제는 곧 출시됩니다!",
+        "submittingList": "일괄 결제 목록 제출 중",
+        "submittingProposal": "제안 제출 중",
+        "proposalSubmitted": "일괄 결제 제안이 제출되었습니다",
+        "submitListFailed": "결제 목록 제출에 실패했습니다",
+        "submitFailed": "일괄 결제 제출에 실패했습니다",
+        "upload": {
+            "pleaseUploadCsv": "CSV 파일을 업로드해 주세요",
+            "fileSizeLimit": "파일 크기는 1.5 MB 미만이어야 합니다",
+            "headerTitle": "일괄 결제 요청",
+            "headerSubtitle": "단일 제안으로 여러 수신자에게 지급하세요.",
+            "creditsUsed": "모든 크레딧을 사용했습니다",
+            "bulkPaymentsUsed": "모든 일괄 결제를 사용했습니다",
+            "upgradeTrial": "더 많이 사용하려면 플랜을 업그레이드하세요",
+            "upgradePaid": "더 많은 액세스를 위해 플랜을 업그레이드하거나 다음 달에 한도가 재설정될 때까지 기다리세요.",
+            "selectAsset": "자산 선택",
+            "disableTokenMessage": "이러한 토큰의 일괄 결제는 곧 제공됩니다.",
+            "providePaymentData": "결제 데이터 제공",
+            "uploadFile": "파일 업로드",
+            "provideData": "데이터 제공",
+            "chooseFile": "파일 선택",
+            "orDragDrop": "또는 드래그 앤 드롭",
+            "maxFileSize": "최대 1개 파일, 1.5 MB까지, CSV 파일만 가능",
+            "noFilePrompt": "업로드할 파일이 없으신가요?",
+            "downloadTemplate": "템플릿 다운로드",
+            "requirements": "일괄 결제 요건",
+            "maxTransactions": "가져오기당 최대 {max}개의 트랜잭션",
+            "singleTokenNetwork": "단일 토큰 및 네트워크",
+            "limitsUsed": "모든 한도를 사용했습니다",
+            "selectAndProvide": "자산을 선택하고 결제 데이터를 제공하세요",
+            "continueToReview": "검토로 계속",
+            "selectTokenError": "토큰을 선택해 주세요",
+            "providePaymentDataError": "결제 데이터를 제공해 주세요"
+        },
+        "editStep": {
+            "title": "결제 편집",
+            "saveChanges": "변경 사항 저장"
+        },
+        "parsing": {
+            "rowPrefix": "{row}행: {message}",
+            "missingRecipientFirstColumn": "수신자 주소가 누락되었습니다. 첫 번째 열에 주소를 추가해 주세요.",
+            "invalidNearAddress": "주소 \"{address}\"은(는) 유효한 NEAR 계정이 아닙니다.",
+            "invalidChainAddress": "주소 \"{address}\"은(는) 유효한 {chain} 계정이 아닙니다.",
+            "rowNeedsAmountRecipient": "각 행에는 쉼표로 구분된 금액과 수신자가 필요합니다. 예: 100, alice.near",
+            "missingRecipientBeforeComma": "수신자 주소가 누락되었습니다. 쉼표 앞에 주소를 추가해 주세요.",
+            "missingAmountAfterComma": "금액이 누락되었습니다. 쉼표 뒤에 숫자를 추가해 주세요. 예: {recipient}, 100",
+            "invalidAmountNumber": "금액 \"{amountStr}\"은(는) 유효한 숫자가 아닙니다. 숫자와 소수점만 사용해 주세요 (예: 100 또는 100.50).",
+            "amountGreaterThanZero": "금액은 0보다 커야 합니다. 입력하신 값은 \"{amountStr}\"입니다.",
+            "amountTooLarge": "금액 \"{amountStr}\"이(가) 너무 큽니다. 더 작은 숫자를 사용해 주세요.",
+            "invalidAmountFallback": "잘못된 금액입니다. 숫자와 소수점만 사용해 주세요 (예: 100 또는 100.50).",
+            "pleaseRemoveChars": "다음 문자를 제거해 주세요: {chars}. 숫자, 쉼표, 점만 허용됩니다.",
+            "amountCannotBeEmpty": "금액은 비워둘 수 없습니다.",
+            "tokenMismatch": "\"{provided}\"을(를) 입력하셨지만 위에 {expected}이(가) 선택되어 있습니다. 토큰 기호를 제거하거나 드롭다운에서 {suggested}을(를) 선택하세요.",
+            "multipleTokenSymbols": "여러 토큰 기호({symbols})를 사용하고 있습니다. 파일 전체에서 한 가지 토큰 유형만 사용하거나 토큰 기호를 제거하고 위의 선택이 토큰을 결정하도록 해 주세요.",
+            "noPaymentDataFound": "결제 데이터를 찾을 수 없습니다. 다음 형식으로 결제를 추가해 주세요: recipient, amount",
+            "exceedsRecipientLimit": "수신자가 {count}명이지만, 일괄당 한도는 {limit}명입니다. {excess, plural, other {수신자 #명}}을(를) 제거하거나 여러 일괄로 분할해 주세요.",
+            "noPaymentDataProvided": "결제 데이터가 제공되지 않았습니다. 다음 형식으로 결제를 입력해 주세요: recipient, amount",
+            "headerColumnsNotFound": "헤더 행이 감지되었지만 'Recipient' 및 'Amount' 열을 찾을 수 없습니다. 이러한 열 이름을 사용하거나 헤더 행을 제거해 주세요.",
+            "failedToParseCsv": "CSV 데이터 구문 분석에 실패했습니다",
+            "failedToParsePaste": "붙여넣은 데이터 구문 분석에 실패했습니다",
+            "failedToValidateAccount": "계정 검증에 실패했습니다",
+            "feeEstimationFailed": "이 금액에 대한 네트워크 수수료를 추정할 수 없습니다. 확인 후 다시 시도해 주세요.",
+            "feeEstimationFailedRow": "{row}행 ({recipient}): 이 금액에 대한 네트워크 수수료를 추정할 수 없습니다. 확인 후 다시 시도해 주세요."
+        },
+        "recipients": "수신자",
+        "insufficientTokens": "토큰이 부족합니다. 요청을 제출하고 승인 전에 충전할 수 있습니다.",
+        "removeRecipient": "수신자 제거",
+        "removeRecipientConfirm": "<strong>{recipient}</strong>에 대한 결제를 제거하시겠습니까? 이 작업은 취소할 수 없습니다.",
+        "remove": "제거",
+        "edit": "편집"
+    },
+    "bulkPaymentCredits": {
+        "title": "일괄 결제",
+        "unlimited": "무제한",
+        "creditsPerPeriod": "{period}당 {amount}",
+        "oneTimeTrial": "일회성 평가판",
+        "month": "월",
+        "moreFlexibility": "더 많은 유연성을 찾고 계신가요?",
+        "contactUs": "문의하기"
+    },
+    "exchange": {
+        "validation": {
+            "amountPositive": "금액은 0보다 커야 합니다"
+        },
+        "requestSubmitted": "교환 요청이 제출되었습니다",
+        "heading": "교환",
+        "sell": "판매",
+        "receive": "수신",
+        "slippageTolerance": "슬리피지 허용치",
+        "disabled": {
+            "differentTokens": "토큰은 서로 달라야 합니다",
+            "enterAmount": "교환할 금액을 입력하세요"
+        },
+        "review": "교환 검토",
+        "poweredBy": "제공",
+        "info": {
+            "priceDifference": "가격 차이",
+            "priceDifferenceTooltip": "견적 환율과 현재 시장 환율 간의 차이입니다. 양수 값은 시장보다 더 나은 환율을 나타냅니다.",
+            "estimatedTime": "예상 시간",
+            "estimatedTimeValue": "{seconds}초",
+            "estimatedTimeTooltip": "교환 완료에 걸리는 대략적인 시간입니다.",
+            "minimumReceived": "최소 수신액",
+            "minimumReceivedTooltip": "이 교환에서 받게 될 최소 금액으로, 요청에 설정된 슬리피지 한도를 기준으로 합니다.",
+            "depositAddress": "입금 주소",
+            "depositAddressCopied": "입금 주소가 복사되었습니다",
+            "quoteExpires": "견적 만료",
+            "exchangeFee": "교환 수수료",
+            "exchangeFeeTooltip": "여기서 발생하는 0.70% 수수료는 거래를 가능하게 하는 NEAR Intents 프로토콜 비용과 Trezu 위젯 수수료를 포함합니다. 이 금액은 견적된 환율에 자동으로 계산됩니다."
+        },
+        "approveWithin24h": "24시간 이내에 이 요청을 승인해 주세요. 그렇지 않으면 만료됩니다. 가능한 한 빨리 확인하는 것을 권장합니다.",
+        "confirmSubmit": "확인 및 요청 제출",
+        "refreshingIn": "환율은 {seconds}초 후에 새로 고침됩니다"
+    },
+    "vesting": {
+        "validation": {
+            "amountMin": "금액은 3.5 이상이어야 합니다",
+            "startBeforeEnd": "시작 날짜는 종료 날짜보다 이전이어야 합니다",
+            "cliffBetween": "클리프 날짜는 다음 사이여야 합니다"
+        },
+        "stepTitles": {
+            "details": "세부정보",
+            "settings": "설정",
+            "review": "검토"
+        },
+        "proposalTitle": "{address}에 대한 베스팅 일정 생성",
+        "scheduleSubmitted": "베스팅 일정 생성 요청이 제출되었습니다",
+        "heading": "새 베스팅 일정",
+        "amount": "금액",
+        "startDate": "시작 날짜",
+        "endDate": "종료 날짜",
+        "noteOptional": "메모 (선택사항)",
+        "continue": "계속",
+        "advancedSettings": "고급 설정",
+        "allowCancellation": "취소 허용",
+        "allowCancellationDescription": "NEAR 재단이 언제든지 락업을 취소할 수 있도록 허용합니다. 취소 불가능한 락업은 클리프 날짜와 호환되지 않습니다.",
+        "cliffDate": "클리프 날짜",
+        "allowEarn": "수익 허용",
+        "allowEarnDescription": "락업 소유자가 락업의 전체 토큰 금액을 스테이킹할 수 있도록 허용합니다 (클리프 날짜 이전에도).",
+        "commentPlaceholder": "이 베스팅 일정에 대한 댓글 추가 (선택사항)...",
+        "reviewRequest": "요청 검토",
+        "reviewHeading": "베스팅 일정 검토",
+        "confirmSubmit": "확인 및 요청 제출",
+        "review": {
+            "recipient": "수신자",
+            "startDate": "시작 날짜",
+            "endDate": "종료 날짜",
+            "cliffDate": "클리프 날짜",
+            "cancelable": "취소 가능",
+            "allowEarn": "수익 허용",
+            "na": "해당 없음"
+        }
+    },
+    "earn": {
+        "placeholder": "수익 기회와 스테이킹 보상을 살펴보세요."
+    },
+    "createTreasury": {
+        "validation": {
+            "nameMin": "트레저리 이름은 최소 2자여야 합니다",
+            "nameMax": "트레저리 이름은 64자 미만이어야 합니다",
+            "accountMin": "계정 이름은 최소 2자여야 합니다",
+            "accountMax": "계정 이름은 64자 미만이어야 합니다",
+            "accountChars": "계정 이름은 라틴 문자, 숫자, 하이픈만 포함할 수 있습니다",
+            "accountTaken": "이 계정 이름은 이미 사용 중입니다"
+        },
+        "votingNote": "투표 설정을 수정하려면 더 많은 멤버가 필요합니다. 투표를 구성하려면 다른 멤버를 추가하세요.",
+        "minimumVoteNote": "최소 한 번의 승인 투표가 필요합니다.",
+        "heading": "트레저리 생성",
+        "addMembers": "멤버 추가",
+        "addMembersInfo": "지금 멤버를 추가하거나 업데이트할 수 있으며, 나중에 언제든지 편집할 수 있습니다.",
+        "treasuryName": "트레저리 이름",
+        "treasuryNamePlaceholder": "내 트레저리",
+        "accountName": "계정 이름",
+        "accountNameInfo": "계정의 고유 이름입니다. 트레저리 URL에 사용되며 결제를 보낸 사람을 식별하기 위해 트랜잭션에 표시됩니다. 짧고 인식하기 쉬운 계정 이름을 선택하세요.",
+        "accountPlaceholder": "my-treasury",
+        "continue": "계속",
+        "votingThreshold": "투표 임계값",
+        "thresholdDescription": "요청을 승인하는 데 필요한 투표 수를 설정하세요:",
+        "financial": "Financial",
+        "financialDescription": "결제 및 교환 요청 승인.",
+        "governance": "Governance",
+        "governanceDescription": "설정, 멤버, 투표 구성 승인.",
+        "confidential": "비공개",
+        "public": "공개",
+        "anyone": "모두",
+        "teamOnly": "팀 전용",
+        "soon": "곧 제공",
+        "publicDescription": "모든 잔액, 활동 및 트랜잭션이 블록체인에서 모든 사람에게 표시됩니다. 이 옵션은 투명한 조직 및 공개 DAO에 가장 적합합니다.",
+        "balanceTransactions": "잔액, 트랜잭션",
+        "membersVoting": "멤버, 투표",
+        "allFeatures": "모든 기능 사용 가능",
+        "confidentialDescription": "모든 잔액, 활동 및 전송이 블록체인에서 비공개로 유지됩니다. 팀만이 이 정보를 볼 수 있습니다. 비공개 회사, 패밀리 오피스 또는 재무 프라이버시를 원하는 팀에 가장 적합합니다.",
+        "recentTransactionsExport": "최근 트랜잭션 내보내기",
+        "bulkPayment": "일괄 결제",
+        "treasuryType": "트레저리 유형",
+        "treasuryTypeWarning": "트레저리당 한 번만 선택할 수 있으며 나중에 변경할 수 없습니다.",
+        "select": "선택",
+        "visibleOnChain": "체인에서 표시 가능",
+        "featuresAvailable": "사용 가능한 기능",
+        "mostFeaturesSupported": "대부분의 기능 지원",
+        "reviewTreasury": "트레저리 검토",
+        "membersLabel": "멤버",
+        "financialThreshold": "Financial 임계값",
+        "governanceThreshold": "Governance 임계값",
+        "noDeploymentFee": "🎉 배포 수수료 없음",
+        "noDeploymentFeeDescription": "신규 프로젝트를 지원하기 위해 TREZU는 모든 일회성 배포 및 네트워크 저장 수수료를 부담합니다.",
+        "createButton": "트레저리 생성",
+        "connectWalletCreate": "트레저리 생성을 위해 지갑 연결",
+        "unexpectedError": "예기치 않은 오류가 발생했습니다",
+        "creationFailed": "트레저리 생성에 실패했습니다. 다시 시도해 주세요.",
+        "stepTitles": {
+            "aboutYou": "사용자 정보",
+            "details": "세부정보",
+            "members": "멤버",
+            "treasuryType": "트레저리 유형",
+            "review": "검토"
+        },
+        "steps": {
+            "creatingNear": "NEAR에서 트레저리 생성 중",
+            "registeringKey": "공개 키 등록 중",
+            "settingUpConfidential": "비공개 트랜잭션 설정 중",
+            "configuringMembers": "트레저리 멤버 구성 중",
+            "finalizingSetup": "설정 완료 중"
+        }
+    },
+    "manageTreasuries": {
+        "warningOne": "최소 하나의 트레저리는 사용 가능하게 유지되어야 합니다",
+        "warningOnePeriod": "최소 하나의 트레저리는 사용 가능하게 유지되어야 합니다.",
+        "activeHeading": "활성 트레저리",
+        "activeDescription": "현재 계정 목록에 표시되는 트레저리입니다.",
+        "activeEmpty": "활성 트레저리가 없습니다.",
+        "hiddenHeading": "숨겨진 트레저리",
+        "hiddenDescription": "계정 목록에서 숨겨진 트레저리입니다.",
+        "removeGuestTitle": "게스트 트레저리 제거",
+        "removeDialog": "<bold>{name}</bold>을(를) 제거하려고 합니다. 확인 후에는 이 작업을 취소할 수 없습니다.",
+        "tooltips": {
+            "removeFromList": "목록에서 제거",
+            "viewTreasury": "트레저리 보기",
+            "hideFromList": "목록에서 숨기기",
+            "showInList": "목록에 표시"
+        }
+    },
+    "wallet": {
+        "proposal": {
+            "transfer": "외부 dApp의 제안: {receiverId}로 NEAR 전송",
+            "functionCall": "외부 dApp의 제안: {receiverId}에서 {methods}",
+            "unsupportedAction": "지원되지 않는 작업 유형 \"{type}\"입니다. Trezu 제안으로 변환할 수 있는 작업은 Transfer 및 FunctionCall뿐입니다."
+        },
+        "loading": "로딩 중...",
+        "connectPrompt": "계속하려면 NEAR 지갑을 연결하세요. 그런 다음 대신 작동할 트레저리를 선택하게 됩니다.",
+        "connectWallet": "지갑 연결",
+        "cancel": "취소",
+        "connectedAs": "<strong>{account}</strong>(으)로 연결됨",
+        "loadingTreasuries": "트레저리 로딩 중...",
+        "selectSignIn": "로그인할 트레저리를 선택하세요:",
+        "selectSignTx": "제안을 생성할 트레저리를 선택하세요:",
+        "notMember": "어떤 트레저리의 멤버도 아닙니다.",
+        "actingAs": "다음으로 작동 중",
+        "signedBy": "{account}이(가) 서명함",
+        "createsNProposals": "다음 항목에 대한 {count, plural, other {Trezu 제안 #건}}이(가) 생성됩니다:",
+        "proposalDescriptionLabel": "제안 설명 (선택사항)",
+        "proposalDescriptionPlaceholder": "이 제안에 대해 설명하세요...",
+        "createProposal": "제안 생성",
+        "creatingProposal": "제안 생성 중...",
+        "confirmInWallet": "지갑에서 확인해 주세요",
+        "proposalSubmitted": "제안 제출됨",
+        "shareProposal": "제안이 생성되었습니다. 투표를 위해 아래 링크를 트레저리 멤버에게 공유하세요.",
+        "proposalLink": "{daoId} — 제안 #{id}",
+        "checking": "확인 중...",
+        "proposalApprovedProceed": "제안이 승인되었습니다. 진행하세요",
+        "signedInSuccess": "성공적으로 로그인되었습니다",
+        "proposalCreatedSuccess": "제안이 성공적으로 생성되었습니다",
+        "closeWindow": "이 창을 닫을 수 있습니다.",
+        "errorGeneric": "오류가 발생했습니다",
+        "tryAgain": "다시 시도",
+        "errors": {
+            "parseTx": "트랜잭션 요청 구문 분석에 실패했습니다. 다시 시도해 주세요.",
+            "fetchTreasuries": "트레저리를 가져오지 못했습니다. 다시 시도해 주세요.",
+            "connectFailed": "지갑 연결에 실패했습니다",
+            "createProposalFailed": "제안 생성에 실패했습니다",
+            "stillPending": "제안이 아직 승인 대기 중입니다. 트레저리 멤버가 투표할 때까지 기다려 주세요.",
+            "wasStatus": "제안 #{id}이(가) {status} 상태입니다",
+            "awaitIndex": "제안이 승인되었지만 실행 트랜잭션이 아직 인덱싱되지 않았습니다. 잠시 후 다시 시도해 주세요.",
+            "checkStatusFailed": "제안 상태 확인에 실패했습니다",
+            "userCancelled": "사용자가 취소했습니다",
+            "proposalWasStatus": "제안이 {status} 상태입니다"
+        }
+    },
+    "telegram": {
+        "tagPill": "Telegram",
+        "invalidLinkTitle": "잘못된 링크",
+        "invalidLinkDescription": "이 Telegram 연결 링크에 토큰이 없습니다. Telegram에서 트레저리 연결을 다시 클릭하여 새 링크를 생성하세요.",
+        "successTitle": "성공적으로 연결됨",
+        "successDescription": "트레저리가 이 Telegram 채팅에 연결되었습니다.",
+        "successToast": "트레저리가 성공적으로 연결되었습니다",
+        "goToApp": "앱으로 이동",
+        "linkExpiredTitle": "링크 만료됨",
+        "linkExpiredDescription": "이 링크가 만료되었거나 이미 사용되었습니다. Telegram에서 아래 명령을 입력하여 연결 흐름을 다시 시작하세요.",
+        "commandCopied": "명령이 복사되었습니다",
+        "copy": "복사",
+        "unableToLoadTitle": "채팅을 불러올 수 없음",
+        "unableToLoadDescription": "지금은 채팅 세부정보를 불러올 수 없습니다. Telegram에서 다시 시도해 주세요.",
+        "signInTitle": "계속하려면 로그인하세요",
+        "signInDescription": "먼저 NEAR 지갑을 연결한 다음, 이 Telegram 채팅에 연결할 트레저리를 선택하세요.",
+        "connectWallet": "지갑 연결",
+        "selectTreasuriesTitle": "트레저리 선택",
+        "selectTreasuriesDescription": "이 Telegram 채팅에 연결할 트레저리를 선택하세요.",
+        "telegramChat": "Telegram 채팅",
+        "chatIdFallback": "채팅 #{id}",
+        "failedToConnect": "트레저리 연결에 실패했습니다. 다시 시도해 주세요.",
+        "relinking": "{count, plural, other {선택한 트레저리 #개가 다른 Telegram 채팅에 연결되어 있습니다. 연결하면 다시 연결되며 채팅 ID 링크가 이 채팅으로 변경됩니다.}}",
+        "alreadyConnected": "이 채팅에 이미 연결됨",
+        "connectedToAnother": "다른 채팅에 연결됨",
+        "notMember": "어떤 트레저리의 정책 멤버도 아닙니다.",
+        "connecting": "연결 중…",
+        "connect": "연결"
+    },
+    "systemStatus": {
+        "underMaintenance": "유지 보수 중",
+        "maintenanceMessage": "현재 유지 보수를 진행하고 있습니다. 일부 기능이 일시적으로 사용 불가능할 수 있습니다. 잠시 후 다시 확인해 주세요."
+    },
+    "creditsQuota": {
+        "available": "{count}개 사용 가능",
+        "used": "{count}개 사용됨",
+        "resetOn": "한도는 {date}에 재설정됩니다"
+    },
+    "approvalInfo": {
+        "infoText": "결제 관련 요청 승인에 필요한 투표입니다. 투표 설정에서 편집 가능합니다.",
+        "thresholdPill": "{total}명 중 {required}명 임계값",
+        "alertBody": "이 결제는 실행 전 <bold>{required}</bold>명의 트레저리 멤버 승인이 필요합니다."
+    },
+    "guestBadge": {
+        "title": "게스트",
+        "tooltip": "이 트레저리의 게스트입니다. 데이터 보기만 가능합니다."
+    },
+    "exportButton": {
+        "confidentialTooltip": "내보내기는 아직 비공개 모드에서 사용할 수 없습니다. 이 기능은 곧 출시됩니다!"
+    },
+    "sponsoredActions": {
+        "titleExhausted": "후원 작업 사용됨",
+        "titleAlmost": "팀의 후원 작업이 거의 소진되었습니다",
+        "closeNotice": "알림 닫기",
+        "teamUsage": "팀 사용량: 월 {total}개 작업",
+        "available": "{count}개 사용 가능",
+        "used": "{count}개 사용됨",
+        "exhaustedBody": "팀이 월간 후원 작업에 도달했습니다. {date} 이후에 계속하거나 문의하실 수 있습니다",
+        "almostBody": "TREZU는 현재 요청 생성 및 투표와 같은 모든 팀 작업의 저장 비용을 후원합니다. 팀이 월간 후원 한도에 거의 도달했습니다.",
+        "contactUs": "문의하기",
+        "nextMonthlyReset": "다음 월간 재설정",
+        "sidebarBody": "팀이 월간 후원 작업에 도달했습니다. {date} 이후에 계속하거나 ⬇️"
+    },
+    "acceptTerms": {
+        "title": "계속하려면 약관에 동의하세요",
+        "privacyTitle": "Trezu에서의 개인정보 보호",
+        "privacyBody": "Trezu는 비수탁형 인터페이스입니다. 플랫폼이 안전하고 기능적으로 유지되도록 하는 동시에 사용자의 개인정보를 우선시합니다.",
+        "minimalTitle": "최소한의 데이터",
+        "minimalBody": "인터페이스를 운영하고 개선하기 위해 공개 지갑 주소, IP 주소, 사용 분석과 같은 제한된 정보를 수집합니다.",
+        "noCustodyTitle": "비수탁",
+        "noCustodyBody": "당사는 사용자의 개인 키, 복구 문구 또는 디지털 자산에 절대 접근하지 않습니다.",
+        "publicTitle": "공개 기록",
+        "publicBody": "모든 블록체인 트랜잭션은 본질적으로 공개되며 당사가 통제하지 않는다는 점을 기억하세요.",
+        "responsibilityTitle": "사용자 책임",
+        "responsibilityBody": "사용자는 지갑 활동을 모니터링하고 자격 증명을 보호하는 것에 전적으로 책임이 있습니다.",
+        "futureTitle": "향후 업데이트",
+        "futureBody": "향후 알림(이메일 또는 Telegram 등)을 수신하기로 선택하시면, 해당 데이터는 정보를 알려드리는 용도로만 사용됩니다.",
+        "agreement": "<terms>이용약관</terms> 및 <privacy>개인정보 처리방침</privacy>을 읽고 동의합니다",
+        "accepting": "동의 중...",
+        "continue": "계속"
+    },
+    "confidentialBanner": {
+        "label": "비공개",
+        "description": "잔액, 활동 및 전송은 팀에게만 표시되며, 공개 블록체인에는 표시되지 않습니다."
+    },
+    "supportCenter": {
+        "title": "지원 센터",
+        "resources": "리소스",
+        "support": "지원",
+        "websiteTitle": "Trezu 웹사이트",
+        "websiteDescription": "Trezu에 대해 자세히 알아보고 블로그를 읽어보세요.",
+        "demo": "Trezu 데모",
+        "demoTitle": "공개 버전 살펴보기",
+        "demoDescription": "실시간 공개 계정의 작동을 확인하세요.",
+        "confidentialDemoTitle": "비공개 버전 살펴보기",
+        "confidentialDemoDescription": "실시간 비공개 계정의 작동을 살펴보세요.",
+        "videoTitle": "데모 시청",
+        "videoDescription": "Trezu 작동 방식을 보여주는 짧은 비디오를 시청하세요.",
+        "xTitle": "X에서 팔로우하기",
+        "xDescription": "최신 릴리스 및 인사이트를 받아보세요.",
+        "statsTitle": "통계",
+        "statsDescription": "모든 sputnik DAO의 총 운용 자산을 확인하세요.",
+        "docsTitle": "문서",
+        "docsDescription": "문서에서 모든 기능에 대해 알아보세요.",
+        "productSupportTitle": "제품 지원",
+        "productSupportDescription": "도움이 필요하시면 지원 팀에 문의하세요."
+    },
+    "progressModal": {
+        "titleCreating": "트레저리 생성 중...",
+        "titleDone": "트레저리 생성됨",
+        "titleFailed": "트레저리 생성 실패",
+        "viewTreasury": "트레저리 보기"
+    },
+    "memberValidation": {
+        "noManagePermission": "멤버를 관리할 권한이 없습니다",
+        "pendingRequest": "활성 요청이 있는 동안에는 멤버를 관리할 수 없습니다",
+        "rolesAnd": "{first} 및 {second}",
+        "rolesMany": "{list} 및 {last}",
+        "cannotRemoveMember": "이 멤버를 제거할 수 없습니다. {roles} {count, plural, other {역할}}이(가) 할당된 유일한 사람입니다.",
+        "cannotRemoveMemberGov": "이 멤버를 제거할 수 없습니다. 팀 멤버 관리 및 투표 구성에 필요한 {roles} {count, plural, other {역할}}이(가) 할당된 유일한 사람입니다.",
+        "cannotBulkRemove": "이 멤버들을 제거할 수 없습니다. 그러면 {roles} {count, plural, other {역할}}이(가) 비게 됩니다.",
+        "cannotBulkRemoveGov": "이 멤버들을 제거할 수 없습니다. 그러면 팀 멤버 관리 및 투표 구성에 필요한 {roles} {count, plural, other {역할}}이(가) 비게 됩니다.",
+        "cannotRemoveRole": "이 멤버에서 {role} 역할을 제거할 수 없습니다. 이 역할이 할당된 유일한 사람입니다.",
+        "cannotRemoveRoleGov": "이 멤버에서 {role} 역할을 제거할 수 없습니다. 유일한 {role} 멤버이며, 이 역할이 없으면 팀 멤버를 관리하거나 투표를 구성할 수 없습니다."
+    },
+    "roleSelector": {
+        "setRole": "역할 설정",
+        "allRoles": "모든 역할",
+        "roles": {
+            "governance": {
+                "title": "Governance",
+                "description": "Governance는 멤버, 권한, 트레저리 외관 등 팀 관련 트레저리 설정에 대해 생성하고 투표할 수 있습니다."
+            },
+            "requestor": {
+                "title": "Requestor",
+                "description": "Requestor는 투표 또는 승인 권한 없이 결제 관련 트랜잭션 요청을 생성할 수 있습니다."
+            },
+            "financial": {
+                "title": "Financial",
+                "description": "Financial은 결제 관련 트랜잭션 요청에 투표할 수 있지만 생성할 수는 없습니다."
+            }
+        }
+    },
+    "memberInput": {
+        "creatorYou": "생성자 (본인)",
+        "memberAddress": "멤버 주소",
+        "addNewMember": "새 멤버 추가",
+        "validation": {
+            "rolesRequired": "최소 하나의 역할이 필요합니다",
+            "duplicateAddress": "주소가 이미 멤버입니다"
+        }
+    },
+    "recipientInput": {
+        "title": "받는 사람",
+        "placeholder": "수신자 주소"
+    },
+    "accountInput": {
+        "failedValidation": "주소 검증에 실패했습니다",
+        "invalidNearFormat": "잘못된 NEAR 계정 형식입니다",
+        "invalidChainAddress": "유효한 {chain} 주소를 입력해 주세요.",
+        "validating": "주소 검증 중...",
+        "validAddress": "유효한 주소",
+        "placeholderWithExample": "수신자 주소 (예: {example})",
+        "placeholderNoExample": "수신자 주소",
+        "nearExample": "alice.near, 0x..., 또는 64자 16진수",
+        "near": {
+            "required": "주소는 필수입니다",
+            "length": "주소는 2자에서 64자 사이여야 합니다",
+            "missingTld": "이름 계정은 .near, .aurora 또는 .tg로 끝나야 합니다",
+            "invalidChars": "주소는 소문자, 숫자, 구분자(., -, _)만 포함할 수 있습니다",
+            "accountMissing": "NEAR 블록체인에 계정이 존재하지 않습니다",
+            "verifyFailed": "계정 존재 여부 확인에 실패했습니다"
+        }
+    },
+    "csvUpload": {
+        "uploadFile": "파일 업로드",
+        "provideData": "데이터 제공",
+        "chooseFile": "파일 선택",
+        "orDragDrop": "또는 드래그 앤 드롭",
+        "maxFileSize": "최대 1개 파일, {maxSize} MB까지, CSV 파일만 가능",
+        "noFilePrompt": "업로드할 파일이 없으신가요?",
+        "downloadTemplate": "템플릿 다운로드"
+    },
+    "tokenSelect": {
+        "selectToken": "토큰 선택",
+        "searchPlaceholder": "토큰 검색...",
+        "noTokensFound": "토큰을 찾을 수 없습니다"
+    },
+    "filterOperations": {
+        "is": "다음과 같음",
+        "isNot": "다음과 다름",
+        "before": "이전",
+        "after": "이후",
+        "between": "사이",
+        "equal": "같음",
+        "moreThan": "초과",
+        "lessThan": "미만",
+        "contains": "포함"
+    },
+    "copyButton": {
+        "copied": "클립보드에 복사됨",
+        "failed": "복사에 실패했습니다"
+    },
+    "recipientForm": {
+        "validation": {
+            "nameRequired": "이름은 필수입니다",
+            "nameMax": "수신자는 {max}자 미만이어야 합니다",
+            "addressRequired": "주소는 필수입니다",
+            "networksRequired": "최소 하나의 네트워크를 선택하세요"
+        }
+    },
+    "paymentForm": {
+        "validation": {
+            "recipientMin": "수신자는 최소 2자여야 합니다",
+            "recipientMax": "수신자는 128자 미만이어야 합니다",
+            "amountGreaterThanZero": "금액은 0보다 커야 합니다",
+            "recipientSameAsToken": "수신자와 토큰 주소는 같을 수 없습니다",
+            "selectToken": "토큰을 선택해 주세요",
+            "recipientMax64": "수신자는 64자 미만이어야 합니다",
+            "amountMinLockup": "금액은 3.5 이상이어야 합니다",
+            "startDateRequired": "시작 날짜는 필수입니다",
+            "endDateRequired": "종료 날짜는 필수입니다",
+            "cliffDateRequired": "클리프 날짜는 필수입니다",
+            "startBeforeEnd": "시작 날짜는 종료 날짜보다 이전이어야 합니다",
+            "cliffBetween": "클리프 날짜는 {start}과(와) {end} 사이여야 합니다"
+        }
+    },
+    "exportToasts": {
+        "downloadFailed": "내보내기 다운로드에 실패했습니다",
+        "invalidDateRange": "잘못된 날짜 범위",
+        "invalidDateRangeDescription": "내보낼 유효한 날짜 범위를 선택해 주세요.",
+        "exportSuccess": "내보내기 성공!",
+        "exportSuccessDescription": "{type} 파일이 다운로드되었습니다. 세부정보는 내보내기 기록을 확인하세요.",
+        "exportFailed": "내보내기 실패",
+        "exportFailedFallback": "데이터 내보내기에 실패했습니다. 다시 시도해 주세요.",
+        "noDownloadPermission": "파일을 다운로드할 권한이 없습니다.",
+        "noExportPermission": "내보내기 권한이 없습니다",
+        "quotaUsed": "할당량을 모두 사용했습니다",
+        "exporting": "내보내는 중...",
+        "export": "내보내기",
+        "columnSubmissionTime": "Submission Time",
+        "columnDateRange": "Date Range",
+        "columnGeneratedBy": "Generated By",
+        "columnStatus": "Status",
+        "typeAll": "모든 유형",
+        "typeSent": "송금",
+        "typeReceived": "수신",
+        "typeStakingRewards": "스테이킹 보상",
+        "allAssets": "모든 자산",
+        "upgradeTrial": "더 많이 사용하려면 플랜을 업그레이드하세요",
+        "upgradePaid": "더 많은 액세스를 위해 플랜을 업그레이드하거나 다음 달에 한도가 재설정될 때까지 기다리세요.",
+        "selectDateRange": "날짜 범위 선택",
+        "noExportsTitle": "아직 내보낸 항목이 없습니다",
+        "noExportsDescription": "지난 한 달 동안 내보낸 파일이 생성되면 여기에 표시됩니다.",
+        "quotaTitle": "내보내기 할당량",
+        "unlimited": "무제한",
+        "creditsPerMonth": "월 {total}회",
+        "requirementsTitle": "내보내기 요건",
+        "exportFromPeriod": "{period}의 데이터를 내보낼 수 있습니다.",
+        "availableFor48Hours": "내보낸 파일은 48시간 동안 다운로드할 수 있습니다.",
+        "moreFlexibility": "더 많은 유연성을 찾고 계신가요?",
+        "contactUs": "문의하기",
+        "last1Year": "최근 1년",
+        "last2Years": "최근 2년",
+        "invalidEmail": "유효한 이메일 주소를 입력해 주세요"
+    },
+    "proposalKinds": {
+        "Batch Payment Request": "일괄 결제 요청",
+        "Payment Request": "결제 요청",
+        "Confidential Request": "비공개 요청",
+        "Exchange": "교환",
+        "Function Call": "함수 호출",
+        "Change Policy": "정책 변경",
+        "Update General Settings": "일반 설정 업데이트",
+        "Earn NEAR": "NEAR 수익",
+        "Unstake NEAR": "NEAR 언스테이크",
+        "Vesting": "베스팅",
+        "Withdraw Earnings": "수익 출금",
+        "Members": "멤버",
+        "Upgrade": "업그레이드",
+        "Set Staking Contract": "스테이킹 컨트랙트 설정",
+        "Bounty": "현상금",
+        "Vote": "투표",
+        "Factory Info Update": "팩토리 정보 업데이트",
+        "Unsupported": "지원되지 않음"
+    },
+    "paymentFormSection": {
+        "selectRecipient": "수신자 선택",
+        "searchByNameOrAddress": "이름 또는 주소로 검색",
+        "restrictedRecipientTitle": "트랜잭션이 허용되지 않음",
+        "restrictedRecipientMessage": "이 주소는 보안 점검으로 인해 현재 제한되어 있습니다. 이 주소가 허용되어야 한다고 생각되시면 <link>화이트리스트 등록을 요청</link>할 수 있습니다.",
+        "send": "보내기",
+        "to": "받는 사람"
+    },
+    "recipientNetworkSelect": {
+        "label": "수신자 네트워크",
+        "placeholder": "수신자 네트워크 선택",
+        "enterAddressFirst": "먼저 수신자 주소를 입력하세요",
+        "noCompatibleNetwork": "이 주소와 일치하는 네트워크가 없습니다",
+        "selectPlaceholder": "네트워크 선택",
+        "title": "네트워크 선택",
+        "available": "사용 가능",
+        "fromAddressBook": "주소록에서",
+        "otherAvailable": "기타 사용 가능",
+        "incompatible": "호환되지 않음",
+        "comingSoon": "곧 제공",
+        "nearComName": "near.com",
+        "nearComDescription": "near.com 및 trezu용 내부 네트워크"
+    },
+    "addressBookTable": {
+        "emptyTitle": "아직 수신자가 없습니다",
+        "emptyDescription": "더 빠른 지급을 위해 이 주소록에 수신자를 추가하세요.",
+        "selectAll": "모든 수신자 선택",
+        "selectEntry": "{name} 선택",
+        "recipient": "수신자",
+        "network": "네트워크",
+        "addedBy": "추가자",
+        "note": "메모",
+        "added": "추가됨",
+        "remove": "제거",
+        "send": "보내기"
+    },
+    "publicDashboard": {
+        "updatesDaily": "매일 업데이트",
+        "noDataTitle": "아직 데이터가 없습니다",
+        "noDataDescription": "첫 일일 스냅샷이 계산된 후 통계가 표시됩니다.",
+        "assetsSecured": "Sputnik DAO 컨트랙트로 보호되는 자산",
+        "acrossDaos": "<bold>{count, plural, other {#개 DAO}}</bold> 전체",
+        "updatedOn": "업데이트: {date}",
+        "topAssets": "상위 20개 자산",
+        "noAssetsTitle": "아직 자산이 없습니다",
+        "noAssetsDescription": "일일 스냅샷이 계산된 후 토큰 데이터가 표시됩니다.",
+        "tableToken": "토큰",
+        "tableTotalValue": "총 가치"
+    },
+    "telegramConnectInstructions": {
+        "title": "Telegram 연결",
+        "subtitle": "Telegram에서 제안 및 활동에 대한 알림을 받으세요.",
+        "step3": "시작을 누르고 지침을 따르세요.",
+        "success": "모두 준비되었습니다!",
+        "copyBotTooltip": "봇 핸들 복사",
+        "botCopiedToast": "봇 핸들이 복사되었습니다",
+        "openInTelegram": "Telegram에서 {bot} 열기"
+    },
+    "transactionHashCell": {
+        "copyHash": "해시 복사",
+        "hashCopied": "해시가 복사되었습니다",
+        "openInExplorer": "익스플로러에서 열기"
+    },
+    "treasurySelector": {
+        "select": "트레저리 선택",
+        "connectWalletTooltip": "트레저리를 보려면 지갑을 연결하세요",
+        "manageTreasuries": "트레저리 관리",
+        "createTreasury": "트레저리 생성",
+        "memberOf": "소속 멤버",
+        "guestTreasuries": "게스트 트레저리"
+    },
+    "selectModal": {
+        "searchByName": "이름으로 검색",
+        "noResults": "결과를 찾을 수 없습니다"
+    },
+    "selectList": {
+        "noResults": "결과를 찾을 수 없습니다"
+    },
+    "datePicker": {
+        "pickDate": "날짜 선택",
+        "timezone": "시간대"
+    },
+    "datePresets": {
+        "today": "오늘",
+        "yesterday": "어제",
+        "last3Days": "최근 3일",
+        "last7Days": "최근 7일",
+        "last14Days": "최근 14일",
+        "lastMonth": "지난달",
+        "last3Months": "최근 3개월",
+        "last6Months": "최근 6개월"
+    },
+    "input": {
+        "openSearch": "검색 열기"
+    },
+    "pagination": {
+        "previous": "이전",
+        "next": "다음"
+    },
+    "confidentialState": {
+        "title": "비공개",
+        "description": "트레저리 멤버만 액세스할 수 있습니다."
+    },
+    "exchangeRate": {
+        "rate": "환율",
+        "clickToReverse": "환율을 반대로 보려면 클릭"
+    },
+    "exchangeSettings": {
+        "title": "교환 설정",
+        "slippageTolerance": "슬리피지 허용치",
+        "custom": "사용자 지정",
+        "customPlaceholder": "예: 2%",
+        "slippageRange": "슬리피지는 0.01%에서 100% 사이여야 합니다",
+        "enterSlippage": "슬리피지 허용치를 입력해 주세요",
+        "slippageHelp": "가격이 이 비율 이상으로 변동하면 자금을 보호하기 위해 트랜잭션이 취소됩니다.",
+        "save": "저장"
+    },
+    "assetsPage": {
+        "title": "자산",
+        "noAssetsTitle": "아직 자산이 없습니다",
+        "noAssetsDescription": "시작하려면 입금하여 트레저리에 자산을 추가하세요."
+    },
+    "newBadge": {
+        "label": "신규"
+    },
+    "numberBadge": {
+        "pendingRequests": "{count, plural, other {대기 중인 요청 #건}}"
+    },
+    "balanceWithGraph": {
+        "allTokens": "모든 토큰",
+        "deposit": "입금",
+        "send": "보내기",
+        "exchange": "교환",
+        "chartNow": "현재",
+        "totalBalance": "총 잔액",
+        "excludedTokens": "제외된 토큰:",
+        "noPriceHistory": "가격 기록이 없습니다. 잔액 변화를 보려면 토큰을 선택하세요.",
+        "bucketAvailable": "사용 가능",
+        "bucketLocked": "잠김",
+        "bucketEarning": "수익 중",
+        "period": {
+            "1W": "1주",
+            "1M": "1개월",
+            "3M": "3개월",
+            "1Y": "1년"
+        }
+    },
+    "changePolicyExpanded": {
+        "proposalBond": "제안 본드",
+        "proposalPeriod": "제안 기간",
+        "bountyBond": "현상금 본드",
+        "bountyForgivenessPeriod": "현상금 면제 기간",
+        "votesCount": "{count}표",
+        "weightKind": "가중치 종류",
+        "quorum": "정족수",
+        "threshold": "임계값",
+        "defaultThreshold": "기본 임계값",
+        "roleThreshold": "{role} 임계값",
+        "member": "멤버",
+        "members": "멤버",
+        "permissions": "권한",
+        "oldPermissions": "이전 권한",
+        "newPermissions": "새 권한",
+        "category": "카테고리",
+        "transactionDetails": "트랜잭션 세부정보",
+        "addNewMember": "새 멤버 추가",
+        "addNewMembers": "새 멤버 추가",
+        "removeMember": "멤버 제거",
+        "removeMembers": "멤버 제거",
+        "updateMemberPermissions": "멤버 권한 업데이트",
+        "updateMembersPermissions": "멤버 권한 업데이트",
+        "memberIndex": "멤버 {index}",
+        "membersCount": "{count}명의 멤버",
+        "collapseAll": "모두 접기",
+        "expandAll": "모두 펼치기",
+        "loadingHistorical": "기록 정책 로딩 중...",
+        "unableToDiff": "이 제안에 대한 차이를 계산할 수 없습니다.",
+        "noChangesCurrent": "변경 사항이 감지되지 않았습니다 - 제안된 정책이 현재 정책과 동일합니다.",
+        "noChangesHistorical": "변경 사항이 감지되지 않았습니다 - 제안된 정책이 기록 정책과 동일합니다."
+    },
+    "balanceChart": {
+        "usdValue": "USD 가치",
+        "tokenBalance": "토큰 잔액",
+        "emptyTitle": "아직 표시할 내용이 없습니다",
+        "emptyDescription": "포트폴리오 추적을 시작하려면 자산을 추가하세요."
+    },
+    "user": {
+        "saveToAddressBook": "주소록에 저장",
+        "walletCopiedToast": "지갑 주소가 클립보드에 복사되었습니다",
+        "copyWalletAddress": "지갑 주소 복사"
+    },
+    "infoDisplay": {
+        "viewLess": "간략히 보기",
+        "viewAllDetails": "모든 세부정보 보기"
+    },
+    "amountSummary": {
+        "defaultTitle": "총 송금 금액"
+    },
+    "residency": {
+        "vestedToken": "베스팅된 토큰",
+        "staked": "스테이킹됨",
+        "fungibleToken": "대체 가능 토큰",
+        "intentsToken": "Intents 토큰",
+        "nativeToken": "네이티브 토큰"
+    },
+    "exchangeErrors": {
+        "noRoute": "교환을 찾을 수 없습니다. 더 적은 금액이나 다른 토큰을 시도하세요.",
+        "amountTooLow": "스왑하기에 금액이 너무 적습니다. 크로스체인 스왑은 네트워크 수수료를 충당하기 위해 더 높은 최소 금액이 필요합니다.",
+        "insufficientBalance": "이 스왑을 위한 잔액이 부족합니다.",
+        "networkError": "네트워크 오류입니다. 연결을 확인하고 다시 시도해 주세요.",
+        "fetchFailed": "견적을 가져오지 못했습니다"
+    },
+    "tokenSelectDialog": {
+        "selectToken": "토큰 선택",
+        "selectAsset": "자산 선택",
+        "selectNetworkFor": "{asset}용 네트워크 선택",
+        "searchByName": "이름으로 검색",
+        "noTokensWithBalance": "잔액이 있는 토큰을 찾을 수 없습니다",
+        "noTokensFound": "토큰을 찾을 수 없습니다",
+        "yourAssets": "내 자산",
+        "otherAssets": "기타 자산",
+        "networksWithAssets": "자산이 있는 네트워크",
+        "supportedNetworks": "지원 네트워크",
+        "comingSoon": "출시 예정"
+    },
+    "intentsQuote": {
+        "initializing": "견적 서비스가 아직 초기화 중입니다. 다시 시도해 주세요.",
+        "noRoute": "지금은 결제 경로를 준비할 수 없습니다. 다시 시도해 주세요.",
+        "fetchFailed": "지금은 결제 경로를 준비할 수 없습니다. 다시 시도해 주세요.",
+        "amountTooLow": "네트워크 수수료를 충당하기에 금액이 너무 적습니다. 더 높은 금액을 입력하고 다시 시도해 주세요.",
+        "amountTooLowWithMin": "네트워크 수수료를 충당하기에 금액이 너무 적습니다. 최소 {min} {token}을(를) 입력하세요.",
+        "networkFeeTooltip": "이 수수료는 선택한 체인에서 트랜잭션을 처리하는 데 사용됩니다."
+    },
+    "pageTours": {
+        "paymentsBulk": "일괄 생성이 도착했습니다! 몇 단계만으로 여러 요청을 생성하세요.",
+        "paymentsPending": "여기서 승인 대기 중인 요청을 확인하세요.",
+        "exchangeSettings": "여기서 허용할 가격 변동의 정도를 설정할 수 있습니다.",
+        "membersPending": "승인 대기 중인 활성 요청을 보려면 클릭하세요.",
+        "guestSaveIntro": "이 트레저리의 게스트입니다. 데이터 보기만 가능합니다.",
+        "guestSaveAction": "이 게스트 트레저리를 트레저리 목록에 저장할 수 있습니다.",
+        "newFeatureRich": "신규! 🎉 자주 사용하는 주소를 저장하여 더 빠르고 오류 없는 지급을 하세요.<br></br> 연락처는 비공개로 유지되며 팀에게만 표시됩니다.",
+        "newFeatureCta": "사용해 보기"
+    },
+    "statusDate": {
+        "expires": "만료 시간",
+        "created": "생성됨",
+        "expired": "만료됨",
+        "removed": "제거됨"
+    },
+    "relativeTime": {
+        "justNow": "방금 전",
+        "moments": "잠시"
+    },
+    "amount": {
+        "network": "네트워크: {network}"
+    },
+    "activityLabels": {
+        "exchangePending": "교환 대기 중",
+        "exchangeRequest": "교환 요청",
+        "exchangeFulfillment": "교환 이행",
+        "stakingRewards": "스테이킹 보상",
+        "proposalAction": "제안 작업",
+        "deposit": "{symbol} 입금",
+        "paymentSent": "결제 송금됨",
+        "transaction": "트랜잭션",
+        "fallbackToken": "토큰",
+        "viaIntents": "NEAR Intents 경유",
+        "from": "{account}에서",
+        "to": "{account}에게",
+        "viewAll": "모든 트랜잭션 기록 보기",
+        "sentReceived": "송금 및 수신 트랜잭션 ({duration})",
+        "unlimitedHistory": "무제한 기록",
+        "oneYear": "1년",
+        "yearsCount": "{count}년",
+        "monthsCount": "{count}개월",
+        "lastDuration": "최근 {duration}"
+    },
+    "nearStore": {
+        "connectAndAcceptTerms": "계속하려면 지갑을 연결하고 약관에 동의해 주세요.",
+        "transactionNotApproved": "트랜잭션이 지갑에서 승인되지 않았습니다.",
+        "failedSubmitVote": "투표 제출에 실패했습니다",
+        "failedSubmitVotes": "투표 제출에 실패했습니다",
+        "viewRequest": "요청 보기",
+        "proposalRemoved": "제안이 제거되었습니다",
+        "voteSubmitted": "투표가 제출되었습니다",
+        "votesSubmitted": "투표가 제출되었습니다"
+    },
+    "tokenInput": {
+        "max": "MAX",
+        "insufficientTokens": "토큰이 부족합니다. 요청을 제출하고 승인 전에 충전할 수 있습니다.",
+        "balance": "잔액: {amount} {symbol}"
+    },
+    "createRequestButton": {
+        "idle": "요청 생성",
+        "noPermission": "요청을 생성할 권한이 없습니다"
+    },
+    "address": {
+        "copied": "주소가 클립보드에 복사되었습니다"
+    },
+    "memberAvatars": {
+        "membersWhoCanVote": "투표할 수 있는 멤버",
+        "moreMembers": "+{count, plural, other {멤버 #명}}"
+    },
+    "accountIdInput": {
+        "minLength": "계정 ID는 최소 2자여야 합니다",
+        "maxLength": "계정 ID는 64자 미만이어야 합니다",
+        "charset": "계정 ID는 소문자, 숫자, 점, 하이픈, 밑줄만 포함할 수 있으며 시작이나 끝에 구분자가 없어야 합니다",
+        "doesNotExist": "계정 ID가 존재하지 않습니다"
+    },
+    "addressBookMutations": {
+        "addedToast": "{count, plural, other {수신자 #명 추가됨}}",
+        "addedSingleToast": "수신자가 추가되었습니다",
+        "addFailedToast": "수신자 추가에 실패했습니다",
+        "addSingleFailedToast": "수신자 추가에 실패했습니다",
+        "removedToast": "{count, plural, other {수신자 #명 제거됨}}",
+        "removeFailedToast": "수신자 제거에 실패했습니다",
+        "exportFailedToast": "수신자 내보내기에 실패했습니다"
+    },
+    "treasuryMutations": {
+        "savedToast": "트레저리가 목록에 저장되었습니다",
+        "saveFailedToast": "트레저리 저장에 실패했습니다",
+        "hiddenToast": "트레저리가 목록에서 숨겨졌습니다",
+        "hideFailedToast": "트레저리 숨기기에 실패했습니다",
+        "unhiddenToast": "트레저리가 다시 표시됩니다",
+        "unhideFailedToast": "트레저리 표시에 실패했습니다",
+        "removedToast": "트레저리가 저장된 목록에서 제거되었습니다",
+        "removeFailedToast": "저장된 목록에서 트레저리 제거에 실패했습니다"
+    },
+    "telegramSettings": {
+        "title": "Telegram",
+        "connectedTo": "{chat}에 연결됨",
+        "chatNumber": "채팅 #{id}",
+        "fallbackChat": "Telegram 채팅",
+        "disconnect": "연결 해제",
+        "connect": "연결",
+        "connectDescription": "알림을 받으려면 트레저리를 Telegram 채팅에 연결하세요.",
+        "noTreasuryDescription": "트레저리를 Telegram 채팅에 연결하세요.",
+        "openSettingsHint": "통합을 관리하려면 트레저리에서 설정을 여세요.",
+        "disconnectedToast": "이 트레저리에 대한 Telegram 연결이 해제되었습니다",
+        "disconnectFailedToast": "Telegram 연결을 해제하지 못했습니다. 다시 시도해 주세요."
+    },
+    "assetsTable": {
+        "noAssetsFound": "자산을 찾을 수 없습니다.",
+        "assetDetails": "자산 세부정보",
+        "coinPrice": "코인 가격",
+        "weight": "비중",
+        "balance": "잔액",
+        "lockedBalance": "잠긴 잔액",
+        "totalBalance": "총 잔액",
+        "source": "출처",
+        "balanceByInvestors": "{count, plural, other {투자자}}별 잔액",
+        "investors": "{count, plural, other {투자자}}",
+        "poolBreakdown": "풀 세부 내역",
+        "unlockedToken": "잠금 해제된 토큰",
+        "lockupStakingPool": "락업 스테이킹 풀",
+        "exchange": "교환",
+        "send": "보내기",
+        "details": "세부정보",
+        "columnToken": "토큰",
+        "columnLocked": "잠김",
+        "columnUnlocked": "잠금 해제됨",
+        "columnTotalAllocated": "총 할당량",
+        "columnAvailableToWithdraw": "출금 가능",
+        "viewAvailable": "사용 가능",
+        "viewLocked": "잠김",
+        "viewEarning": "수익 중",
+        "fullAllocatedBalance": "전체 할당된 잔액",
+        "partAllocatedBalance": "할당된 잔액의 일부",
+        "currentlyEarning": "({amount} {symbol})이(가) 현재 수익 중입니다.",
+        "willAppearHere": " 수익을 중지하면 여기에 표시됩니다.",
+        "seeInEarningTab": "Earning 탭에서 보기",
+        "seeInEarning": "Earning에서 보기"
+    },
+    "earningDetails": {
+        "title": "수익 세부정보",
+        "totalStaked": "총 스테이킹",
+        "earningOverview": "수익 개요",
+        "poolBreakdown": "풀 세부 내역 ({count, plural, other {풀 #개}})",
+        "almostReady": "Earn이 거의 준비되었습니다!",
+        "finalizingFeature": "이 기능을 마무리하고 있습니다<br></br>곧 토큰 수익을 시작할 수 있습니다.",
+        "comingSoon": "출시 예정",
+        "goToEarn": "Earn으로 이동",
+        "readyToWithdraw": "출금 준비됨",
+        "unstaking": "언스테이킹",
+        "overview": {
+            "staked": "스테이킹됨",
+            "stakedInfo": "현재 검증자에게 위임되어 보상을 얻고 있는 토큰입니다.",
+            "pendingRelease": "릴리스 대기 중",
+            "pendingReleaseInfo": "언스테이킹되었지만 아직 본딩 해제 기간(보통 2-3일)에 있는 토큰입니다.",
+            "availableForWithdraw": "출금 가능",
+            "availableForWithdrawInfo": "본딩 해제 기간을 완료하여 출금할 수 있는 언스테이킹된 토큰입니다."
+        }
+    },
+    "lockupDetails": {
+        "title": "락업 세부정보",
+        "balance": "잔액",
+        "reservedForStorage": "저장소용 예약됨",
+        "reservedForStorageInfo": "저장 비용을 지불하기 위해 락업 계정이 예약한 NEAR입니다.",
+        "tokenBreakdown": "토큰 세부 내역",
+        "allocatedAmount": "할당된 금액",
+        "earned": "수익",
+        "progress": "진행률",
+        "unlocked": "잠금 해제됨",
+        "locked": "잠김",
+        "schedule": "일정",
+        "startDate": "시작 날짜",
+        "endDate": "종료 날짜",
+        "rounds": "라운드",
+        "releaseInterval": "릴리스 간격",
+        "nextUnlockDate": "다음 잠금 해제 날짜",
+        "allEarning": "락업의 모든 {amount} {symbol}이(가) 현재 수익 중입니다.",
+        "partEarning": "락업의 일부({amount} {symbol})가 현재 수익 중입니다.",
+        "stopEarningFirst": "잠금 해제된 토큰을 사용하려면 먼저 수익을 중지하고 출금하세요.",
+        "howGrantWorks": "그랜트 작동 방식",
+        "ftStep1": "특정 기간 동안 그랜트를 받습니다. 한 번에 전액을 받는 대신, 자산이 시간이 지남에 따라 부분적으로 사용 가능해집니다.",
+        "ftStep2": "다음 릴리스 날짜가 도래하면 해당 토큰 부분이 자동으로 잠금 해제되어 트레저리 잔액으로 이동합니다.",
+        "ftStep3": "잔액에 표시되면 즉시 결제, 전송 또는 기타 트랜잭션에 사용할 수 있습니다.",
+        "nearStep1": "정해진 시작 및 종료 날짜가 있는 일정 기간 동안 그랜트를 받습니다.",
+        "nearStep2": "토큰이 잠금 해제되면 자동으로 트레저리 잔액에서 사용 가능해집니다.",
+        "nearStep3": "잠금 해제된 토큰을 즉시 결제, 전송 또는 기타 트랜잭션에 사용할 수 있습니다.",
+        "notAvailable": "해당 없음",
+        "everyMonth": "매월",
+        "everyQuarter": "매 분기",
+        "everyUnit": "매 {unit}",
+        "everyMultiple": "매 {text}",
+        "completed": "완료됨",
+        "unit": {
+            "year": "{count, plural, other {#년}}",
+            "day": "{count, plural, other {#일}}",
+            "hour": "{count, plural, other {#시간}}",
+            "minute": "{count, plural, other {#분}}",
+            "second": "{count, plural, other {#초}}"
+        }
+    },
+    "vestingDetails": {
+        "title": "베스팅 세부정보",
+        "availableToUse": "사용 가능",
+        "vestingPeriod": "베스팅 기간",
+        "vestingPeriodDescription": "이 기간 동안 토큰이 매일 잠금 해제됩니다.",
+        "startDate": "시작 날짜",
+        "endDate": "종료 날짜",
+        "tokenBreakdown": "토큰 세부 내역",
+        "originalVestedAmount": "원래 베스팅 금액",
+        "reservedForStorage": "저장소용 예약됨",
+        "reservedForStorageInfo": "베스팅을 활성 상태로 유지하고 저장 비용을 충당하기 위해 필요한 소량의 토큰입니다.",
+        "percentVested": "{percent}% 베스팅됨",
+        "vestedOf": "{total} {symbol} 중 {vested}",
+        "send": "보내기"
+    },
+    "earningPoolDetails": {
+        "balance": "잔액",
+        "apy": "APY",
+        "fee": "수수료",
+        "notAvailable": "해당 없음",
+        "lockupStakingPool": "락업 스테이킹 풀",
+        "lockupAssetsNote": "이 포지션의 모든 자산은 락업에서 가져온 것입니다. 수익을 중지한 후에도 일부 토큰은 잠겨 있어 사용 불가능할 수 있습니다 - 잠금 해제 시점을 보려면 락업 일정을 확인하세요."
+    },
+    "onboardingQuestions": {
+        "stepTitle": "시작하기 위한 몇 가지 간단한 질문입니다.",
+        "other": "기타",
+        "placeholders": {
+            "describeRole": "역할을 설명하세요 (선택사항)",
+            "describeUseCase": "사용 사례를 설명하세요 (선택사항)",
+            "networkName": "네트워크 이름을 입력하세요 (선택사항)",
+            "currentChallenge": "현재 어려움을 입력하세요 (선택사항)",
+            "describeOther": "기타를 설명하세요 (선택사항)"
+        },
+        "questions": {
+            "role": "사용자의 역할을 가장 잘 설명하는 것은 무엇입니까?",
+            "useCases": "Trezu를 어떤 용도로 사용할 계획이십니까?",
+            "teamSize": "트레저리를 관리하는 인원은 몇 명입니까?",
+            "networks": "가장 자주 사용하는 네트워크는 무엇입니까?",
+            "multisigExperience": "멀티시그에 대한 경험은 어떻습니까?",
+            "currentTools": "현재 재무 관리에 어떤 도구를 사용하십니까?",
+            "monthlyVolume": "월간 트랜잭션 대략적인 거래량은?",
+            "biggestChallenges": "현재 가장 큰 과제는 무엇입니까?"
+        },
+        "options": {
+            "role": {
+                "founder": "창립자",
+                "co-founder": "공동 창립자",
+                "cfo-finance-lead": "CFO / 재무 책임자",
+                "operations-manager": "운영 매니저",
+                "treasury-manager": "트레저리 매니저",
+                "other": "기타"
+            },
+            "useCases": {
+                "team-payroll-grants": "팀 급여 및 그랜트",
+                "company-assets-management": "회사 자산 관리",
+                "dao-treasury-management": "DAO 트레저리 관리",
+                "investment-portfolio": "투자 포트폴리오",
+                "operational-spending": "운영 지출",
+                "other": "기타"
+            },
+            "teamSize": {
+                "just-me": "나 혼자",
+                "2-5-people": "2-5명",
+                "6-15-people": "6-15명",
+                "15-plus-people": "15명 이상"
+            },
+            "networks": {
+                "near": "NEAR",
+                "bitcoin": "Bitcoin",
+                "ethereum": "Ethereum",
+                "solana": "Solana",
+                "arbitrum": "Arbitrum",
+                "base": "Base",
+                "optimism": "Optimism",
+                "polygon": "Polygon",
+                "gnosis": "Gnosis",
+                "avalanche": "Avalanche",
+                "bnb-chain": "BNB Chain",
+                "other": "기타"
+            },
+            "multisigExperience": {
+                "never-heard-of-it": "들어본 적 없음",
+                "heard-about-it": "들어본 적 있음",
+                "never-used-it": "사용한 적 없음",
+                "used-gnosis-safe-or-similar": "Gnosis Safe 또는 유사 서비스 사용",
+                "experienced": "경험 있음",
+                "looking-for-a-better-option": "더 나은 옵션 찾는 중"
+            },
+            "currentTools": {
+                "gnosis-safe": "Gnosis Safe",
+                "fireblocks": "Fireblocks",
+                "tholos": "Tholos",
+                "squads-multisig": "Squads Multisig",
+                "mpc-vault": "MPC Vault",
+                "other": "기타"
+            },
+            "monthlyVolume": {
+                "under-10k": "$10K 미만",
+                "10k-100k": "$10K - $100K",
+                "100k-1m": "$100K - $1M",
+                "1m-plus": "$1M+"
+            },
+            "biggestChallenges": {
+                "slow-approvals-and-signing": "느린 승인 및 서명",
+                "lack-of-transparency-in-the-team": "팀 내 투명성 부족",
+                "hard-to-track-spending-and-balances": "지출과 잔액 추적의 어려움",
+                "security-and-access-control": "보안 및 액세스 제어",
+                "no-good-web3-tool-yet": "아직 좋은 Web3 도구가 없음",
+                "looking-for-crypto-earnings": "암호화폐 수익을 찾고 있음",
+                "other": "기타"
+            }
+        }
+    },
+    "onboarding": {
+        "tour": {
+            "addAssets": "입금하여 트레저리에 자산을 추가하세요.",
+            "makeRequests": "자산을 보내야 할 때마다 결제 요청을 만드세요.",
+            "exchangeAssets": "여기서 자산을 교환할 수 있습니다.",
+            "addMembers": "트레저리에 멤버를 추가하고 역할을 할당하세요.",
+            "newTreasury": "새 트레저리를 설정하시겠습니까? 여기서 몇 번의 클릭으로 할 수 있습니다.",
+            "helpSupport": "필요할 때 언제든지 도움과 지원을 받으세요."
+        },
+        "tourCard": {
+            "close": "닫기",
+            "stepProgress": "{total} 중 {current}",
+            "gotIt": "확인",
+            "done": "완료",
+            "next": "다음"
+        },
+        "progress": {
+            "title": "빠른 단계를 따라 트레저리 살펴보기",
+            "createTreasuryTitle": "트레저리 계정 생성",
+            "createTreasuryDescription": "계정 설정을 성공적으로 완료했습니다. 좋은 시작입니다!",
+            "addAssetsTitle": "자산 추가",
+            "addAssetsDescription": "자산을 추가하여 작동하는 모습을 확인하세요.",
+            "deposit": "입금",
+            "createPaymentTitle": "결제 요청 생성",
+            "createPaymentDescription": "설정을 완료하기 위해 결제 요청을 생성하세요.",
+            "send": "보내기"
+        },
+        "welcome": {
+            "heading": "🎉 환영합니다!",
+            "subheading": "트레저리를 빠르게 둘러보세요",
+            "body": "안녕하세요! Trezu가 준비되었습니다 - 지원되는 네트워크에서 자산을 추가하여 포트폴리오를 구축해 보세요.",
+            "progress": "{total} 중 {current}",
+            "next": "다음",
+            "body2": "입금 방법, 요청 생성, 새 계정 설정 방법을 확인하세요.",
+            "noThanks": "괜찮습니다",
+            "letsGo": "시작하기"
+        },
+        "congrats": {
+            "heading": "🎉 축하합니다!",
+            "body": "트레저리 설정을 완료했습니다. 자산의 손쉬운 관리를 즐기세요.",
+            "letsGo": "시작하기!"
+        },
+        "createBanner": {
+            "close": "닫기",
+            "title": "Trezu 살펴보기",
+            "description": "Trezu의 모든 기능과 혜택에 대한 권한을 잠금 해제하려면 계정을 생성하세요.",
+            "cta": "트레저리 생성"
+        },
+        "questionnaire": {
+            "continue": "계속",
+            "skip": "건너뛰기"
+        },
+        "createPrompt": {
+            "title": "거의 다 되었습니다",
+            "description": "지갑이 연결되었지만 아직 트레저리를 생성하지 않았습니다. Trezu 사용을 시작하려면 계정을 생성하거나 {suffix}",
+            "suffixDemo": "데모를 확인하세요.",
+            "suffixExploring": "계속 살펴보세요.",
+            "createCta": "트레저리 생성",
+            "viewDemo": "데모 보기",
+            "keepExploring": "계속 살펴보기"
+        },
+        "infoBox": {
+            "title": "Trezu에서 더 많은 것을 얻으세요",
+            "close": "닫기",
+            "description": "다른 사람들이 트레저리를 어떻게 사용하는지 확인하고, 데모를 사용해 보고, 문서를 통해 기능을 알아보세요.",
+            "demoTitle": "Trezu 데모 살펴보기",
+            "demoDescription": "실시간 데모 계정의 작동을 확인하세요.",
+            "docsTitle": "문서",
+            "docsDescription": "문서에서 모든 기능에 대해 알아보세요.",
+            "videoTitle": "데모 시청",
+            "videoDescription": "Trezu 작동 방식을 보여주는 짧은 비디오를 시청하세요."
+        }
+    }
+}

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -1,0 +1,2101 @@
+{
+    "common": {
+        "loading": "Carregando...",
+        "notAvailable": "N/D",
+        "connecting": "Conectando...",
+        "save": "Salvar",
+        "cancel": "Cancelar",
+        "submit": "Enviar",
+        "close": "Fechar",
+        "back": "Voltar",
+        "seeDemo": "Ver demonstração do Trezu",
+        "search": "Buscar",
+        "filter": "Filtrar",
+        "filterActive": "Filtro (ativo)",
+        "export": "Exportar",
+        "exporting": "Exportando",
+        "import": "Importar",
+        "remove": "Remover",
+        "removing": "Removendo...",
+        "edit": "Editar",
+        "continue": "Continuar",
+        "select": "Selecionar",
+        "all": "Todos",
+        "none": "Nenhum",
+        "retry": "Tentar novamente",
+        "tryAgain": "Por favor, tente novamente.",
+        "confirm": "Confirmar",
+        "next": "Próximo",
+        "previous": "Anterior",
+        "yes": "Sim",
+        "no": "Não",
+        "approve": "Aprovar",
+        "reject": "Rejeitar",
+        "copy": "Copiar",
+        "copied": "Copiado",
+        "viewAll": "Ver tudo",
+        "viewDetails": "Ver detalhes",
+        "noResults": "Nenhum resultado encontrado",
+        "add": "Adicionar"
+    },
+    "languageSwitcher": {
+        "label": "Idioma",
+        "select": "Selecionar idioma",
+        "english": "English",
+        "spanish": "Español",
+        "ukrainian": "Українська",
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
+    },
+    "header": {
+        "toggleSidebar": "Alternar barra lateral",
+        "toggleTheme": "Alternar tema"
+    },
+    "nav": {
+        "dashboard": "Painel",
+        "requests": "Solicitações",
+        "payments": "Pagamentos",
+        "exchange": "Troca",
+        "addressBook": "Catálogo de endereços",
+        "members": "Membros",
+        "settings": "Configurações",
+        "helpSupport": "Ajuda e suporte",
+        "saveGuestTreasury": "Salve esta tesouraria de convidado na sua lista de tesourarias."
+    },
+    "signIn": {
+        "connect": "Conectar",
+        "connectWallet": "Conectar carteira",
+        "wallet": "Carteira",
+        "termsOfService": "Termos de Serviço",
+        "privacyPolicy": "Política de Privacidade",
+        "disconnect": "Desconectar"
+    },
+    "auth": {
+        "noWallet": "Conecte sua carteira",
+        "noPermission": "Você não tem permissão para realizar esta ação",
+        "noVote": "Você já votou nesta proposta",
+        "noSponsoredTransactions": "Não há transações patrocinadas restantes"
+    },
+    "landing": {
+        "welcome": "Bem-vindo ao Trezu",
+        "chooseOption": "Escolha uma opção abaixo para começar.",
+        "newUserTitle": "Sou novo no Trezu",
+        "newUserDescription": "Já ouvi falar do Trezu, mas ainda não tenho uma tesouraria.",
+        "existingUserTitle": "Já uso o Trezu",
+        "existingUserDescription": "Tenho uma conta e gerencio uma tesouraria.",
+        "gradientTagline": "Segurança multisig multichain para gerenciar ativos digitais",
+        "waitlistTitle": "Entre na lista de espera do Trezu",
+        "waitlistSubmittedTitle": "Você está na lista 🎉",
+        "waitlistSubmittedDescription": "Obrigado! Avisaremos você assim que a criação de tesouraria ficar disponível.",
+        "waitlistDescription": "Atingimos o limite de tesourarias de hoje. Sem problemas — tente novamente mais tarde ou deixe seu contato para entrar na lista de espera. Avisaremos quando uma vaga abrir.",
+        "waitlistInputPlaceholder": "E-mail ou Telegram (ex.: @usuario)",
+        "waitlistPrivacyNote": "Usaremos isso apenas para notificá-lo",
+        "waitlistSubmit": "Entrar na lista de espera",
+        "waitlistSubmitFailed": "Falha ao enviar. Por favor, tente novamente.",
+        "welcomeAlt": "bem-vindo"
+    },
+    "blocked": {
+        "title": "Serviço não disponível no seu país",
+        "description": "Devido a restrições, este serviço não está disponível atualmente na sua região."
+    },
+    "notFound": {
+        "title": "Ops, esta página não existe mais...",
+        "description": "Parece que você seguiu um link que não funciona mais. Tente voltar ou retornar ao Painel.",
+        "backToDashboard": "Voltar ao Painel"
+    },
+    "treasuryInfo": {
+        "logoAlt": "Logotipo da tesouraria"
+    },
+    "dateInput": {
+        "placeholder": "dd/mm/aaaa"
+    },
+    "thresholdSlider": {
+        "warningSingleMember": "Um limite de 1 de {memberCount} significa que qualquer membro pode executar transações. Isso reduz a segurança.",
+        "infoBalanced": "Um limite de {currentThreshold} de {memberCount} oferece um bom equilíbrio entre segurança e flexibilidade operacional."
+    },
+    "intentsFee": {
+        "amountTooLowForFee": "{prefix}Valor muito baixo para a taxa de rede ({fee} {symbol}). Adicione pelo menos {addMore} {symbol}."
+    },
+    "metadata": {
+        "treasuryTitle": "Painel | Trezu",
+        "landingTitle": "Trezu | Gestão de tesouraria multichain",
+        "description": "Gerencie o capital da sua equipe em minutos a partir de um único painel sem nunca abrir mão das suas chaves.",
+        "ogTitle": "Trezu | Um multisig. Qualquer cripto. Controle total."
+    },
+    "pages": {
+        "dashboard": {
+            "title": "Painel",
+            "description": "Visão geral dos ativos e da atividade da sua tesouraria",
+            "descriptionLong": "Gerencie os ativos da sua tesouraria e acompanhe a atividade"
+        },
+        "activity": {
+            "title": "Transações recentes",
+            "descriptionDetails": "Detalhes da solicitação",
+            "descriptionList": "Transações recentes em todos os ativos"
+        },
+        "requests": {
+            "title": "Solicitações",
+            "description": "Visualize e gerencie todas as solicitações multisig pendentes",
+            "detailDescription": "Detalhes da solicitação",
+            "detailTitle": "Solicitação nº {id}"
+        },
+        "members": {
+            "title": "Membros",
+            "description": "Gerencie membros da equipe e permissões"
+        },
+        "settings": {
+            "title": "Configurações",
+            "description": "Ajuste as configurações do aplicativo"
+        },
+        "addressBook": {
+            "title": "Catálogo de endereços",
+            "description": "Gerencie seus destinatários salvos"
+        },
+        "payments": {
+            "title": "Pagamentos",
+            "description": "Envie e receba fundos com segurança"
+        },
+        "exchange": {
+            "title": "Troca",
+            "description": "Troque seus tokens de forma segura e eficiente"
+        },
+        "vesting": {
+            "title": "Vesting",
+            "description": "Crie cronogramas de vesting de forma rápida e fácil"
+        },
+        "earn": {
+            "title": "Ganhar",
+            "description": "Obtenha recompensas com seus ativos",
+            "placeholder": "Explore oportunidades de ganhos e recompensas de staking."
+        },
+        "createTreasury": {
+            "title": "Criar tesouraria",
+            "description": "Configure uma nova tesouraria multisig para sua equipe"
+        },
+        "manageTreasuries": {
+            "title": "Gerenciar tesourarias",
+            "description": "Controle quais tesourarias aparecem na sua conta"
+        },
+        "stats": {
+            "title": "Estatísticas",
+            "description": "Ativos sob gestão em tempo real em todas as tesourarias de DAOs sputnik."
+        },
+        "telegram": {
+            "title": "Conectar tesouraria",
+            "description": "Vincule suas tesourarias a um chat do Telegram",
+            "metaTitle": "Trezu — Conectar Telegram",
+            "metaDescription": "Conecte sua tesouraria Trezu a um chat do Telegram"
+        },
+        "wallet": {
+            "title": "Trezu Wallet",
+            "description": "Assine propostas de tesouraria pelo Trezu"
+        }
+    },
+    "depositModal": {
+        "validation": {
+            "selectAsset": "Por favor, selecione um ativo",
+            "selectNetwork": "Por favor, selecione uma rede"
+        },
+        "sections": {
+            "supportedNetworks": "Redes suportadas",
+            "networksWithAssets": "Redes com ativos",
+            "yourAssets": "Seus ativos",
+            "otherAssets": "Outros ativos"
+        },
+        "errors": {
+            "addressUnavailable": "Não foi possível obter o endereço de depósito para o ativo e a rede selecionados.",
+            "fetchFailed": "Falha ao obter o endereço de depósito. Por favor, tente novamente."
+        },
+        "title": "Depósito",
+        "subtitle": "Selecione o ativo e a rede para ver o endereço de depósito",
+        "assetLabel": "Ativo",
+        "networkLabel": "Rede",
+        "selectAsset": "Selecionar ativo",
+        "selectNetwork": "Selecionar rede",
+        "otherAssetName": "Outro",
+        "otherNetworkInfo": "Você pode depositar qualquer token não listado nos ativos, mas apenas pela rede NEAR.",
+        "depositAddressHeading": "Endereço de depósito",
+        "depositAddressSubtitle": "Sempre confira novamente seu endereço de depósito.",
+        "addressLabel": "Endereço",
+        "addressCopied": "Endereço copiado para a área de transferência",
+        "memoLabel": "Memo",
+        "memoCopied": "Memo copiado para a área de transferência",
+        "memoWarning": "Você <bold>deve</bold> incluir o memo ao enviar fundos para este endereço. Enviar sem o memo pode resultar em perda permanente de fundos.",
+        "onlyDeposit": "Deposite apenas <symbolTag>{symbol}</symbolTag> da rede <networkTag>{network}</networkTag>. Recomendamos começar com uma pequena transação de teste para garantir que tudo funcione corretamente antes de enviar o valor total.",
+        "minimumDeposit": "Depósito mínimo é <amountTag>{amount} {symbol}</amountTag>",
+        "searchByName": "Buscar por nome"
+    },
+    "assetDetails": {
+        "coinPrice": "Preço da moeda",
+        "weight": "Peso",
+        "source": "Origem",
+        "send": "Enviar",
+        "exchange": "Trocar",
+        "comingSoon": "Em breve",
+        "vesting": "Vesting",
+        "vestedPercent": "{percent}% liberado",
+        "frozen": "Congelado",
+        "frozenTooltip": "Tokens congelados estão bloqueados e não podem ser usados. Eles podem estar bloqueados por serem usados para armazenamento, staking ou ainda não terem sido liberados.",
+        "vested": "Liberado"
+    },
+    "dashboard": {
+        "overview": "Visão geral dos ativos e da atividade da sua tesouraria",
+        "assets": "Ativos",
+        "balance": "Saldo",
+        "totalBalance": "Saldo total",
+        "deposit": "Depositar",
+        "addAssets": "Adicionar ativos",
+        "hidden": "Ocultos",
+        "confidentialHidden": "Saldos ocultos para tesourarias confidenciais",
+        "recentActivity": "Atividade recente",
+        "viewAllTransactions": "Ver todas as transações"
+    },
+    "activity": {
+        "filters": {
+            "createdDate": "Data de criação",
+            "token": "Token",
+            "from": "De",
+            "to": "Para"
+        },
+        "tabs": {
+            "all": "Todas",
+            "sent": "Enviadas",
+            "received": "Recebidas",
+            "stakingRewards": "Recompensas de staking",
+            "exchange": "Troca"
+        },
+        "searchPlaceholder": "Buscar por hash da transação",
+        "searchPlaceholderShort": "Hash da transação",
+        "fromPool": "do {pool}",
+        "table": {
+            "type": "TIPO",
+            "transaction": "TRANSAÇÃO",
+            "from": "DE",
+            "to": "PARA",
+            "transactionHash": "HASH DA TRANSAÇÃO",
+            "hashTooltip": "Identificador único (hash) desta transação"
+        },
+        "empty": {
+            "title": "Nenhuma transação encontrada",
+            "description": "Suas transações aparecerão aqui quando ocorrerem"
+        },
+        "emptyDashboard": {
+            "title": "Nada para mostrar ainda",
+            "description": "Suas transações e ações aparecerão aqui quando ocorrerem"
+        },
+        "recentTitle": "Transações recentes",
+        "details": {
+            "title": "Detalhes da transação",
+            "copyAddress": "Copiar endereço",
+            "addressCopied": "Endereço copiado para a área de transferência",
+            "sell": "Vender",
+            "receive": "Receber",
+            "pending": "Pendente",
+            "type": "Tipo",
+            "date": "Data",
+            "from": "De",
+            "to": "Para",
+            "method": "Método",
+            "contract": "Contrato",
+            "transaction": "Transação"
+        }
+    },
+    "export": {
+        "types": {
+            "csv": ".CSV",
+            "json": ".JSON",
+            "xlsx": ".XLSX"
+        },
+        "transactionTypes": {
+            "all": "Todos os tipos",
+            "sent": "Enviadas",
+            "received": "Recebidas",
+            "stakingRewards": "Recompensas de staking"
+        },
+        "validation": {
+            "invalidEmail": "Por favor, insira um e-mail válido"
+        },
+        "columns": {
+            "submissionTime": "Data de envio",
+            "dateRange": "Intervalo de datas",
+            "generatedBy": "Gerado por",
+            "status": "Status"
+        },
+        "status": {
+            "generating": "Gerando",
+            "expired": "Expirado",
+            "failed": "Falhou"
+        },
+        "noPermission": "Você não tem permissão para baixar o arquivo.",
+        "download": "Baixar",
+        "heading": "Exportar transações recentes",
+        "teamOnly": "A geração e o download de exportações estão disponíveis apenas para membros da equipe.",
+        "creditsUsed": "Você usou todos os seus créditos",
+        "exportsUsed": "Você usou todas as suas exportações",
+        "upgradePrompt": "Faça upgrade do seu plano para obter mais e continuar",
+        "resetPrompt": "Faça upgrade do seu plano para mais acesso ou aguarde até que seus limites sejam redefinidos no próximo mês.",
+        "tabs": {
+            "generate": "Gerar exportação",
+            "history": "Histórico"
+        },
+        "fields": {
+            "documentType": "Tipo de documento",
+            "timeRange": "Intervalo de tempo",
+            "selectDateRange": "Selecionar intervalo de datas",
+            "asset": "Ativo",
+            "allAssets": "Todos os ativos",
+            "transactionType": "Tipo de transação"
+        },
+        "buttons": {
+            "noPermissionExport": "Você não tem permissão para exportar",
+            "quotaExhausted": "Você usou toda a sua cota",
+            "exporting": "Exportando...",
+            "export": "Exportar"
+        },
+        "empty": {
+            "title": "Nenhuma exportação ainda",
+            "description": "Seus arquivos exportados do último mês aparecerão aqui assim que forem gerados."
+        },
+        "requirements": {
+            "heading": "Requisitos de exportação",
+            "canExportFrom": "Você pode exportar dados a partir de",
+            "availability": "Os arquivos exportados ficam disponíveis para download por 48 horas."
+        },
+        "quota": {
+            "heading": "Cota de exportação",
+            "unlimited": "Ilimitado",
+            "perMonth": "{count} / mês",
+            "flexibilityPrompt": "Procurando mais flexibilidade?",
+            "contactUs": "Fale conosco"
+        }
+    },
+    "requests": {
+        "filters": {
+            "proposalTypes": {
+                "Payments": "Pagamentos",
+                "Exchange": "Troca",
+                "Earn": "Ganhar",
+                "Vesting": "Vesting",
+                "Function Call": "Chamada de função",
+                "Change Policy": "Alterar política",
+                "Settings": "Configurações",
+                "Confidential": "Confidencial"
+            },
+            "voteStatus": {
+                "Approved": "Aprovado",
+                "Rejected": "Rejeitado",
+                "No Voted": "Não votado"
+            },
+            "requestsType": "Tipo de solicitação",
+            "createdDate": "Data de criação",
+            "recipient": "Destinatário",
+            "token": "Token",
+            "requester": "Solicitante",
+            "approver": "Aprovador",
+            "myVoteStatus": "Status do meu voto",
+            "all": "TODOS",
+            "amount": "Valor",
+            "from": "De",
+            "to": "Para",
+            "min": "Mín.",
+            "max": "Máx.",
+            "invalidDate": "Data inválida",
+            "operationIsNot": " não é",
+            "operationBefore": " antes",
+            "operationAfter": " depois",
+            "operationContains": " contém",
+            "searchByAddress": "Buscar por endereço",
+            "loadingMembers": "Carregando membros...",
+            "noMembersFound": "Nenhum membro encontrado. Pressione Enter para adicionar \"{query}\"",
+            "noMembersAvailable": "Nenhum membro disponível",
+            "reset": "Redefinir",
+            "clear": "Limpar",
+            "addFilter": "Adicionar filtro"
+        },
+        "tabs": {
+            "all": "Todas",
+            "pending": "Pendentes",
+            "executed": "Executadas",
+            "rejected": "Rejeitadas",
+            "expired": "Expiradas",
+            "failed": "Falharam"
+        },
+        "searchPlaceholder": "Buscar solicitação por nome ou ID",
+        "searchPlaceholderShort": "Buscar por nome ou ID",
+        "errorLoading": "Erro ao carregar propostas. Por favor, tente novamente.",
+        "empty": {
+            "title": "Crie sua primeira solicitação",
+            "description": "Solicitações de pagamentos, trocas e outras ações aparecerão aqui assim que forem criadas.",
+            "send": "Enviar",
+            "exchange": "Trocar"
+        },
+        "actions": {
+            "approve": "Aprovar",
+            "reject": "Rejeitar",
+            "deposit": "Depositar",
+            "viewRequest": "Ver solicitação"
+        },
+        "table": {
+            "selectAll": "Selecionar tudo",
+            "selectRow": "Selecionar linha",
+            "request": "Solicitação",
+            "transaction": "Transação",
+            "requester": "Solicitante",
+            "voting": "Votação",
+            "votingTooltip": "O primeiro número mostra as aprovações recebidas. O segundo número mostra as aprovações necessárias para executar.",
+            "status": "Status",
+            "notPending": "A proposta não está pendente.",
+            "noPermissionVote": "Você não tem permissão para votar nesta solicitação.",
+            "alreadyVoted": "Você já votou nesta solicitação.",
+            "noResults": "Nenhuma solicitação encontrada para seus filtros.",
+            "allCaughtUp": "Tudo em dia!",
+            "noPending": "Não há solicitações pendentes.",
+            "send": "Enviar",
+            "exchange": "Trocar",
+            "requestsSelected": "{count, plural, one {# solicitação selecionada} other {# solicitações selecionadas}}",
+            "bulkApproveDisabled": "Esta solicitação não pode ser aprovada porque a tesouraria tem saldo insuficiente."
+        },
+        "pending": {
+            "title": "Solicitações pendentes",
+            "viewAll": "Ver tudo",
+            "emptyTitle": "Tudo em dia!",
+            "emptyDescription": "Não há solicitações pendentes."
+        }
+    },
+    "proposals": {
+        "status": {
+            "pending": "Pendente",
+            "approved": "Aprovada",
+            "rejected": "Rejeitada",
+            "executed": "Executada",
+            "expired": "Expirada",
+            "failed": "Falhou",
+            "removed": "Removida",
+            "inProgress": "Em andamento"
+        },
+        "statusTooltip": {
+            "pending": "Esta solicitação ainda está pendente e não atingiu o número necessário de votos para execução.",
+            "executed": "Executada após {approved} de {required} membros aprovarem a solicitação.",
+            "rejected": "Rejeitada após {rejected} de {required} membros votarem para rejeitar a solicitação.",
+            "expired": "Expirada por não receber votos suficientes para ser executada.",
+            "failed": "A solicitação falhou ao ser concluída. Confira os detalhes da transação <link>aqui</link>.",
+            "failedPlain": "A solicitação falhou ao ser concluída. Confira os detalhes da transação aqui."
+        },
+        "votes": {
+            "approved": "Aprovado",
+            "rejected": "Rejeitado",
+            "pending": "Pendente"
+        },
+        "voteModal": {
+            "confirmTitle": "Confirme seu voto",
+            "removeTitle": "Remover solicitação",
+            "bulkBody": "Você está prestes a {action} várias solicitações. Após o envio, esta decisão não pode ser alterada.",
+            "singleBody": "Você está prestes a {action} esta solicitação. Após confirmada, esta ação não pode ser desfeita.",
+            "actionApprove": "aprovar",
+            "actionReject": "rejeitar",
+            "actionRemove": "remover",
+            "insufficientBalance": "As solicitações <highlight>{ids}</highlight> não podem ser aprovadas devido a saldo insuficiente. Sua aprovação será aplicada apenas às solicitações restantes.",
+            "remove": "Remover",
+            "confirm": "Confirmar"
+        },
+        "expanded": {
+            "recipient": "Destinatário",
+            "amount": "Valor",
+            "networkFee": "Taxa de rede",
+            "notes": "Notas",
+            "sent": "Enviado",
+            "received": "Recebido",
+            "priceDifference": "Diferença de preço",
+            "priceDifferenceTooltip": "Diferença entre a taxa cotada e a taxa de mercado atual. Valores positivos indicam uma taxa melhor que a do mercado.",
+            "slippageTolerance": "Tolerância de slippage",
+            "estimatedTime": "Tempo estimado",
+            "seconds": "{count} segundos",
+            "description": "Descrição",
+            "methodName": "Nome do método",
+            "args": "Args",
+            "deposit": "Depósito",
+            "gas": "Gas",
+            "totalDeposit": "Depósito total",
+            "totalGas": "Gas total",
+            "receiverId": "ID do receptor",
+            "contractId": "ID do contrato",
+            "actionsCount": "{count, plural, one {# ação} other {# ações}}",
+            "functionCallsCount": "{count, plural, one {# chamada de função} other {# chamadas de função}}",
+            "showLess": "Mostrar menos",
+            "showMore": "Mostrar mais",
+            "stakingPool": "Pool de staking",
+            "validator": "Validador",
+            "action": "Ação",
+            "stake": "Fazer stake",
+            "unstake": "Desfazer stake",
+            "withdraw": "Retirar",
+            "lockupOwner": "Proprietário do lockup",
+            "lockupDuration": "Duração do lockup",
+            "cliff": "Cliff",
+            "releaseDuration": "Duração da liberação",
+            "vestingSchedule": "Cronograma de vesting",
+            "cancellable": "Cancelável",
+            "allowEarn": "Permitir staking",
+            "yes": "Sim",
+            "no": "Não",
+            "notSet": "Não definido",
+            "from": "De",
+            "to": "Para",
+            "paymentsCount": "{count, plural, one {# pagamento} other {# pagamentos}}",
+            "sourceWallet": "Carteira de origem",
+            "allNear": "Todo NEAR",
+            "startDate": "Data de início",
+            "endDate": "Data de término",
+            "cliffDate": "Data do cliff",
+            "allowCancellation": "Permitir cancelamento",
+            "allowStaking": "Permitir staking",
+            "loadingHistorical": "Carregando configuração histórica...",
+            "name": "Nome",
+            "purpose": "Finalidade",
+            "logo": "Logotipo",
+            "logoAlt": "Logotipo",
+            "primaryColor": "Cor primária",
+            "noChangesCurrent": "Nenhuma alteração detectada na configuração em comparação com o estado atual.",
+            "noChangesHistorical": "Nenhuma alteração detectada na configuração em comparação com o estado histórico.",
+            "method": "Método",
+            "arguments": "Argumentos",
+            "contract": "Contrato",
+            "actionNumber": "Ação {number}",
+            "actions": "Ações",
+            "collapseAll": "Recolher tudo",
+            "expandAll": "Expandir tudo",
+            "send": "Enviar",
+            "receive": "Receber",
+            "rate": "Taxa",
+            "priceSlippageLimit": "Limite de slippage de preço",
+            "slippageTooltip": "Este é o limite de slippage definido para esta solicitação. Se a taxa de mercado mudar além deste limite durante a execução, a solicitação falhará automaticamente.",
+            "estimatedTimeTooltip": "Tempo estimado para o swap ser executado após a confirmação da transação de depósito.",
+            "minReceive": "Receb. mín.",
+            "minimumReceived": "Mínimo recebido",
+            "minReceiveTooltip": "Este é o valor mínimo que você receberá desta troca, com base no limite de slippage definido para a solicitação.",
+            "depositAddress": "Endereço de depósito",
+            "depositAddressTooltip": "O endereço de depósito 1Click para onde os tokens serão enviados para a execução do swap multichain.",
+            "quoteSignature": "Assinatura da cotação",
+            "quoteSignatureTooltip": "A assinatura criptográfica da API 1Click que valida esta cotação.",
+            "quoteDeadline": "Prazo da cotação 1-Click",
+            "quoteDeadlineTooltip": "Horário em que o endereço de depósito se torna inativo e os fundos podem ser perdidos.",
+            "status": "Status",
+            "transactionLink": "Link da transação",
+            "viewTransaction": "Ver transação",
+            "recipientNumber": "Destinatário {number}",
+            "oopsTitle": "Ops! Algo deu errado",
+            "oopsDescription": "Não conseguimos encontrar dados para mostrar aqui.",
+            "totalAmount": "Valor total",
+            "recipients": "Destinatários",
+            "recipientsCount": "{count, plural, one {# destinatário} other {# destinatários}}",
+            "unsupportedProposal": "Tipo de proposta não suportado",
+            "requestDetails": "Detalhes da solicitação",
+            "linkCopied": "Link copiado para a área de transferência",
+            "copyLink": "Copiar link",
+            "openRequestPage": "Abrir página da solicitação",
+            "deleteRequest": "Excluir solicitação",
+            "unknownRecipients": "Destinatários desconhecidos",
+            "loadingConfig": "Carregando configuração...",
+            "historicalData": "Dados históricos...",
+            "generalUpdate": "Atualização geral",
+            "detailsUnavailable": "Detalhes indisponíveis",
+            "changesCount": "{count, plural, one {# Alteração} other {# Alterações}}",
+            "policyUpdate": "Atualização de política",
+            "noChangesDetected": "Nenhuma alteração detectada",
+            "loadingPolicy": "Carregando política...",
+            "roleChanges": "Alterações de função",
+            "policyParameters": "Parâmetros da política",
+            "defaultVotePolicy": "Política de voto padrão",
+            "policyRoleChanges": "Alterações de política e funções",
+            "membersAdded": "{count, plural, one {# membro adicionado} other {# membros adicionados}}",
+            "membersRemoved": "{count, plural, one {# membro removido} other {# membros removidos}}",
+            "membersUpdated": "{count, plural, one {# membro atualizado} other {# membros atualizados}}",
+            "rolesModified": "{count, plural, one {# função modificada} other {# funções modificadas}}",
+            "parametersChanged": "{count, plural, one {# parâmetro alterado} other {# parâmetros alterados}}",
+            "defaultVotePolicyPart": "política de voto padrão",
+            "onReceiver": "em {receiver}",
+            "toPrefix": "Para:",
+            "validatorPrefix": "Validador:",
+            "validatorSubtitle": "Validador: {address}",
+            "impactTitle": "Impacto da alteração da duração da votação",
+            "impactBody": "Você está prestes a atualizar a duração da votação. Isso afetará as seguintes solicitações existentes.",
+            "activeRequestsBullet": "{count, plural, one {# solicitação ficará ativa para votação após esta alteração, com datas de expiração atualizadas.} other {# solicitações ficarão ativas para votação após esta alteração, com datas de expiração atualizadas.}}",
+            "expiringRequestsBullet": "{count, plural, one {# solicitação será marcada como \"Expirada\" sob a nova duração de votação.} other {# solicitações serão marcadas como \"Expiradas\" sob a nova duração de votação.}}",
+            "remainActiveHeading": "Solicitações que permanecem ativas para votação com nova data de expiração",
+            "willExpireHeading": "Solicitações que serão marcadas como \"Expirada\"",
+            "tableRequest": "Solicitação",
+            "tableTransaction": "Transação",
+            "tableNewExpiry": "Nova expiração",
+            "expireInDays": "{count, plural, one {Expira em # dia} other {Expira em # dias}}",
+            "today": "Hoje",
+            "uponApproval": "Após aprovação",
+            "yesContinue": "Sim, continuar",
+            "transactionCreated": "Transação criada",
+            "voting": "Votação",
+            "approvalsReceived": "{received}/{required} aprovações recebidas",
+            "expiresAt": "Expira em",
+            "expiredAt": "Expirou em",
+            "exchangingTokens": "Trocando tokens",
+            "exchangingTokensBody": "Esta solicitação foi aprovada pela equipe. A troca de tokens está em andamento e pode levar algum tempo.",
+            "requestFailed": "Solicitação falhou",
+            "requestFailedBody": "A equipe aprovou esta solicitação, mas ela falhou devido a flutuações de taxa. Por favor, crie uma nova solicitação e tente novamente.",
+            "votingPeriod24h": "Período de votação: 24 horas",
+            "votingPeriod24hBody": "Esta solicitação de troca tem duração de votação de 24 horas. Aprove esta solicitação dentro deste prazo, ou ela expirará.",
+            "reject": "Rejeitar",
+            "approve": "Aprovar"
+        },
+        "insufficientBalance": {
+            "noAsset": "Esta solicitação não pode ser aprovada porque o token necessário não está disponível na tesouraria.",
+            "bond": "Esta solicitação não pode ser aprovada porque a tesouraria tem saldo insuficiente de <token>{symbol}</token>. Adicione <token>{amount} {symbol}</token> para cobrir os custos do bond da proposta.",
+            "continue": "Esta solicitação não pode ser aprovada porque a tesouraria tem saldo insuficiente de <token>{symbol}</token>. Adicione <token>{amount} {symbol}</token> para continuar.",
+            "modalTitle": "Saldo insuficiente de NEAR",
+            "modalBodyVote": "Você não tem NEAR suficiente na sua carteira para registrar este voto. Votar requer um saldo mínimo de <amount>{required} NEAR</amount>. Por favor, adicione NEAR à sua carteira e tente novamente.",
+            "modalBodyProposal": "Você não tem NEAR suficiente na sua carteira para criar esta solicitação. Criar uma solicitação requer um saldo mínimo de <amount>{required} NEAR</amount>. Por favor, adicione NEAR à sua carteira e tente novamente.",
+            "gotIt": "Entendi"
+        }
+    },
+    "members": {
+        "title": "Membros",
+        "description": "Gerencie membros da equipe e permissões",
+        "permissions": "Permissões",
+        "member": "Membro",
+        "activeMembers": "Membros ativos",
+        "noActiveMembers": "Nenhum membro ativo encontrado.",
+        "addNewMember": "Adicionar novo membro",
+        "membersSelected": "{count, plural, =0 {nenhum membro} one {# membro} other {# membros}} selecionado",
+        "remove": "Remover",
+        "edit": "Editar",
+        "requestorOnlyTooltip": "Você só pode adicionar a função de Solicitante para este membro, pois ele é responsável por criar solicitações de pagamento a partir do NEARN.",
+        "memberModal": {
+            "editRoles": "Editar funções",
+            "addNewMember": "Adicionar novo membro",
+            "validatingAddresses": "Validando endereços...",
+            "creatingProposal": "Criando proposta...",
+            "reviewRequest": "Revisar solicitação",
+            "noChanges": "Nenhuma alteração foi feita nas funções dos membros"
+        },
+        "previewModal": {
+            "title": "Revise sua solicitação",
+            "youAreEditing": "Você está editando",
+            "youAreAdding": "Você está adicionando",
+            "membersCount": "{count, plural, one {# membro} other {# membros}}",
+            "newMembersCount": "{count, plural, one {# novo membro} other {# novos membros}}",
+            "updatedMembers": "Membros atualizados",
+            "newMembers": "Novos membros",
+            "creatingProposal": "Criando proposta...",
+            "confirmSubmit": "Confirmar e enviar solicitação"
+        },
+        "removeDialog": {
+            "title": "Remover solicitação",
+            "nearnBody": "Após aprovado, {account} será removido permanentemente da tesouraria e todas as permissões associadas serão revogadas. Após a remoção, esta conta não poderá mais criar solicitações a partir do NEARN.",
+            "genericBody": "Após aprovada, esta ação removerá permanentemente <bold>{accounts}</bold> da tesouraria e revogará todas as permissões atribuídas.",
+            "creatingProposal": "Criando proposta..."
+        },
+        "validation": {
+            "accountIdRequired": "ID da conta é obrigatório",
+            "invalidNearAddress": "Endereço NEAR inválido.",
+            "atLeastOneRole": "Pelo menos uma função deve ser selecionada",
+            "atLeastOneMember": "Pelo menos um membro é obrigatório",
+            "alreadyAdded": "Este membro já foi adicionado acima",
+            "alreadyInTreasury": "Este membro já existe na tesouraria",
+            "cannotRemoveRoleAfter": "Você não pode remover a função {role} deste membro. Após todas as suas alterações, ele seria a única pessoa atribuída a esta função.",
+            "cannotRemoveRoleAfterGov": "Você não pode remover a função {role} deste membro. Após todas as suas alterações, ele seria o único membro {role}, e sem esta função você não poderá gerenciar membros da equipe nem configurar a votação."
+        },
+        "policy": {
+            "addMembers": "Atualizar política - Adicionar novos membros",
+            "addMembersSuccess": "Solicitação de novo membro criada com sucesso",
+            "editMember": "Atualizar política - Editar permissões de membro",
+            "editMembers": "Atualizar política - Editar vários membros",
+            "editMemberSuccess": "Solicitação de atualização de funções do membro criada com sucesso",
+            "editMembersSuccess": "Solicitação de atualização em massa de funções de membros criada com sucesso",
+            "removeMember": "Atualizar política - Remover membro",
+            "removeMembers": "Atualizar política - Remover membros",
+            "removeMemberSuccess": "Solicitação de remoção de membro criada com sucesso"
+        }
+    },
+    "settings": {
+        "tabs": {
+            "general": "Geral",
+            "voting": "Votação",
+            "preferences": "Preferências",
+            "integrations": "Integrações"
+        },
+        "general": {
+            "validation": {
+                "displayNameRequired": "O nome de exibição é obrigatório",
+                "displayNameMax": "O nome de exibição deve ter menos de 100 caracteres"
+            },
+            "proposalDescriptionTitle": "Atualizar configuração - Tema e logotipo",
+            "proposalSubmitted": "Solicitação para atualizar a configuração enviada",
+            "treasuryNotFound": "Tesouraria não encontrada",
+            "treasuryName": "Nome da tesouraria",
+            "treasuryNameDescription": "O nome da sua tesouraria. Será exibido em todo o aplicativo.",
+            "displayName": "Nome de exibição",
+            "displayNamePlaceholder": "Insira o nome de exibição",
+            "accountName": "Nome da conta",
+            "logo": "Logotipo",
+            "logoDescription": "Faça upload de um logotipo para sua tesouraria. Recomendado SVG, PNG ou JPG (256x256 px).",
+            "treasuryLogoAlt": "Logotipo da tesouraria",
+            "uploading": "Enviando...",
+            "uploadLogo": "Fazer upload do logotipo",
+            "removeLogo": "Remover logotipo",
+            "logoUploaded": "Logotipo enviado com sucesso",
+            "uploadError": "Ocorreu um erro ao enviar a imagem, por favor tente novamente.",
+            "invalidLogo": "Logotipo inválido. Por favor, envie um arquivo PNG, JPG ou SVG com exatamente 256x256 px",
+            "invalidImage": "Arquivo de imagem inválido. Por favor, envie uma imagem válida.",
+            "fileReadError": "Erro ao ler o arquivo. Por favor, tente novamente.",
+            "primaryColor": "Cor primária",
+            "primaryColorDescription": "Defina a cor primária para os elementos da interface da sua tesouraria. Esta cor será usada nos modos claro e escuro, então leve em conta o contraste ao escolher tons neutros.",
+            "selectColorLabel": "Selecionar cor {color}"
+        },
+        "voting": {
+            "validation": {
+                "required": "A duração do voto é obrigatória",
+                "validNumber": "A duração do voto deve ser um número válido",
+                "min": "A duração do voto deve ser de pelo menos 1 dia",
+                "max": "A duração do voto deve ser inferior a 1000 dias",
+                "whole": "A duração do voto deve ser em dias inteiros"
+            },
+            "missingData": "Dados obrigatórios ausentes",
+            "thresholdProposalTitle": "Atualizar política - Limites de votação",
+            "thresholdProposalSummary": "{account} solicitou alterar o limite de votação de {oldValue} para {newValue}.",
+            "thresholdSubmitted": "Solicitação para atualizar o limite de votação enviada",
+            "createProposalFailed": "Falha ao criar proposta",
+            "durationProposalTitle": "Atualizar política - Duração da votação",
+            "durationProposalSummary": "{account} solicitou alterar a duração da votação de {oldValue} para {newValue}.",
+            "durationSubmitted": "Solicitação criada com sucesso",
+            "pendingTitle": "Solicitação de limite de votação ativa",
+            "pendingBody": "Para evitar conflitos, você precisa concluir ou resolver as solicitações pendentes existentes antes de prosseguir. Estas solicitações estão atualmente ativas e devem ser aprovadas ou rejeitadas primeiro.",
+            "viewRequest": "Ver solicitação",
+            "thresholdHeading": "Limite de votação",
+            "thresholdDescriptionApprovers": "Defina quantos votos são necessários para aprovar solicitações de pagamento e relacionadas à equipe. Configure os limites separadamente para Aprovadores e Governança.",
+            "thresholdDescriptionGeneric": "Defina quantos votos são necessários para aprovar solicitações. Configure os limites para cada função com base em suas responsabilidades.",
+            "membersWhoCanVote": "Membros que podem votar",
+            "votesRequired": "Votos são necessários para aprovar solicitações",
+            "durationHeading": "Duração do voto",
+            "durationDescription": "O tempo (em dias) que uma proposta permanecerá aberta para votação. Se a votação não for concluída neste período, a decisão expira.",
+            "durationApprovers": " Esta duração se aplica igualmente às funções de Governança e Aprovadores.",
+            "durationGeneric": " Esta duração é a mesma para todas as funções da tesouraria.",
+            "days": "Dias"
+        },
+        "preferences": {
+            "timeZone": "Fuso horário",
+            "timeZoneDescription": "Defina seu fuso horário local para exibição precisa de data e hora.",
+            "timeFormat": "Formato de hora",
+            "hour12": "12 horas (1:00 PM)",
+            "hour24": "24 horas (13:00)",
+            "autoTimezone": "Definir fuso horário automaticamente usando sua localização",
+            "timezone": "Fuso horário",
+            "loadingTimezones": "Carregando fusos horários...",
+            "selectTimezone": "Selecionar fuso horário",
+            "searchTimezones": "Buscar fusos horários...",
+            "noTimezones": "Nenhum fuso horário encontrado",
+            "save": "Salvar",
+            "savedToast": "Preferências salvas com sucesso",
+            "saveFailed": "Falha ao salvar preferências",
+            "loadFailed": "Falha ao carregar fusos horários"
+        }
+    },
+    "addressBook": {
+        "emptyTitle": "Adicione seu primeiro destinatário",
+        "emptyDescription": "Salve endereços usados com frequência para pagamentos mais rápidos e sem erros. Seus contatos permanecem privados e visíveis apenas para sua equipe.",
+        "import": "Importar",
+        "addRecipient": "Adicionar destinatário",
+        "recipientsHeading": "Destinatários",
+        "recipientsSelected": "{count, plural, =0 {nenhum destinatário} one {# destinatário} other {# destinatários}} selecionado",
+        "sectionHeading": "Destinatários",
+        "privacyNote": "Os endereços salvos são privados e visíveis apenas para sua equipe.",
+        "searchPlaceholder": "Buscar destinatário por nome",
+        "searchPlaceholderShort": "Buscar",
+        "review": {
+            "header": "Revisar detalhes",
+            "youAreAdding": "Você está adicionando",
+            "newRecipients": "{count, plural, one {# novo destinatário} other {# novos destinatários}}",
+            "onNetworks": "em {count, plural, one {# rede} other {# redes}}",
+            "recipients": "Destinatários",
+            "allDuplicates": "Todos os destinatários importados já existem no seu catálogo de endereços. Volte para enviar uma lista diferente ou remova duplicatas desta revisão.",
+            "someDuplicates": "{duplicates} destinatários duplicados de {total} destinatários no total. Continue para importar apenas os novos destinatários.",
+            "duplicated": "Duplicado",
+            "notePlaceholder": "Adicione uma nota para ajudar a identificar este destinatário (ex.: pagamento de prestador, distribuição de vesting).",
+            "skipDuplicates": "Ignorar duplicatas e importar apenas os novos.",
+            "allDuplicatesTooltip": "Todos os destinatários importados já estão no seu catálogo de endereços, então não há nada novo para importar.",
+            "duplicateActionTooltip": "Ative o pulo de duplicatas ou remova destinatários duplicados para continuar.",
+            "adding": "Adicionando…",
+            "nothingNew": "Nada novo para importar",
+            "addRecipientsButton": "{count, plural, one {Adicionar destinatário} other {Adicionar destinatários}}"
+        },
+        "removeDialog": {
+            "title": "Remover destinatário",
+            "bulk": "Isso removerá <bold>{count, plural, one {# destinatário} other {# destinatários}}</bold> do seu catálogo de endereços. Você pode adicioná-los novamente a qualquer momento.",
+            "single": "Isso removerá <bold>{name}</bold> do seu catálogo de endereços. Você pode adicionar este destinatário novamente a qualquer momento."
+        },
+        "importFlow": {
+            "title": "Importar destinatários",
+            "description": "Faça upload de uma lista de endereços de destinatários para o seu catálogo de endereços.",
+            "foundSummary": "{count, plural, one {# destinatário encontrado} other {# destinatários encontrados}} em {networkCount, plural, one {# rede} other {# redes}}",
+            "uploadPrompt": "Faça upload ou cole os dados dos destinatários",
+            "fixErrors": "Corrija os erros para continuar",
+            "continueReview": "Continuar para revisão"
+        },
+        "form": {
+            "editRecipient": "Editar destinatário",
+            "addRecipient": "Adicionar destinatário",
+            "import": "Importar",
+            "recipientName": "Nome do destinatário",
+            "namePlaceholder": "Alice",
+            "recipientAddress": "Endereço do destinatário",
+            "network": "Rede",
+            "networkInfo": "Redes compatíveis com este endereço",
+            "enterAddressFirst": "Insira primeiro o endereço do destinatário",
+            "selectNetwork": "Selecionar rede",
+            "selectNetworksTitle": "Selecionar redes",
+            "searchNetworksPlaceholder": "Buscar redes…",
+            "done": "Concluído",
+            "edit": "Editar",
+            "remove": "Remover",
+            "incomplete": "Incompleto",
+            "addAnother": "Adicionar outro destinatário",
+            "fillAllTooltip": "Você deve preencher todos os campos para adicionar um destinatário.",
+            "reviewDetails": "Revisar detalhes",
+            "reviewTooltip": "Todos os destinatários devem estar completos antes de revisar.",
+            "invalidAddress": "Endereço inválido",
+            "noCompatibleNetworks": "Nenhuma rede compatível com este endereço"
+        },
+        "parsing": {
+            "rowPrefix": "Linha {row}: {message}",
+            "missingName": "Nome do destinatário ausente. Por favor, adicione um nome.",
+            "missingAddress": "Endereço do destinatário ausente. Por favor, adicione um endereço de carteira.",
+            "invalidAddressFormat": "O endereço \"{address}\" não está em um formato válido para nenhuma rede suportada.",
+            "unknownNetwork": "Rede desconhecida \"{network}\". As redes suportadas incluem: {available}.",
+            "incompatibleNetwork": "O endereço \"{address}\" não é compatível com {network}. Redes compatíveis: {compatible}.",
+            "noDataFound": "Nenhum dado encontrado. Por favor, adicione destinatários neste formato: Name, Address, Network, Note",
+            "headerColumnsNotFound": "Detectamos uma linha de cabeçalho, mas não conseguimos encontrar as colunas 'Name' e 'Address'. Por favor, use estes nomes de coluna ou remova a linha de cabeçalho.",
+            "failedToParseCsv": "Falha ao analisar dados CSV"
+        }
+    },
+    "payments": {
+        "validation": {
+            "recipientMin": "O destinatário deve ter pelo menos 2 caracteres",
+            "recipientMax": "O destinatário deve ter menos de 128 caracteres",
+            "amountPositive": "O valor deve ser maior que 0",
+            "recipientTokenSame": "O destinatário e o endereço do token não podem ser iguais"
+        },
+        "newPayment": "Novo pagamento",
+        "reviewYourPayment": "Revise seu pagamento",
+        "reviewButton": "Revisar pagamento",
+        "reviewButtonDisabled": "Insira o valor e o endereço",
+        "comingSoon": "Em breve",
+        "bulkPayments": "Pagamentos em massa",
+        "summaryRecipients": "para {count, plural, one {# destinatário} other {# destinatários}}",
+        "networkFee": "Taxa de rede",
+        "networkFeeInfo": "Informações sobre a taxa de rede",
+        "commentPlaceholder": "Adicionar um comentário (opcional)...",
+        "preparingRoute": "Preparando rota de transferência 1Click...",
+        "confirmSubmit": "Confirmar e enviar solicitação",
+        "useDifferentAddress": "Usar um endereço diferente",
+        "failed1ClickQuote": "Falha ao criar cotação de transferência 1Click",
+        "paymentSubmitted": "Solicitação de envio de pagamento enviada"
+    },
+    "bulkPayment": {
+        "comingSoonToast": "Pagamentos em massa estão chegando em breve!",
+        "submittingList": "Enviando lista de pagamentos em massa",
+        "submittingProposal": "Enviando proposta",
+        "proposalSubmitted": "Proposta de pagamento em massa enviada",
+        "submitListFailed": "Falha ao enviar lista de pagamentos",
+        "submitFailed": "Falha ao enviar pagamento em massa",
+        "upload": {
+            "pleaseUploadCsv": "Por favor, faça upload de um arquivo CSV",
+            "fileSizeLimit": "O tamanho do arquivo deve ser inferior a 1,5 MB",
+            "headerTitle": "Solicitações de pagamento em massa",
+            "headerSubtitle": "Pague vários destinatários com uma única proposta.",
+            "creditsUsed": "Você usou todos os seus créditos",
+            "bulkPaymentsUsed": "Você usou todos os seus pagamentos em massa",
+            "upgradeTrial": "Faça upgrade do seu plano para obter mais e continuar",
+            "upgradePaid": "Faça upgrade do seu plano para mais acesso ou aguarde até que seus limites sejam redefinidos no próximo mês.",
+            "selectAsset": "Selecionar ativo",
+            "disableTokenMessage": "Pagamentos em massa para estes tokens estão chegando em breve.",
+            "providePaymentData": "Forneça os dados de pagamento",
+            "uploadFile": "Enviar arquivo",
+            "provideData": "Fornecer dados",
+            "chooseFile": "Escolher arquivo",
+            "orDragDrop": "ou arraste e solte",
+            "maxFileSize": "máx. 1 arquivo de até 1,5 MB, somente arquivo CSV",
+            "noFilePrompt": "Não tem um arquivo para enviar?",
+            "downloadTemplate": "Baixar um modelo",
+            "requirements": "Requisitos de pagamento em massa",
+            "maxTransactions": "Máx. {max} transações por importação",
+            "singleTokenNetwork": "Token e rede únicos",
+            "limitsUsed": "Você usou todos os seus limites",
+            "selectAndProvide": "Selecione o ativo e forneça os dados de pagamento",
+            "continueToReview": "Continuar para revisão",
+            "selectTokenError": "Por favor, selecione um token",
+            "providePaymentDataError": "Por favor, forneça os dados de pagamento"
+        },
+        "editStep": {
+            "title": "Editar pagamento",
+            "saveChanges": "Salvar alterações"
+        },
+        "parsing": {
+            "rowPrefix": "Linha {row}: {message}",
+            "missingRecipientFirstColumn": "Endereço do destinatário ausente. Por favor, adicione um endereço na primeira coluna.",
+            "invalidNearAddress": "O endereço \"{address}\" não é uma conta NEAR válida.",
+            "invalidChainAddress": "O endereço \"{address}\" não é uma conta {chain} válida.",
+            "rowNeedsAmountRecipient": "Cada linha precisa do valor e do destinatário separados por uma vírgula. Exemplo: 100, alice.near",
+            "missingRecipientBeforeComma": "Endereço do destinatário ausente. Por favor, adicione um endereço antes da vírgula.",
+            "missingAmountAfterComma": "Valor ausente. Por favor, adicione um número após a vírgula. Exemplo: {recipient}, 100",
+            "invalidAmountNumber": "O valor \"{amountStr}\" não é um número válido. Por favor, use apenas números e decimais (ex.: 100 ou 100.50).",
+            "amountGreaterThanZero": "O valor deve ser maior que 0. Você inseriu \"{amountStr}\".",
+            "amountTooLarge": "O valor \"{amountStr}\" é muito grande. Por favor, use um número menor.",
+            "invalidAmountFallback": "Valor inválido. Por favor, use apenas números e decimais (ex.: 100 ou 100.50).",
+            "pleaseRemoveChars": "Por favor, remova estes caracteres: {chars}. Apenas números, vírgulas e pontos são permitidos.",
+            "amountCannotBeEmpty": "O valor não pode estar vazio.",
+            "tokenMismatch": "Você inseriu \"{provided}\", mas {expected} está selecionado acima. Remova o símbolo do token ou selecione {suggested} no menu suspenso.",
+            "multipleTokenSymbols": "Você está usando vários símbolos de token ({symbols}). Por favor, use apenas um tipo de token em todo o arquivo, ou remova os símbolos de token e deixe a seleção acima determinar o token.",
+            "noPaymentDataFound": "Nenhum dado de pagamento encontrado. Por favor, adicione seus pagamentos neste formato: recipient, amount",
+            "exceedsRecipientLimit": "Você tem {count} destinatários, mas o limite é {limit} por lote. Por favor, remova {excess, plural, one {# destinatário} other {# destinatários}} ou divida em vários lotes.",
+            "noPaymentDataProvided": "Nenhum dado de pagamento fornecido. Por favor, insira seus pagamentos neste formato: recipient, amount",
+            "headerColumnsNotFound": "Detectamos uma linha de cabeçalho, mas não conseguimos encontrar as colunas 'Recipient' e 'Amount'. Por favor, use estes nomes de coluna ou remova a linha de cabeçalho.",
+            "failedToParseCsv": "Falha ao analisar dados CSV",
+            "failedToParsePaste": "Falha ao analisar dados colados",
+            "failedToValidateAccount": "Falha ao validar a conta",
+            "feeEstimationFailed": "Não foi possível estimar a taxa de rede para este valor. Por favor, verifique e tente novamente.",
+            "feeEstimationFailedRow": "Linha {row} ({recipient}): Não foi possível estimar a taxa de rede para este valor. Por favor, verifique e tente novamente."
+        },
+        "recipients": "Destinatários",
+        "insufficientTokens": "Tokens insuficientes. Você pode enviar a solicitação e completar o saldo antes da aprovação.",
+        "removeRecipient": "Remover destinatário",
+        "removeRecipientConfirm": "Tem certeza de que deseja remover o pagamento para <strong>{recipient}</strong>? Esta ação não pode ser desfeita.",
+        "remove": "Remover",
+        "edit": "Editar"
+    },
+    "bulkPaymentCredits": {
+        "title": "Pagamentos em massa",
+        "unlimited": "Ilimitado",
+        "creditsPerPeriod": "{amount} / {period}",
+        "oneTimeTrial": "teste único",
+        "month": "mês",
+        "moreFlexibility": "Procurando mais flexibilidade?",
+        "contactUs": "Fale conosco"
+    },
+    "exchange": {
+        "validation": {
+            "amountPositive": "O valor deve ser maior que 0"
+        },
+        "requestSubmitted": "Solicitação de troca enviada",
+        "heading": "Troca",
+        "sell": "Vender",
+        "receive": "Receber",
+        "slippageTolerance": "Tolerância de slippage",
+        "disabled": {
+            "differentTokens": "Os tokens devem ser diferentes",
+            "enterAmount": "Insira um valor para trocar"
+        },
+        "review": "Revisar troca",
+        "poweredBy": "Desenvolvido por",
+        "info": {
+            "priceDifference": "Diferença de preço",
+            "priceDifferenceTooltip": "Diferença entre a taxa cotada e a taxa de mercado atual. Valores positivos indicam uma taxa melhor que a do mercado.",
+            "estimatedTime": "Tempo estimado",
+            "estimatedTimeValue": "{seconds} segundos",
+            "estimatedTimeTooltip": "Tempo aproximado para concluir a troca.",
+            "minimumReceived": "Mínimo recebido",
+            "minimumReceivedTooltip": "Este é o valor mínimo que você receberá desta troca, com base no limite de slippage definido para a solicitação.",
+            "depositAddress": "Endereço de depósito",
+            "depositAddressCopied": "Endereço de depósito copiado",
+            "quoteExpires": "A cotação expira",
+            "exchangeFee": "Taxa de troca",
+            "exchangeFeeTooltip": "A taxa de 0,70% incorrida aqui cobre os custos do protocolo NEAR Intents para facilitar sua negociação e a taxa do widget Trezu. Este valor é calculado automaticamente na sua taxa cotada."
+        },
+        "approveWithin24h": "Por favor, aprove esta solicitação em até 24 horas, caso contrário ela expirará. Recomendamos confirmar o quanto antes.",
+        "confirmSubmit": "Confirmar e enviar solicitação",
+        "refreshingIn": "A taxa de câmbio será atualizada em {seconds}s"
+    },
+    "vesting": {
+        "validation": {
+            "amountMin": "O valor deve ser maior ou igual a 3,5",
+            "startBeforeEnd": "A data de início deve ser anterior à data de término",
+            "cliffBetween": "A data do cliff deve estar entre"
+        },
+        "stepTitles": {
+            "details": "Detalhes",
+            "settings": "Configurações",
+            "review": "Revisar"
+        },
+        "proposalTitle": "Criar cronograma de vesting para {address}",
+        "scheduleSubmitted": "Solicitação para criar cronograma de vesting enviada",
+        "heading": "Novo cronograma de vesting",
+        "amount": "Valor",
+        "startDate": "Data de início",
+        "endDate": "Data de término",
+        "noteOptional": "Nota (opcional)",
+        "continue": "Continuar",
+        "advancedSettings": "Configurações avançadas",
+        "allowCancellation": "Permitir cancelamento",
+        "allowCancellationDescription": "Permite que a NEAR Foundation cancele o lockup a qualquer momento. Lockups não canceláveis não são compatíveis com datas de cliff.",
+        "cliffDate": "Data do cliff",
+        "allowEarn": "Permitir ganhos",
+        "allowEarnDescription": "Permite ao proprietário do lockup fazer staking do valor total dos tokens no lockup (mesmo antes da data do cliff).",
+        "commentPlaceholder": "Adicionar um comentário para este cronograma de vesting (opcional)...",
+        "reviewRequest": "Revisar solicitação",
+        "reviewHeading": "Revise seu cronograma de vesting",
+        "confirmSubmit": "Confirmar e enviar solicitação",
+        "review": {
+            "recipient": "Destinatário",
+            "startDate": "Data de início",
+            "endDate": "Data de término",
+            "cliffDate": "Data do cliff",
+            "cancelable": "Cancelável",
+            "allowEarn": "Permitir ganhos",
+            "na": "N/D"
+        }
+    },
+    "earn": {
+        "placeholder": "Explore oportunidades de ganhos e recompensas de staking."
+    },
+    "createTreasury": {
+        "validation": {
+            "nameMin": "O nome da tesouraria deve ter pelo menos 2 caracteres",
+            "nameMax": "O nome da tesouraria deve ter menos de 64 caracteres",
+            "accountMin": "O nome da conta deve ter pelo menos 2 caracteres",
+            "accountMax": "O nome da conta deve ter menos de 64 caracteres",
+            "accountChars": "O nome da conta pode conter apenas letras latinas, números e hifens",
+            "accountTaken": "Este nome de conta já está em uso"
+        },
+        "votingNote": "Você precisa de mais membros para modificar as configurações de votação. Adicione outro membro para configurar a votação.",
+        "minimumVoteNote": "É necessário no mínimo um voto de aprovação.",
+        "heading": "Criar uma tesouraria",
+        "addMembers": "Adicionar membros",
+        "addMembersInfo": "Você pode adicionar ou atualizar membros agora e editar isso depois a qualquer momento.",
+        "treasuryName": "Nome da tesouraria",
+        "treasuryNamePlaceholder": "Minha tesouraria",
+        "accountName": "Nome da conta",
+        "accountNameInfo": "Este é o nome único da sua conta. Será usado na URL da sua tesouraria e exibido nas transações para identificar quem enviou o pagamento. Escolha um nome curto e reconhecível para sua conta.",
+        "accountPlaceholder": "minha-tesouraria",
+        "continue": "Continuar",
+        "votingThreshold": "Limite de votação",
+        "thresholdDescription": "Defina quantos votos são necessários para aprovar solicitações:",
+        "financial": "Financeiro",
+        "financialDescription": "Aprovação de solicitações de pagamento e troca.",
+        "governance": "Governança",
+        "governanceDescription": "Aprovação de configurações, membros e configuração de votação.",
+        "confidential": "Confidencial",
+        "public": "Público",
+        "anyone": "Qualquer pessoa",
+        "teamOnly": "Apenas a equipe",
+        "soon": "Em breve",
+        "publicDescription": "Todos os saldos, atividades e transações são visíveis a qualquer pessoa na blockchain. Esta opção é melhor para organizações transparentes e DAOs públicos.",
+        "balanceTransactions": "Saldo, transações",
+        "membersVoting": "Membros, votação",
+        "allFeatures": "Todos os recursos disponíveis",
+        "confidentialDescription": "Todos os saldos, atividades e transferências privados na blockchain. Apenas sua equipe pode ver estas informações. Melhor para empresas privadas, family offices ou equipes que querem privacidade financeira.",
+        "recentTransactionsExport": "Exportação de transações recentes",
+        "bulkPayment": "Pagamento em massa",
+        "treasuryType": "Tipo de tesouraria",
+        "treasuryTypeWarning": "Você só pode selecionar uma vez por tesouraria e não pode alterá-la depois.",
+        "select": "Selecionar",
+        "visibleOnChain": "Visível na chain",
+        "featuresAvailable": "Recursos disponíveis",
+        "mostFeaturesSupported": "A maioria dos recursos é suportada",
+        "reviewTreasury": "Revisar tesouraria",
+        "membersLabel": "Membros",
+        "financialThreshold": "Limite financeiro",
+        "governanceThreshold": "Limite de governança",
+        "noDeploymentFee": "🎉 Sem taxa de implantação",
+        "noDeploymentFeeDescription": "Para apoiar novos projetos, a TREZU cobre todas as taxas únicas de implantação e armazenamento de rede.",
+        "createButton": "Criar tesouraria",
+        "connectWalletCreate": "Conecte a carteira para criar a tesouraria",
+        "unexpectedError": "Ocorreu um erro inesperado",
+        "creationFailed": "Falha ao criar tesouraria. Por favor, tente novamente.",
+        "stepTitles": {
+            "aboutYou": "Sobre você",
+            "details": "Detalhes",
+            "members": "Membros",
+            "treasuryType": "Tipo de tesouraria",
+            "review": "Revisar"
+        },
+        "steps": {
+            "creatingNear": "Criando sua tesouraria na NEAR",
+            "registeringKey": "Registrando chave pública",
+            "settingUpConfidential": "Configurando transações confidenciais",
+            "configuringMembers": "Configurando membros da tesouraria",
+            "finalizingSetup": "Finalizando configuração"
+        }
+    },
+    "manageTreasuries": {
+        "warningOne": "Pelo menos uma tesouraria deve permanecer disponível",
+        "warningOnePeriod": "Pelo menos uma tesouraria deve permanecer disponível.",
+        "activeHeading": "Tesourarias ativas",
+        "activeDescription": "Tesourarias atualmente visíveis na lista das suas contas.",
+        "activeEmpty": "Nenhuma tesouraria ativa.",
+        "hiddenHeading": "Tesourarias ocultas",
+        "hiddenDescription": "Tesourarias ocultas da lista das suas contas.",
+        "removeGuestTitle": "Remover tesouraria de convidado",
+        "removeDialog": "Você está prestes a remover <bold>{name}</bold>. Após confirmada, esta ação não pode ser desfeita.",
+        "tooltips": {
+            "removeFromList": "Remover da sua lista",
+            "viewTreasury": "Ver tesouraria",
+            "hideFromList": "Ocultar da sua lista",
+            "showInList": "Mostrar na sua lista"
+        }
+    },
+    "wallet": {
+        "proposal": {
+            "transfer": "Proposta de dApp externo: Transferir NEAR para {receiverId}",
+            "functionCall": "Proposta de dApp externo: {methods} em {receiverId}",
+            "unsupportedAction": "Tipo de ação não suportado \"{type}\". Apenas ações Transfer e FunctionCall podem ser convertidas em propostas Trezu."
+        },
+        "loading": "Carregando...",
+        "connectPrompt": "Conecte sua carteira NEAR para continuar. Em seguida, você selecionará uma tesouraria para agir em nome dela.",
+        "connectWallet": "Conectar carteira",
+        "cancel": "Cancelar",
+        "connectedAs": "Conectado como <strong>{account}</strong>",
+        "loadingTreasuries": "Carregando tesourarias...",
+        "selectSignIn": "Selecione uma tesouraria para fazer login como:",
+        "selectSignTx": "Selecione uma tesouraria para criar uma proposta:",
+        "notMember": "Você não é membro de nenhuma tesouraria.",
+        "actingAs": "Agindo como",
+        "signedBy": "Assinado por {account}",
+        "createsNProposals": "Isto criará {count, plural, one {uma proposta Trezu} other {# propostas Trezu}} para:",
+        "proposalDescriptionLabel": "Descrição da proposta (opcional)",
+        "proposalDescriptionPlaceholder": "Descreva esta proposta...",
+        "createProposal": "Criar proposta",
+        "creatingProposal": "Criando proposta...",
+        "confirmInWallet": "Por favor, confirme na sua carteira",
+        "proposalSubmitted": "Proposta enviada",
+        "shareProposal": "Sua proposta foi criada. Compartilhe o link abaixo com os membros da tesouraria para votarem.",
+        "proposalLink": "{daoId} — Proposta nº {id}",
+        "checking": "Verificando...",
+        "proposalApprovedProceed": "A proposta foi aprovada. Continuar",
+        "signedInSuccess": "Login realizado com sucesso",
+        "proposalCreatedSuccess": "Proposta criada com sucesso",
+        "closeWindow": "Você pode fechar esta janela.",
+        "errorGeneric": "Ocorreu um erro",
+        "tryAgain": "Tentar novamente",
+        "errors": {
+            "parseTx": "Falha ao analisar a solicitação de transação. Por favor, tente novamente.",
+            "fetchTreasuries": "Falha ao buscar suas tesourarias. Por favor, tente novamente.",
+            "connectFailed": "Falha ao conectar carteira",
+            "createProposalFailed": "Falha ao criar proposta",
+            "stillPending": "A proposta ainda está pendente de aprovação. Por favor, aguarde os membros da tesouraria votarem.",
+            "wasStatus": "Proposta nº {id} foi {status}",
+            "awaitIndex": "A proposta foi aprovada, mas a transação de execução ainda não foi indexada. Por favor, tente novamente em um momento.",
+            "checkStatusFailed": "Falha ao verificar o status da proposta",
+            "userCancelled": "Usuário cancelou",
+            "proposalWasStatus": "A proposta foi {status}"
+        }
+    },
+    "telegram": {
+        "tagPill": "Telegram",
+        "invalidLinkTitle": "Link inválido",
+        "invalidLinkDescription": "Este link de conexão do Telegram não tem token. Clique novamente em Conectar Tesouraria no Telegram para gerar um link novo.",
+        "successTitle": "Conectado com sucesso",
+        "successDescription": "As tesourarias foram vinculadas a este chat do Telegram.",
+        "successToast": "Tesourarias conectadas com sucesso",
+        "goToApp": "Ir para o app",
+        "linkExpiredTitle": "Link expirado",
+        "linkExpiredDescription": "Este link expirou ou já foi usado. No Telegram, digite o comando abaixo para reiniciar o fluxo de conexão.",
+        "commandCopied": "Comando copiado",
+        "copy": "Copiar",
+        "unableToLoadTitle": "Não foi possível carregar o chat",
+        "unableToLoadDescription": "Os detalhes do chat não puderam ser carregados agora. Por favor, tente novamente pelo Telegram.",
+        "signInTitle": "Faça login para continuar",
+        "signInDescription": "Conecte sua carteira NEAR primeiro e depois escolha quais tesourarias vincular a este chat do Telegram.",
+        "connectWallet": "Conectar carteira",
+        "selectTreasuriesTitle": "Selecionar tesourarias",
+        "selectTreasuriesDescription": "Escolha quais tesourarias conectar a este chat do Telegram.",
+        "telegramChat": "Chat do Telegram",
+        "chatIdFallback": "Chat nº {id}",
+        "failedToConnect": "Falha ao conectar tesourarias. Por favor, tente novamente.",
+        "relinking": "{count, plural, one {# tesouraria selecionada está vinculada a outro chat do Telegram. Conectar fará a reconexão e alterará o link do ID do chat para este chat.} other {# tesourarias selecionadas estão vinculadas a outros chats do Telegram. Conectar fará a reconexão e alterará os links de ID do chat para este chat.}}",
+        "alreadyConnected": "Já conectada a este chat",
+        "connectedToAnother": "Conectada a outro chat",
+        "notMember": "Você não é membro de nenhuma tesouraria.",
+        "connecting": "Conectando…",
+        "connect": "Conectar"
+    },
+    "systemStatus": {
+        "underMaintenance": "Em manutenção",
+        "maintenanceMessage": "Estamos realizando manutenção no momento. Alguns recursos podem ficar temporariamente indisponíveis. Por favor, volte em breve."
+    },
+    "creditsQuota": {
+        "available": "{count} disponíveis",
+        "used": "{count} usados",
+        "resetOn": "O limite será redefinido em {date}"
+    },
+    "approvalInfo": {
+        "infoText": "Votos necessários para aprovar solicitações relacionadas a pagamentos. Editável nas configurações de votação.",
+        "thresholdPill": "Limite {required} de {total}",
+        "alertBody": "Este pagamento exigirá aprovação de <bold>{required}</bold> membros da tesouraria antes da execução."
+    },
+    "guestBadge": {
+        "title": "Convidado",
+        "tooltip": "Você é um convidado desta tesouraria. Você só pode ver os dados."
+    },
+    "exportButton": {
+        "confidentialTooltip": "A exportação ainda não está disponível no modo confidencial. Este recurso está chegando em breve!"
+    },
+    "sponsoredActions": {
+        "titleExhausted": "Ações patrocinadas usadas",
+        "titleAlmost": "Sua equipe está quase sem ações patrocinadas",
+        "closeNotice": "Fechar aviso",
+        "teamUsage": "Uso da equipe: {total} ações por mês",
+        "available": "{count} disponíveis",
+        "used": "{count} usadas",
+        "exhaustedBody": "Sua equipe atingiu o limite mensal de ações patrocinadas. Você pode continuar após {date} ou entre em contato conosco",
+        "almostBody": "A TREZU atualmente patrocina os custos de armazenamento de todas as ações da equipe, como criar solicitações e votar nelas. Sua equipe está perto de atingir o limite mensal patrocinado.",
+        "contactUs": "Fale conosco",
+        "nextMonthlyReset": "sua próxima redefinição mensal",
+        "sidebarBody": "Sua equipe atingiu o limite mensal de ações patrocinadas. Você pode continuar após {date} ou ⬇️"
+    },
+    "acceptTerms": {
+        "title": "Aceite os termos para continuar",
+        "privacyTitle": "Sua privacidade na Trezu",
+        "privacyBody": "A Trezu é uma interface não custodial. Priorizamos sua privacidade ao mesmo tempo em que garantimos que a plataforma permaneça segura e funcional.",
+        "minimalTitle": "Dados mínimos",
+        "minimalBody": "Coletamos informações limitadas, como endereços públicos de carteira, endereços IP e análises de uso, para operar e melhorar a Interface.",
+        "noCustodyTitle": "Sem custódia",
+        "noCustodyBody": "Nunca temos acesso às suas chaves privadas, frases de recuperação ou ativos digitais.",
+        "publicTitle": "Registros públicos",
+        "publicBody": "Lembre-se de que todas as transações em blockchain são inerentemente públicas e não são controladas por nós.",
+        "responsibilityTitle": "Sua responsabilidade",
+        "responsibilityBody": "Você é o único responsável por monitorar a atividade da sua carteira e proteger suas credenciais.",
+        "futureTitle": "Atualizações futuras",
+        "futureBody": "Se você optar por receber notificações futuras (como e-mail ou Telegram), usaremos esses dados apenas para mantê-lo informado.",
+        "agreement": "Eu li e concordo com os <terms>Termos de Serviço</terms> e a <privacy>Política de Privacidade</privacy>",
+        "accepting": "Aceitando...",
+        "continue": "Continuar"
+    },
+    "confidentialBanner": {
+        "label": "Confidencial",
+        "description": "Saldos, atividades e transferências são visíveis apenas para sua equipe — não para a blockchain pública."
+    },
+    "supportCenter": {
+        "title": "Central de suporte",
+        "resources": "Recursos",
+        "support": "Suporte",
+        "websiteTitle": "Site da Trezu",
+        "websiteDescription": "Saiba mais sobre a Trezu e leia nosso blog.",
+        "demo": "Demo da Trezu",
+        "demoTitle": "Explore a versão pública",
+        "demoDescription": "Veja uma conta pública ao vivo em ação.",
+        "confidentialDemoTitle": "Explore a versão confidencial",
+        "confidentialDemoDescription": "Explore uma conta confidencial ao vivo em ação.",
+        "videoTitle": "Assista à demonstração",
+        "videoDescription": "Assista a um vídeo curto mostrando como a Trezu funciona.",
+        "xTitle": "Siga-nos no X",
+        "xDescription": "Mantenha-se atualizado com nossos lançamentos e novidades.",
+        "statsTitle": "Estatísticas",
+        "statsDescription": "Veja o total de ativos sob gestão em todos os DAOs sputnik.",
+        "docsTitle": "Documentação",
+        "docsDescription": "Conheça todos os recursos na documentação.",
+        "productSupportTitle": "Suporte ao produto",
+        "productSupportDescription": "Entre em contato com nossa equipe de suporte para obter ajuda."
+    },
+    "progressModal": {
+        "titleCreating": "Criando tesouraria...",
+        "titleDone": "Tesouraria criada",
+        "titleFailed": "Falha na criação da tesouraria",
+        "viewTreasury": "Ver tesouraria"
+    },
+    "memberValidation": {
+        "noManagePermission": "Você não tem permissão para gerenciar membros",
+        "pendingRequest": "Você não pode gerenciar membros enquanto houver uma solicitação ativa",
+        "rolesAnd": "{first} e {second}",
+        "rolesMany": "{list} e {last}",
+        "cannotRemoveMember": "Não é possível remover este membro. Ele é a única pessoa atribuída à {count, plural, one {função} other {funções}} {roles}.",
+        "cannotRemoveMemberGov": "Não é possível remover este membro. Ele é a única pessoa atribuída à {count, plural, one {função {roles}, que é necessária} other {funções {roles}, que são necessárias}} para gerenciar membros da equipe e configurar a votação.",
+        "cannotBulkRemove": "Não é possível remover estes membros. Isso deixaria a {count, plural, one {função} other {funções}} {roles} vazia.",
+        "cannotBulkRemoveGov": "Não é possível remover estes membros. Isso deixaria a {count, plural, one {função {roles}, que é necessária} other {funções {roles}, que são necessárias}} vazia, necessária para gerenciar membros da equipe e configurar a votação.",
+        "cannotRemoveRole": "Você não pode remover a função {role} deste membro. Ele é a única pessoa atribuída a esta função.",
+        "cannotRemoveRoleGov": "Você não pode remover a função {role} deste membro. Ele é o único membro {role}, e sem esta função você não poderá gerenciar membros da equipe nem configurar a votação."
+    },
+    "roleSelector": {
+        "setRole": "Definir função",
+        "allRoles": "Todas as funções",
+        "roles": {
+            "governance": {
+                "title": "Governança",
+                "description": "A Governança pode criar e votar nas configurações da tesouraria relacionadas à equipe, incluindo membros, permissões e aparência da tesouraria."
+            },
+            "requestor": {
+                "title": "Solicitante",
+                "description": "O Solicitante pode criar solicitações de transação relacionadas a pagamentos, sem direitos de voto ou aprovação."
+            },
+            "financial": {
+                "title": "Financeiro",
+                "description": "O Financeiro pode votar em solicitações de transação relacionadas a pagamentos, mas não pode criá-las."
+            }
+        }
+    },
+    "memberInput": {
+        "creatorYou": "Criador (você)",
+        "memberAddress": "Endereço do membro",
+        "addNewMember": "Adicionar novo membro",
+        "validation": {
+            "rolesRequired": "Pelo menos uma função é obrigatória",
+            "duplicateAddress": "O endereço já é membro"
+        }
+    },
+    "recipientInput": {
+        "title": "Para",
+        "placeholder": "Endereço do destinatário"
+    },
+    "accountInput": {
+        "failedValidation": "Falha ao validar o endereço",
+        "invalidNearFormat": "Formato de conta NEAR inválido",
+        "invalidChainAddress": "Por favor, insira um endereço {chain} válido.",
+        "validating": "Validando endereço...",
+        "validAddress": "Endereço válido",
+        "placeholderWithExample": "Endereço do destinatário (ex.: {example})",
+        "placeholderNoExample": "Endereço do destinatário",
+        "nearExample": "alice.near, 0x... ou hex de 64 caracteres",
+        "near": {
+            "required": "O endereço é obrigatório",
+            "length": "O endereço deve ter entre 2 e 64 caracteres",
+            "missingTld": "Contas nomeadas devem terminar com .near, .aurora ou .tg",
+            "invalidChars": "O endereço só pode conter letras minúsculas, dígitos e separadores (., -, _)",
+            "accountMissing": "A conta não existe na blockchain NEAR",
+            "verifyFailed": "Falha ao verificar a existência da conta"
+        }
+    },
+    "csvUpload": {
+        "uploadFile": "Enviar arquivo",
+        "provideData": "Fornecer dados",
+        "chooseFile": "Escolher arquivo",
+        "orDragDrop": "ou arraste e solte",
+        "maxFileSize": "máx. 1 arquivo de até {maxSize} MB, somente arquivo CSV",
+        "noFilePrompt": "Não tem um arquivo para enviar?",
+        "downloadTemplate": "Baixar um modelo"
+    },
+    "tokenSelect": {
+        "selectToken": "Selecionar token",
+        "searchPlaceholder": "Buscar tokens...",
+        "noTokensFound": "Nenhum token encontrado"
+    },
+    "filterOperations": {
+        "is": "É",
+        "isNot": "Não é",
+        "before": "Antes",
+        "after": "Depois",
+        "between": "Entre",
+        "equal": "Igual",
+        "moreThan": "Mais que",
+        "lessThan": "Menos que",
+        "contains": "Contém"
+    },
+    "copyButton": {
+        "copied": "Copiado para a área de transferência",
+        "failed": "Falha ao copiar"
+    },
+    "recipientForm": {
+        "validation": {
+            "nameRequired": "O nome é obrigatório",
+            "nameMax": "O destinatário deve ter menos de {max} caracteres",
+            "addressRequired": "O endereço é obrigatório",
+            "networksRequired": "Selecione pelo menos uma rede"
+        }
+    },
+    "paymentForm": {
+        "validation": {
+            "recipientMin": "O destinatário deve ter pelo menos 2 caracteres",
+            "recipientMax": "O destinatário deve ter menos de 128 caracteres",
+            "amountGreaterThanZero": "O valor deve ser maior que 0",
+            "recipientSameAsToken": "O destinatário e o endereço do token não podem ser iguais",
+            "selectToken": "Por favor, selecione um token",
+            "recipientMax64": "O destinatário deve ter menos de 64 caracteres",
+            "amountMinLockup": "O valor deve ser maior ou igual a 3,5",
+            "startDateRequired": "A data de início é obrigatória",
+            "endDateRequired": "A data de término é obrigatória",
+            "cliffDateRequired": "A data do cliff é obrigatória",
+            "startBeforeEnd": "A data de início deve ser anterior à data de término",
+            "cliffBetween": "A data do cliff deve estar entre {start} e {end}"
+        }
+    },
+    "exportToasts": {
+        "downloadFailed": "Falha ao baixar a exportação",
+        "invalidDateRange": "Intervalo de datas inválido",
+        "invalidDateRangeDescription": "Por favor, selecione um intervalo de datas válido para a exportação.",
+        "exportSuccess": "Exportação bem-sucedida!",
+        "exportSuccessDescription": "Seu arquivo {type} foi baixado. Verifique seu histórico de exportações para mais detalhes.",
+        "exportFailed": "Exportação falhou",
+        "exportFailedFallback": "Falha ao exportar dados. Por favor, tente novamente.",
+        "noDownloadPermission": "Você não tem permissão para baixar o arquivo.",
+        "noExportPermission": "Você não tem permissão para exportar",
+        "quotaUsed": "Você usou toda a sua cota",
+        "exporting": "Exportando...",
+        "export": "Exportar",
+        "columnSubmissionTime": "Data de envio",
+        "columnDateRange": "Intervalo de datas",
+        "columnGeneratedBy": "Gerado por",
+        "columnStatus": "Status",
+        "typeAll": "Todos os tipos",
+        "typeSent": "Enviadas",
+        "typeReceived": "Recebidas",
+        "typeStakingRewards": "Recompensas de staking",
+        "allAssets": "Todos os ativos",
+        "upgradeTrial": "Faça upgrade do seu plano para obter mais e continuar",
+        "upgradePaid": "Faça upgrade do seu plano para mais acesso ou aguarde até que seus limites sejam redefinidos no próximo mês.",
+        "selectDateRange": "Selecionar intervalo de datas",
+        "noExportsTitle": "Nenhuma exportação ainda",
+        "noExportsDescription": "Seus arquivos exportados do último mês aparecerão aqui assim que forem gerados.",
+        "quotaTitle": "Cota de exportação",
+        "unlimited": "Ilimitado",
+        "creditsPerMonth": "{total} / mês",
+        "requirementsTitle": "Requisitos de exportação",
+        "exportFromPeriod": "Você pode exportar dados do {period}.",
+        "availableFor48Hours": "Os arquivos exportados ficam disponíveis para download por 48 horas.",
+        "moreFlexibility": "Procurando mais flexibilidade?",
+        "contactUs": "Fale conosco",
+        "last1Year": "Último 1 ano",
+        "last2Years": "Últimos 2 anos",
+        "invalidEmail": "Por favor, insira um e-mail válido"
+    },
+    "proposalKinds": {
+        "Batch Payment Request": "Solicitação de pagamento em lote",
+        "Payment Request": "Solicitação de pagamento",
+        "Confidential Request": "Solicitação confidencial",
+        "Exchange": "Troca",
+        "Function Call": "Chamada de função",
+        "Change Policy": "Alterar política",
+        "Update General Settings": "Atualizar configurações gerais",
+        "Earn NEAR": "Ganhar NEAR",
+        "Unstake NEAR": "Desfazer stake de NEAR",
+        "Vesting": "Vesting",
+        "Withdraw Earnings": "Retirar ganhos",
+        "Members": "Membros",
+        "Upgrade": "Atualizar",
+        "Set Staking Contract": "Definir contrato de staking",
+        "Bounty": "Recompensa",
+        "Vote": "Voto",
+        "Factory Info Update": "Atualização de informações da fábrica",
+        "Unsupported": "Não suportado"
+    },
+    "paymentFormSection": {
+        "selectRecipient": "Selecionar destinatário",
+        "searchByNameOrAddress": "Buscar por nome ou endereço",
+        "restrictedRecipientTitle": "Transação não permitida",
+        "restrictedRecipientMessage": "Este endereço está atualmente restrito devido a verificações de segurança. Se você acredita que este endereço deve ser permitido, pode <link>solicitar a inclusão na lista de permissões</link>.",
+        "send": "Enviar",
+        "to": "Para"
+    },
+    "recipientNetworkSelect": {
+        "label": "Rede do destinatário",
+        "placeholder": "Selecionar rede do destinatário",
+        "enterAddressFirst": "Insira primeiro o endereço do destinatário",
+        "noCompatibleNetwork": "Nenhuma rede corresponde a este endereço",
+        "selectPlaceholder": "Selecionar rede",
+        "title": "Selecionar rede",
+        "available": "Disponível",
+        "fromAddressBook": "Do catálogo de endereços",
+        "otherAvailable": "Outras disponíveis",
+        "incompatible": "Incompatível",
+        "comingSoon": "Em breve",
+        "nearComName": "near.com",
+        "nearComDescription": "Rede interna para near.com e trezu"
+    },
+    "addressBookTable": {
+        "emptyTitle": "Nenhum destinatário ainda",
+        "emptyDescription": "Adicione destinatários a este catálogo de endereços para pagamentos mais rápidos.",
+        "selectAll": "Selecionar todos os destinatários",
+        "selectEntry": "Selecionar {name}",
+        "recipient": "Destinatário",
+        "network": "Rede",
+        "addedBy": "Adicionado por",
+        "note": "Nota",
+        "added": "Adicionado",
+        "remove": "Remover",
+        "send": "Enviar"
+    },
+    "publicDashboard": {
+        "updatesDaily": "Atualiza diariamente",
+        "noDataTitle": "Sem dados ainda",
+        "noDataDescription": "As estatísticas aparecerão após o primeiro snapshot diário ser computado.",
+        "assetsSecured": "Ativos protegidos com o contrato Sputnik DAO",
+        "acrossDaos": "Em <bold>{count, plural, one {# DAO} other {# DAOs}}</bold>",
+        "updatedOn": "Atualizado em {date}",
+        "topAssets": "Top 20 ativos",
+        "noAssetsTitle": "Nenhum ativo ainda",
+        "noAssetsDescription": "Os dados de tokens aparecerão assim que o snapshot diário for computado.",
+        "tableToken": "Token",
+        "tableTotalValue": "Valor total"
+    },
+    "telegramConnectInstructions": {
+        "title": "Conectar Telegram",
+        "subtitle": "Receba notificações sobre propostas e atividades no seu Telegram.",
+        "step3": "Pressione Iniciar e siga as instruções.",
+        "success": "Tudo pronto!",
+        "copyBotTooltip": "Copiar handle do bot",
+        "botCopiedToast": "Handle do bot copiado",
+        "openInTelegram": "Abrir {bot} no Telegram"
+    },
+    "transactionHashCell": {
+        "copyHash": "Copiar hash",
+        "hashCopied": "Hash copiado",
+        "openInExplorer": "Abrir no explorador"
+    },
+    "treasurySelector": {
+        "select": "Selecionar tesouraria",
+        "connectWalletTooltip": "Conecte a carteira para ver as tesourarias",
+        "manageTreasuries": "Gerenciar tesourarias",
+        "createTreasury": "Criar tesouraria",
+        "memberOf": "Membro de",
+        "guestTreasuries": "Tesourarias de convidado"
+    },
+    "selectModal": {
+        "searchByName": "Buscar por nome",
+        "noResults": "Nenhum resultado encontrado"
+    },
+    "selectList": {
+        "noResults": "Nenhum resultado encontrado"
+    },
+    "datePicker": {
+        "pickDate": "Escolher uma data",
+        "timezone": "Fuso horário"
+    },
+    "datePresets": {
+        "today": "Hoje",
+        "yesterday": "Ontem",
+        "last3Days": "Últimos 3 dias",
+        "last7Days": "Últimos 7 dias",
+        "last14Days": "Últimos 14 dias",
+        "lastMonth": "Último mês",
+        "last3Months": "Últimos 3 meses",
+        "last6Months": "Últimos 6 meses"
+    },
+    "input": {
+        "openSearch": "Abrir busca"
+    },
+    "pagination": {
+        "previous": "Anterior",
+        "next": "Próximo"
+    },
+    "confidentialState": {
+        "title": "Confidencial",
+        "description": "Apenas membros da tesouraria têm acesso."
+    },
+    "exchangeRate": {
+        "rate": "Taxa",
+        "clickToReverse": "Clique para inverter a taxa"
+    },
+    "exchangeSettings": {
+        "title": "Configurações de troca",
+        "slippageTolerance": "Tolerância de slippage",
+        "custom": "Personalizado",
+        "customPlaceholder": "ex: 2%",
+        "slippageRange": "O slippage deve estar entre 0,01% e 100%",
+        "enterSlippage": "Por favor, insira uma tolerância de slippage",
+        "slippageHelp": "Se o preço mudar mais que esta porcentagem, a transação será cancelada para proteger seus fundos.",
+        "save": "Salvar"
+    },
+    "assetsPage": {
+        "title": "Ativos",
+        "noAssetsTitle": "Nenhum ativo ainda",
+        "noAssetsDescription": "Para começar, adicione ativos à sua tesouraria fazendo um depósito."
+    },
+    "newBadge": {
+        "label": "Novo"
+    },
+    "numberBadge": {
+        "pendingRequests": "{count, plural, one {# solicitação pendente} other {# solicitações pendentes}}"
+    },
+    "balanceWithGraph": {
+        "allTokens": "Todos os tokens",
+        "deposit": "Depositar",
+        "send": "Enviar",
+        "exchange": "Trocar",
+        "chartNow": "Agora",
+        "totalBalance": "Saldo total",
+        "excludedTokens": "Tokens excluídos:",
+        "noPriceHistory": "Sem histórico de preços. Selecione um token para ver as variações de saldo dele.",
+        "bucketAvailable": "Disponível",
+        "bucketLocked": "Bloqueado",
+        "bucketEarning": "Rendendo",
+        "period": {
+            "1W": "1S",
+            "1M": "1M",
+            "3M": "3M",
+            "1Y": "1A"
+        }
+    },
+    "changePolicyExpanded": {
+        "proposalBond": "Bond da proposta",
+        "proposalPeriod": "Período da proposta",
+        "bountyBond": "Bond da recompensa",
+        "bountyForgivenessPeriod": "Período de perdão da recompensa",
+        "votesCount": "{count} votos",
+        "weightKind": "Tipo de peso",
+        "quorum": "Quórum",
+        "threshold": "Limite",
+        "defaultThreshold": "Limite padrão",
+        "roleThreshold": "Limite de {role}",
+        "member": "Membro",
+        "members": "Membros",
+        "permissions": "Permissões",
+        "oldPermissions": "Permissões antigas",
+        "newPermissions": "Novas permissões",
+        "category": "Categoria",
+        "transactionDetails": "Detalhes da transação",
+        "addNewMember": "Adicionar novo membro",
+        "addNewMembers": "Adicionar novos membros",
+        "removeMember": "Remover membro",
+        "removeMembers": "Remover membros",
+        "updateMemberPermissions": "Atualizar permissões do membro",
+        "updateMembersPermissions": "Atualizar permissões dos membros",
+        "memberIndex": "Membro {index}",
+        "membersCount": "{count} membros",
+        "collapseAll": "Recolher tudo",
+        "expandAll": "Expandir tudo",
+        "loadingHistorical": "Carregando política histórica...",
+        "unableToDiff": "Não é possível calcular as diferenças para esta proposta.",
+        "noChangesCurrent": "Nenhuma alteração detectada — a política proposta é idêntica à política atual.",
+        "noChangesHistorical": "Nenhuma alteração detectada — a política proposta é idêntica à política histórica."
+    },
+    "balanceChart": {
+        "usdValue": "Valor em USD",
+        "tokenBalance": "Saldo do token",
+        "emptyTitle": "Nada para mostrar ainda",
+        "emptyDescription": "Adicione ativos para começar a acompanhar seu portfólio."
+    },
+    "user": {
+        "saveToAddressBook": "Salvar no catálogo de endereços",
+        "walletCopiedToast": "Endereço da carteira copiado para a área de transferência",
+        "copyWalletAddress": "Copiar endereço da carteira"
+    },
+    "infoDisplay": {
+        "viewLess": "Ver menos",
+        "viewAllDetails": "Ver todos os detalhes"
+    },
+    "amountSummary": {
+        "defaultTitle": "Você está enviando um total de"
+    },
+    "residency": {
+        "vestedToken": "Token liberado",
+        "staked": "Em staking",
+        "fungibleToken": "Token fungível",
+        "intentsToken": "Token de Intents",
+        "nativeToken": "Token nativo"
+    },
+    "exchangeErrors": {
+        "noRoute": "Nenhuma troca encontrada. Tente um valor menor ou um token diferente.",
+        "amountTooLow": "Valor muito baixo para o swap. Swaps multichain exigem um mínimo maior para cobrir as taxas de rede.",
+        "insufficientBalance": "Saldo insuficiente para este swap.",
+        "networkError": "Erro de rede. Por favor, verifique sua conexão e tente novamente.",
+        "fetchFailed": "Falha ao obter cotação"
+    },
+    "tokenSelectDialog": {
+        "selectToken": "Selecionar token",
+        "selectAsset": "Selecionar ativo",
+        "selectNetworkFor": "Selecionar rede para {asset}",
+        "searchByName": "Buscar por nome",
+        "noTokensWithBalance": "Nenhum token com saldo encontrado",
+        "noTokensFound": "Nenhum token encontrado",
+        "yourAssets": "Seus ativos",
+        "otherAssets": "Outros ativos",
+        "networksWithAssets": "Redes com ativos",
+        "supportedNetworks": "Redes suportadas",
+        "comingSoon": "Em breve"
+    },
+    "intentsQuote": {
+        "initializing": "O serviço de cotação ainda está inicializando. Por favor, tente novamente.",
+        "noRoute": "Não foi possível preparar uma rota de pagamento agora. Por favor, tente novamente.",
+        "fetchFailed": "Não foi possível preparar uma rota de pagamento agora. Por favor, tente novamente.",
+        "amountTooLow": "O valor é muito baixo para cobrir as taxas de rede. Insira um valor maior e tente novamente.",
+        "amountTooLowWithMin": "O valor é muito baixo para cobrir as taxas de rede. Insira pelo menos {min} {token}.",
+        "networkFeeTooltip": "Esta taxa é usada para processar a transação na chain selecionada."
+    },
+    "pageTours": {
+        "paymentsBulk": "A criação em massa chegou! Crie várias solicitações em apenas alguns passos.",
+        "paymentsPending": "Veja aqui as solicitações que aguardam aprovação.",
+        "exchangeSettings": "Aqui você pode definir quanta variação de preço está disposto a aceitar.",
+        "membersPending": "Clique para ver solicitações ativas aguardando aprovação.",
+        "guestSaveIntro": "Você é um convidado desta tesouraria. Você só pode ver os dados.",
+        "guestSaveAction": "Você pode salvar esta tesouraria de convidado na sua lista de tesourarias.",
+        "newFeatureRich": "Novo! 🎉 Salve endereços usados com frequência para pagamentos mais rápidos e sem erros.<br></br> Seus contatos permanecem privados e visíveis apenas para sua equipe.",
+        "newFeatureCta": "Experimente"
+    },
+    "statusDate": {
+        "expires": "Expira",
+        "created": "Criada",
+        "expired": "Expirou",
+        "removed": "Removida"
+    },
+    "relativeTime": {
+        "justNow": "Agora mesmo",
+        "moments": "instantes"
+    },
+    "amount": {
+        "network": "Rede: {network}"
+    },
+    "activityLabels": {
+        "exchangePending": "Troca pendente",
+        "exchangeRequest": "Solicitação de troca",
+        "exchangeFulfillment": "Conclusão da troca",
+        "stakingRewards": "Recompensas de staking",
+        "proposalAction": "Ação da proposta",
+        "deposit": "Depósito de {symbol}",
+        "paymentSent": "Pagamento enviado",
+        "transaction": "Transação",
+        "fallbackToken": "Token",
+        "viaIntents": "via NEAR Intents",
+        "from": "de {account}",
+        "to": "para {account}",
+        "viewAll": "Ver todo o seu histórico de transações",
+        "sentReceived": "Transações enviadas e recebidas ({duration})",
+        "unlimitedHistory": "histórico ilimitado",
+        "oneYear": "1 ano",
+        "yearsCount": "{count} anos",
+        "monthsCount": "{count} meses",
+        "lastDuration": "últimos {duration}"
+    },
+    "nearStore": {
+        "connectAndAcceptTerms": "Por favor, conecte a carteira e aceite os termos para continuar.",
+        "transactionNotApproved": "A transação não foi aprovada na sua carteira.",
+        "failedSubmitVote": "Falha ao enviar voto",
+        "failedSubmitVotes": "Falha ao enviar votos",
+        "viewRequest": "Ver solicitação",
+        "proposalRemoved": "Sua proposta foi removida",
+        "voteSubmitted": "Seu voto foi enviado",
+        "votesSubmitted": "Seus votos foram enviados"
+    },
+    "tokenInput": {
+        "max": "MAX",
+        "insufficientTokens": "Tokens insuficientes. Você pode enviar a solicitação e completar o saldo antes da aprovação.",
+        "balance": "Saldo: {amount} {symbol}"
+    },
+    "createRequestButton": {
+        "idle": "Criar solicitação",
+        "noPermission": "Você não tem permissão para criar uma solicitação"
+    },
+    "address": {
+        "copied": "Endereço copiado para a área de transferência"
+    },
+    "memberAvatars": {
+        "membersWhoCanVote": "Membros que podem votar",
+        "moreMembers": "+{count, plural, one {# membro} other {# membros}}"
+    },
+    "accountIdInput": {
+        "minLength": "O ID da conta deve ter pelo menos 2 caracteres",
+        "maxLength": "O ID da conta deve ter menos de 64 caracteres",
+        "charset": "O ID da conta deve conter apenas letras minúsculas, dígitos, pontos, hifens e underscores, sem separadores no início ou no final",
+        "doesNotExist": "O ID da conta não existe"
+    },
+    "addressBookMutations": {
+        "addedToast": "{count, plural, one {Destinatário adicionado} other {# destinatários adicionados}}",
+        "addedSingleToast": "Destinatário adicionado",
+        "addFailedToast": "Falha ao adicionar destinatários",
+        "addSingleFailedToast": "Falha ao adicionar destinatário",
+        "removedToast": "{count, plural, one {Destinatário removido} other {# destinatários removidos}}",
+        "removeFailedToast": "Falha ao remover destinatários",
+        "exportFailedToast": "Falha ao exportar destinatários"
+    },
+    "treasuryMutations": {
+        "savedToast": "Tesouraria salva na sua lista",
+        "saveFailedToast": "Falha ao salvar tesouraria",
+        "hiddenToast": "Tesouraria oculta da lista",
+        "hideFailedToast": "Falha ao ocultar tesouraria",
+        "unhiddenToast": "Tesouraria visível novamente",
+        "unhideFailedToast": "Falha ao reexibir tesouraria",
+        "removedToast": "Tesouraria removida da lista de salvas",
+        "removeFailedToast": "Falha ao remover tesouraria da lista de salvas"
+    },
+    "telegramSettings": {
+        "title": "Telegram",
+        "connectedTo": "Conectado a {chat}",
+        "chatNumber": "Chat nº {id}",
+        "fallbackChat": "um chat do Telegram",
+        "disconnect": "Desconectar",
+        "connect": "Conectar",
+        "connectDescription": "Vincule sua tesouraria a um chat do Telegram para receber notificações.",
+        "noTreasuryDescription": "Vincule suas tesourarias a um chat do Telegram.",
+        "openSettingsHint": "Abra as configurações em uma tesouraria para gerenciar integrações.",
+        "disconnectedToast": "Telegram desconectado para esta tesouraria",
+        "disconnectFailedToast": "Não foi possível desconectar o Telegram. Tente novamente."
+    },
+    "assetsTable": {
+        "noAssetsFound": "Nenhum ativo encontrado.",
+        "assetDetails": "Detalhes do ativo",
+        "coinPrice": "Preço da moeda",
+        "weight": "Peso",
+        "balance": "Saldo",
+        "lockedBalance": "Saldo bloqueado",
+        "totalBalance": "Saldo total",
+        "source": "Origem",
+        "balanceByInvestors": "Saldo por {count, plural, one {investidor} other {investidores}}",
+        "investors": "{count, plural, one {Investidor} other {Investidores}}",
+        "poolBreakdown": "Detalhamento do pool",
+        "unlockedToken": "Token desbloqueado",
+        "lockupStakingPool": "Pool de staking de lockup",
+        "exchange": "Trocar",
+        "send": "Enviar",
+        "details": "Detalhes",
+        "columnToken": "Token",
+        "columnLocked": "Bloqueado",
+        "columnUnlocked": "Desbloqueado",
+        "columnTotalAllocated": "Total alocado",
+        "columnAvailableToWithdraw": "Disponível para retirada",
+        "viewAvailable": "Disponível",
+        "viewLocked": "Bloqueado",
+        "viewEarning": "Rendendo",
+        "fullAllocatedBalance": "Seu saldo alocado total",
+        "partAllocatedBalance": "Parte do seu saldo alocado",
+        "currentlyEarning": "({amount} {symbol}) está rendendo no momento.",
+        "willAppearHere": " Aparecerá aqui assim que você parar de render.",
+        "seeInEarningTab": "Ver na aba Rendimentos",
+        "seeInEarning": "Ver em Rendimentos"
+    },
+    "earningDetails": {
+        "title": "Detalhes dos rendimentos",
+        "totalStaked": "Total em staking",
+        "earningOverview": "Visão geral dos rendimentos",
+        "poolBreakdown": "Detalhamento do pool ({count, plural, one {# pool} other {# pools}})",
+        "almostReady": "Os rendimentos estão quase prontos!",
+        "finalizingFeature": "Estamos finalizando este recurso<br></br>para que você possa começar a render tokens em breve.",
+        "comingSoon": "Em breve",
+        "goToEarn": "Ir para Ganhar",
+        "readyToWithdraw": "Pronto para retirada",
+        "unstaking": "Desfazendo stake",
+        "overview": {
+            "staked": "Em staking",
+            "stakedInfo": "Tokens atualmente delegados a validadores rendendo recompensas.",
+            "pendingRelease": "Liberação pendente",
+            "pendingReleaseInfo": "Tokens que tiveram o stake desfeito mas ainda estão no período de unbonding (geralmente 2-3 dias).",
+            "availableForWithdraw": "Disponível para retirada",
+            "availableForWithdrawInfo": "Tokens com stake desfeito que concluíram o período de unbonding e podem ser retirados."
+        }
+    },
+    "lockupDetails": {
+        "title": "Detalhes do lockup",
+        "balance": "Saldo",
+        "reservedForStorage": "Reservado para armazenamento",
+        "reservedForStorageInfo": "NEAR reservado pela conta de lockup para pagar os custos de armazenamento.",
+        "tokenBreakdown": "Detalhamento do token",
+        "allocatedAmount": "Valor alocado",
+        "earned": "Ganho",
+        "progress": "Progresso",
+        "unlocked": "Desbloqueado",
+        "locked": "Bloqueado",
+        "schedule": "Cronograma",
+        "startDate": "Data de início",
+        "endDate": "Data de término",
+        "rounds": "Rodadas",
+        "releaseInterval": "Intervalo de liberação",
+        "nextUnlockDate": "Próxima data de desbloqueio",
+        "allEarning": "Todos os {amount} {symbol} do seu lockup estão rendendo no momento.",
+        "partEarning": "Parte do seu lockup ({amount} {symbol}) está rendendo no momento.",
+        "stopEarningFirst": "Para usar tokens desbloqueados, pare de render primeiro e retire-os.",
+        "howGrantWorks": "Como sua concessão funciona",
+        "ftStep1": "Você recebe uma concessão por um período específico. Em vez de obter o valor total de uma vez, os ativos ficam disponíveis em partes ao longo do tempo.",
+        "ftStep2": "Quando chega a data da próxima liberação, essa parcela de tokens é automaticamente desbloqueada e movida para o saldo da sua tesouraria.",
+        "ftStep3": "Assim que aparecem no seu saldo, você pode usá-los imediatamente para pagamentos, transferências ou outras transações.",
+        "nearStep1": "Você recebe uma concessão por um período definido com data de início e término definidas.",
+        "nearStep2": "À medida que os tokens são desbloqueados, eles ficam automaticamente disponíveis no saldo da sua tesouraria.",
+        "nearStep3": "Você pode usar os tokens desbloqueados imediatamente para pagamentos, transferências ou outras transações.",
+        "notAvailable": "N/D",
+        "everyMonth": "Todo mês",
+        "everyQuarter": "Todo trimestre",
+        "everyUnit": "A cada {unit}",
+        "everyMultiple": "A cada {text}",
+        "completed": "Concluído",
+        "unit": {
+            "year": "{count, plural, one {# ano} other {# anos}}",
+            "day": "{count, plural, one {# dia} other {# dias}}",
+            "hour": "{count, plural, one {# hora} other {# horas}}",
+            "minute": "{count, plural, one {# minuto} other {# minutos}}",
+            "second": "{count, plural, one {# segundo} other {# segundos}}"
+        }
+    },
+    "vestingDetails": {
+        "title": "Detalhes do vesting",
+        "availableToUse": "Disponível para uso",
+        "vestingPeriod": "Período de vesting",
+        "vestingPeriodDescription": "Os tokens são desbloqueados diariamente durante este período.",
+        "startDate": "Data de início",
+        "endDate": "Data de término",
+        "tokenBreakdown": "Detalhamento do token",
+        "originalVestedAmount": "Valor original com vesting",
+        "reservedForStorage": "Reservado para armazenamento",
+        "reservedForStorageInfo": "Uma pequena quantidade de tokens necessária para manter o vesting ativo e cobrir os custos de armazenamento.",
+        "percentVested": "{percent}% liberado",
+        "vestedOf": "{vested} de {total} {symbol}",
+        "send": "Enviar"
+    },
+    "earningPoolDetails": {
+        "balance": "Saldo",
+        "apy": "APY",
+        "fee": "Taxa",
+        "notAvailable": "N/D",
+        "lockupStakingPool": "Pool de staking de lockup",
+        "lockupAssetsNote": "Todos os ativos nesta posição são do seu lockup. Após você parar de render, alguns tokens ainda podem ficar bloqueados e indisponíveis — verifique seu cronograma de lockup para ver quando eles são desbloqueados."
+    },
+    "onboardingQuestions": {
+        "stepTitle": "Algumas perguntas rápidas para começar.",
+        "other": "Outro",
+        "placeholders": {
+            "describeRole": "Descreva sua função (opcional)",
+            "describeUseCase": "Descreva seu caso de uso (opcional)",
+            "networkName": "Insira o nome da rede (opcional)",
+            "currentChallenge": "Insira seu desafio atual (opcional)",
+            "describeOther": "Descreva outro (opcional)"
+        },
+        "questions": {
+            "role": "O que melhor descreve sua função?",
+            "useCases": "Para que você planeja usar a Trezu?",
+            "teamSize": "Quantas pessoas vão gerenciar a tesouraria?",
+            "networks": "Quais redes você usa com mais frequência?",
+            "multisigExperience": "Qual é sua experiência com multisig?",
+            "currentTools": "Quais ferramentas você usa atualmente para gerenciar finanças?",
+            "monthlyVolume": "Volume mensal aproximado de transações?",
+            "biggestChallenges": "Qual é seu maior desafio no momento?"
+        },
+        "options": {
+            "role": {
+                "founder": "Fundador",
+                "co-founder": "Cofundador",
+                "cfo-finance-lead": "CFO / Líder financeiro",
+                "operations-manager": "Gerente de operações",
+                "treasury-manager": "Gerente de tesouraria",
+                "other": "Outro"
+            },
+            "useCases": {
+                "team-payroll-grants": "Folha de pagamento e concessões da equipe",
+                "company-assets-management": "Gestão de ativos da empresa",
+                "dao-treasury-management": "Gestão de tesouraria de DAO",
+                "investment-portfolio": "Portfólio de investimentos",
+                "operational-spending": "Gastos operacionais",
+                "other": "Outro"
+            },
+            "teamSize": {
+                "just-me": "Apenas eu",
+                "2-5-people": "2-5 pessoas",
+                "6-15-people": "6-15 pessoas",
+                "15-plus-people": "15+"
+            },
+            "networks": {
+                "near": "NEAR",
+                "bitcoin": "Bitcoin",
+                "ethereum": "Ethereum",
+                "solana": "Solana",
+                "arbitrum": "Arbitrum",
+                "base": "Base",
+                "optimism": "Optimism",
+                "polygon": "Polygon",
+                "gnosis": "Gnosis",
+                "avalanche": "Avalanche",
+                "bnb-chain": "BNB Chain",
+                "other": "Outro"
+            },
+            "multisigExperience": {
+                "never-heard-of-it": "Nunca ouvi falar",
+                "heard-about-it": "Já ouvi falar",
+                "never-used-it": "Nunca usei",
+                "used-gnosis-safe-or-similar": "Usei Gnosis Safe ou similar",
+                "experienced": "Experiente",
+                "looking-for-a-better-option": "Procurando uma opção melhor"
+            },
+            "currentTools": {
+                "gnosis-safe": "Gnosis Safe",
+                "fireblocks": "Fireblocks",
+                "tholos": "Tholos",
+                "squads-multisig": "Squads Multisig",
+                "mpc-vault": "MPC Vault",
+                "other": "Outro"
+            },
+            "monthlyVolume": {
+                "under-10k": "Menos de US$ 10 mil",
+                "10k-100k": "US$ 10 mil - US$ 100 mil",
+                "100k-1m": "US$ 100 mil - US$ 1 milhão",
+                "1m-plus": "US$ 1 milhão+"
+            },
+            "biggestChallenges": {
+                "slow-approvals-and-signing": "Aprovações e assinaturas lentas",
+                "lack-of-transparency-in-the-team": "Falta de transparência na equipe",
+                "hard-to-track-spending-and-balances": "Difícil acompanhar gastos e saldos",
+                "security-and-access-control": "Segurança e controle de acesso",
+                "no-good-web3-tool-yet": "Ainda não há uma boa ferramenta Web3",
+                "looking-for-crypto-earnings": "Estou em busca de rendimentos em cripto",
+                "other": "Outro"
+            }
+        }
+    },
+    "onboarding": {
+        "tour": {
+            "addAssets": "Adicione ativos à sua tesouraria fazendo um depósito.",
+            "makeRequests": "Faça solicitações de pagamento sempre que precisar enviar ativos.",
+            "exchangeAssets": "Aqui você pode trocar seus ativos.",
+            "addMembers": "Adicione membros à sua tesouraria e atribua funções a eles.",
+            "newTreasury": "Quer configurar uma nova tesouraria? Você pode fazer isso aqui em apenas alguns cliques.",
+            "helpSupport": "Obtenha ajuda e suporte sempre que precisar."
+        },
+        "tourCard": {
+            "close": "Fechar",
+            "stepProgress": "{current} de {total}",
+            "gotIt": "Entendi",
+            "done": "Concluído",
+            "next": "Próximo"
+        },
+        "progress": {
+            "title": "Siga passos rápidos para explorar a tesouraria",
+            "createTreasuryTitle": "Criar conta da tesouraria",
+            "createTreasuryDescription": "Você configurou sua conta com sucesso. Ótimo começo!",
+            "addAssetsTitle": "Adicione seus ativos",
+            "addAssetsDescription": "Comece adicionando ativos para vê-los em ação.",
+            "deposit": "Depositar",
+            "createPaymentTitle": "Crie uma solicitação de pagamento",
+            "createPaymentDescription": "Crie uma solicitação de pagamento para concluir sua configuração.",
+            "send": "Enviar"
+        },
+        "welcome": {
+            "heading": "🎉 Bem-vindo!",
+            "subheading": "Faça um tour rápido pela tesouraria",
+            "body": "Olá! Sua Trezu está pronta — comece a construir seu portfólio adicionando ativos das redes suportadas.",
+            "progress": "{current} de {total}",
+            "next": "Próximo",
+            "body2": "Veja como fazer um depósito, criar uma solicitação e configurar uma nova conta.",
+            "noThanks": "Não, obrigado",
+            "letsGo": "Vamos lá"
+        },
+        "congrats": {
+            "heading": "🎉 Parabéns!",
+            "body": "Você concluiu a configuração da sua tesouraria. Aproveite a gestão fácil dos seus ativos.",
+            "letsGo": "Vamos lá!"
+        },
+        "createBanner": {
+            "close": "Fechar",
+            "title": "Explore a Trezu",
+            "description": "Crie uma conta para desbloquear permissões a todos os recursos e benefícios da Trezu.",
+            "cta": "Criar tesouraria"
+        },
+        "questionnaire": {
+            "continue": "Continuar",
+            "skip": "Pular"
+        },
+        "createPrompt": {
+            "title": "Você está quase pronto",
+            "description": "Sua carteira está conectada, mas você ainda não criou uma tesouraria. Crie uma conta para começar a usar a Trezu, ou {suffix}",
+            "suffixDemo": "veja a demonstração.",
+            "suffixExploring": "continue explorando.",
+            "createCta": "Criar uma tesouraria",
+            "viewDemo": "Ver demonstração",
+            "keepExploring": "Continuar explorando"
+        },
+        "infoBox": {
+            "title": "Aproveite mais a Trezu",
+            "close": "Fechar",
+            "description": "Descubra como outros usam a tesouraria, experimente a demonstração e confira a documentação para conhecer os recursos.",
+            "demoTitle": "Explore a demonstração da Trezu",
+            "demoDescription": "Veja uma conta de demonstração ao vivo em ação.",
+            "docsTitle": "Documentação",
+            "docsDescription": "Conheça todos os recursos na documentação.",
+            "videoTitle": "Assista à demonstração",
+            "videoDescription": "Assista a um vídeo curto mostrando como a Trezu funciona."
+        }
+    }
+}

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -1,0 +1,2101 @@
+{
+    "common": {
+        "loading": "Yükleniyor...",
+        "notAvailable": "Yok",
+        "connecting": "Bağlanıyor...",
+        "save": "Kaydet",
+        "cancel": "İptal",
+        "submit": "Gönder",
+        "close": "Kapat",
+        "back": "Geri",
+        "seeDemo": "Demo Trezu'yu Görüntüle",
+        "search": "Ara",
+        "filter": "Filtrele",
+        "filterActive": "Filtre (aktif)",
+        "export": "Dışa Aktar",
+        "exporting": "Dışa Aktarılıyor",
+        "import": "İçe Aktar",
+        "remove": "Kaldır",
+        "removing": "Kaldırılıyor...",
+        "edit": "Düzenle",
+        "continue": "Devam Et",
+        "select": "Seç",
+        "all": "Tümü",
+        "none": "Yok",
+        "retry": "Yeniden Dene",
+        "tryAgain": "Lütfen tekrar deneyin.",
+        "confirm": "Onayla",
+        "next": "İleri",
+        "previous": "Geri",
+        "yes": "Evet",
+        "no": "Hayır",
+        "approve": "Onayla",
+        "reject": "Reddet",
+        "copy": "Kopyala",
+        "copied": "Kopyalandı",
+        "viewAll": "Tümünü Görüntüle",
+        "viewDetails": "Ayrıntıları görüntüle",
+        "noResults": "Sonuç bulunamadı",
+        "add": "Ekle"
+    },
+    "languageSwitcher": {
+        "label": "Dil",
+        "select": "Dil seçin",
+        "english": "English",
+        "spanish": "Español",
+        "ukrainian": "Українська",
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
+    },
+    "header": {
+        "toggleSidebar": "Kenar çubuğunu aç/kapat",
+        "toggleTheme": "Temayı değiştir"
+    },
+    "nav": {
+        "dashboard": "Panel",
+        "requests": "Talepler",
+        "payments": "Ödemeler",
+        "exchange": "Takas",
+        "addressBook": "Adres Defteri",
+        "members": "Üyeler",
+        "settings": "Ayarlar",
+        "helpSupport": "Yardım ve Destek",
+        "saveGuestTreasury": "Bu misafir hazinesini hazinelerinize kaydedin."
+    },
+    "signIn": {
+        "connect": "Bağlan",
+        "connectWallet": "Cüzdan Bağla",
+        "wallet": "Cüzdan",
+        "termsOfService": "Hizmet Şartları",
+        "privacyPolicy": "Gizlilik Politikası",
+        "disconnect": "Bağlantıyı Kes"
+    },
+    "auth": {
+        "noWallet": "Cüzdanınızı bağlayın",
+        "noPermission": "Bu işlemi gerçekleştirme izniniz yok",
+        "noVote": "Bu öneri için zaten oy kullandınız",
+        "noSponsoredTransactions": "Sponsorlu işlem kalmadı"
+    },
+    "landing": {
+        "welcome": "Trezu'ya Hoş Geldiniz",
+        "chooseOption": "Başlamak için aşağıdaki seçeneklerden birini seçin.",
+        "newUserTitle": "Trezu'da yeniyim",
+        "newUserDescription": "Trezu'yu duydum ama henüz bir hazinem yok.",
+        "existingUserTitle": "Trezu'yu zaten kullanıyorum",
+        "existingUserDescription": "Bir hesabım var ve bir hazineyi yönetiyorum.",
+        "gradientTagline": "Dijital varlıkların yönetimi için zincirler arası multisig güvenlik",
+        "waitlistTitle": "Trezu Bekleme Listesine Katılın",
+        "waitlistSubmittedTitle": "Listedesiniz 🎉",
+        "waitlistSubmittedDescription": "Teşekkürler! Hazine oluşturma kullanılabilir hale geldiğinde sizi haberdar edeceğiz.",
+        "waitlistDescription": "Bugünkü hazine limitine ulaştık. Endişelenmeyin - daha sonra tekrar deneyin veya bekleme listesine katılmak için iletişim bilgilerinizi bırakın. Bir yer açıldığında size bildireceğiz.",
+        "waitlistInputPlaceholder": "E-posta adresi veya Telegram (örn. @kullaniciadi)",
+        "waitlistPrivacyNote": "Bunu yalnızca size haber vermek için kullanacağız",
+        "waitlistSubmit": "Bekleme Listesine Katıl",
+        "waitlistSubmitFailed": "Gönderilemedi. Lütfen tekrar deneyin.",
+        "welcomeAlt": "hoş geldiniz"
+    },
+    "blocked": {
+        "title": "Hizmet ülkenizde kullanılamıyor",
+        "description": "Kısıtlamalar nedeniyle bu hizmet şu anda bölgenizde kullanılamamaktadır."
+    },
+    "notFound": {
+        "title": "Hay aksi, bu sayfa kaybolmuş...",
+        "description": "Görünüşe göre artık çalışmayan bir bağlantıyı takip ettiniz. Geri dönmeyi veya Panel'e dönmeyi deneyin.",
+        "backToDashboard": "Panel'e Dön"
+    },
+    "treasuryInfo": {
+        "logoAlt": "Hazine Logosu"
+    },
+    "dateInput": {
+        "placeholder": "gg.aa.yyyy"
+    },
+    "thresholdSlider": {
+        "warningSingleMember": "{memberCount} üyeden 1'lik bir eşik, herhangi bir üyenin tek başına işlem gerçekleştirebileceği anlamına gelir. Bu güvenliği azaltır.",
+        "infoBalanced": "{memberCount} üyeden {currentThreshold}'lik bir eşik, güvenlik ile operasyonel esneklik arasında iyi bir denge sağlar."
+    },
+    "intentsFee": {
+        "amountTooLowForFee": "{prefix}Miktar ağ ücreti için çok düşük ({fee} {symbol}). En az {addMore} {symbol} ekleyin."
+    },
+    "metadata": {
+        "treasuryTitle": "Panel | Trezu",
+        "landingTitle": "Trezu | Zincirler Arası Hazine Yönetimi",
+        "description": "Anahtarlarınızı asla teslim etmeden, tek bir panelden ekibinizin sermayesini dakikalar içinde yönetin.",
+        "ogTitle": "Trezu | Tek multisig. Her kripto. Tam kontrol."
+    },
+    "pages": {
+        "dashboard": {
+            "title": "Panel",
+            "description": "Hazine varlıklarınızın ve etkinliğinizin genel görünümü",
+            "descriptionLong": "Hazine varlıklarınızı yönetin ve etkinliği takip edin"
+        },
+        "activity": {
+            "title": "Son İşlemler",
+            "descriptionDetails": "Talep Ayrıntıları",
+            "descriptionList": "Tüm varlıklardaki son işlemler"
+        },
+        "requests": {
+            "title": "Talepler",
+            "description": "Tüm bekleyen multisig taleplerini görüntüleyin ve yönetin",
+            "detailDescription": "Talep Ayrıntıları",
+            "detailTitle": "Talep #{id}"
+        },
+        "members": {
+            "title": "Üyeler",
+            "description": "Ekip üyelerini ve izinleri yönetin"
+        },
+        "settings": {
+            "title": "Ayarlar",
+            "description": "Uygulama ayarlarınızı düzenleyin"
+        },
+        "addressBook": {
+            "title": "Adres Defteri",
+            "description": "Kayıtlı alıcılarınızı yönetin"
+        },
+        "payments": {
+            "title": "Ödemeler",
+            "description": "Güvenle para gönderin ve alın"
+        },
+        "exchange": {
+            "title": "Takas",
+            "description": "Tokenlerinizi güvenli ve verimli bir şekilde takas edin"
+        },
+        "vesting": {
+            "title": "Vesting",
+            "description": "Vesting planlarını hızlı ve zahmetsizce oluşturun"
+        },
+        "earn": {
+            "title": "Kazan",
+            "description": "Varlıklarınızdan ödüller kazanın",
+            "placeholder": "Kazanç fırsatlarını ve staking ödüllerini keşfedin."
+        },
+        "createTreasury": {
+            "title": "Hazine Oluştur",
+            "description": "Ekibiniz için yeni bir multisig hazine kurun"
+        },
+        "manageTreasuries": {
+            "title": "Hazineleri Yönet",
+            "description": "Hesabınızda hangi hazinelerin görüneceğini kontrol edin"
+        },
+        "stats": {
+            "title": "İstatistikler",
+            "description": "Tüm sputnik DAO hazineleri genelinde gerçek zamanlı yönetim altındaki varlıklar."
+        },
+        "telegram": {
+            "title": "Hazineyi Bağla",
+            "description": "Hazinelerinizi bir Telegram sohbetine bağlayın",
+            "metaTitle": "Trezu — Telegram Bağla",
+            "metaDescription": "Trezu hazinenizi bir Telegram sohbetine bağlayın"
+        },
+        "wallet": {
+            "title": "Trezu Cüzdan",
+            "description": "Trezu üzerinden hazine önerilerini imzalayın"
+        }
+    },
+    "depositModal": {
+        "validation": {
+            "selectAsset": "Lütfen bir varlık seçin",
+            "selectNetwork": "Lütfen bir ağ seçin"
+        },
+        "sections": {
+            "supportedNetworks": "Desteklenen Ağlar",
+            "networksWithAssets": "Varlıkları Olan Ağlar",
+            "yourAssets": "Varlıklarınız",
+            "otherAssets": "Diğer Varlıklar"
+        },
+        "errors": {
+            "addressUnavailable": "Seçili varlık ve ağ için para yatırma adresi alınamadı.",
+            "fetchFailed": "Para yatırma adresi alınamadı. Lütfen tekrar deneyin."
+        },
+        "title": "Para Yatır",
+        "subtitle": "Para yatırma adresini görmek için varlık ve ağ seçin",
+        "assetLabel": "Varlık",
+        "networkLabel": "Ağ",
+        "selectAsset": "Varlık Seç",
+        "selectNetwork": "Ağ Seç",
+        "otherAssetName": "Diğer",
+        "otherNetworkInfo": "Varlıklar arasında listelenmeyen herhangi bir token'ı yatırabilirsiniz, ancak yalnızca NEAR ağı üzerinden.",
+        "depositAddressHeading": "Para Yatırma Adresi",
+        "depositAddressSubtitle": "Para yatırma adresinizi her zaman iki kez kontrol edin.",
+        "addressLabel": "Adres",
+        "addressCopied": "Adres panoya kopyalandı",
+        "memoLabel": "Not",
+        "memoCopied": "Not panoya kopyalandı",
+        "memoWarning": "Bu adrese para gönderirken notu <bold>mutlaka</bold> eklemelisiniz. Not olmadan göndermek paranın kalıcı olarak kaybolmasına neden olabilir.",
+        "onlyDeposit": "Yalnızca <networkTag>{network}</networkTag> ağından <symbolTag>{symbol}</symbolTag> yatırın. Tüm tutarı göndermeden önce her şeyin doğru çalıştığından emin olmak için küçük bir test işlemiyle başlamanızı öneririz.",
+        "minimumDeposit": "Minimum para yatırma <amountTag>{amount} {symbol}</amountTag>",
+        "searchByName": "İsme göre ara"
+    },
+    "assetDetails": {
+        "coinPrice": "Coin Fiyatı",
+        "weight": "Ağırlık",
+        "source": "Kaynak",
+        "send": "Gönder",
+        "exchange": "Takas",
+        "comingSoon": "Yakında",
+        "vesting": "Vesting",
+        "vestedPercent": "%{percent} Hak Edildi",
+        "frozen": "Donduruldu",
+        "frozenTooltip": "Dondurulmuş tokenler kilitlidir ve kullanılamaz. Depolama, staking veya henüz hak edilmemiş olma nedeniyle kilitlenmiş olabilirler.",
+        "vested": "Hak Edildi"
+    },
+    "dashboard": {
+        "overview": "Hazine varlıklarınızın ve etkinliğinizin genel görünümü",
+        "assets": "Varlıklar",
+        "balance": "Bakiye",
+        "totalBalance": "Toplam Bakiye",
+        "deposit": "Para Yatır",
+        "addAssets": "Varlık ekle",
+        "hidden": "Gizli",
+        "confidentialHidden": "Gizli hazineler için bakiyeler gizlendi",
+        "recentActivity": "Son Etkinlik",
+        "viewAllTransactions": "Tüm işlemleri görüntüle"
+    },
+    "activity": {
+        "filters": {
+            "createdDate": "Oluşturma Tarihi",
+            "token": "Token",
+            "from": "Kimden",
+            "to": "Kime"
+        },
+        "tabs": {
+            "all": "Tümü",
+            "sent": "Gönderildi",
+            "received": "Alındı",
+            "stakingRewards": "Staking Ödülleri",
+            "exchange": "Takas"
+        },
+        "searchPlaceholder": "İşlem hash'i ile ara",
+        "searchPlaceholderShort": "İşlem hash'i",
+        "fromPool": "{pool} havuzundan",
+        "table": {
+            "type": "TÜR",
+            "transaction": "İŞLEM",
+            "from": "KİMDEN",
+            "to": "KİME",
+            "transactionHash": "İŞLEM HASH'İ",
+            "hashTooltip": "Bu işlemin benzersiz tanımlayıcısı (hash)"
+        },
+        "empty": {
+            "title": "İşlem bulunamadı",
+            "description": "İşlemleriniz gerçekleştiklerinde burada görünecek"
+        },
+        "emptyDashboard": {
+            "title": "Henüz gösterilecek bir şey yok",
+            "description": "İşlemleriniz ve eylemleriniz gerçekleştiklerinde burada görünecek"
+        },
+        "recentTitle": "Son İşlemler",
+        "details": {
+            "title": "İşlem Ayrıntıları",
+            "copyAddress": "Adresi Kopyala",
+            "addressCopied": "Adres panoya kopyalandı",
+            "sell": "Sat",
+            "receive": "Al",
+            "pending": "Beklemede",
+            "type": "Tür",
+            "date": "Tarih",
+            "from": "Kimden",
+            "to": "Kime",
+            "method": "Metot",
+            "contract": "Sözleşme",
+            "transaction": "İşlem"
+        }
+    },
+    "export": {
+        "types": {
+            "csv": ".CSV",
+            "json": ".JSON",
+            "xlsx": ".XLSX"
+        },
+        "transactionTypes": {
+            "all": "Tüm Türler",
+            "sent": "Gönderildi",
+            "received": "Alındı",
+            "stakingRewards": "Staking Ödülleri"
+        },
+        "validation": {
+            "invalidEmail": "Lütfen geçerli bir e-posta adresi girin"
+        },
+        "columns": {
+            "submissionTime": "Gönderim Zamanı",
+            "dateRange": "Tarih Aralığı",
+            "generatedBy": "Oluşturan",
+            "status": "Durum"
+        },
+        "status": {
+            "generating": "Oluşturuluyor",
+            "expired": "Süresi Doldu",
+            "failed": "Başarısız"
+        },
+        "noPermission": "Dosyayı indirme izniniz yok.",
+        "download": "İndir",
+        "heading": "Son İşlemleri Dışa Aktar",
+        "teamOnly": "Dışa aktarma oluşturma ve indirmeleri yalnızca ekip üyelerine açıktır.",
+        "creditsUsed": "Tüm kredilerinizi kullandınız",
+        "exportsUsed": "Tüm dışa aktarmalarınızı kullandınız",
+        "upgradePrompt": "Devam etmek için planınızı yükseltin",
+        "resetPrompt": "Daha fazla erişim için planınızı yükseltin veya limitleriniz gelecek ay sıfırlanana kadar bekleyin.",
+        "tabs": {
+            "generate": "Dışa Aktarma Oluştur",
+            "history": "Geçmiş"
+        },
+        "fields": {
+            "documentType": "Belge Türü",
+            "timeRange": "Zaman Aralığı",
+            "selectDateRange": "Tarih aralığı seçin",
+            "asset": "Varlık",
+            "allAssets": "Tüm Varlıklar",
+            "transactionType": "İşlem Türü"
+        },
+        "buttons": {
+            "noPermissionExport": "Dışa aktarma izniniz yok",
+            "quotaExhausted": "Tüm kotanızı kullandınız",
+            "exporting": "Dışa Aktarılıyor...",
+            "export": "Dışa Aktar"
+        },
+        "empty": {
+            "title": "Henüz dışa aktarma yok",
+            "description": "Son aydaki dışa aktarılmış dosyalarınız oluşturulduklarında burada görünecek."
+        },
+        "requirements": {
+            "heading": "Dışa Aktarma Gereksinimleri",
+            "canExportFrom": "Şu tarihten itibaren veri dışa aktarabilirsiniz:",
+            "availability": "Dışa aktarılan dosyalar 48 saat boyunca indirilebilir."
+        },
+        "quota": {
+            "heading": "Dışa Aktarma Kotası",
+            "unlimited": "Sınırsız",
+            "perMonth": "{count} / ay",
+            "flexibilityPrompt": "Daha fazla esneklik mi arıyorsunuz?",
+            "contactUs": "Bize Ulaşın"
+        }
+    },
+    "requests": {
+        "filters": {
+            "proposalTypes": {
+                "Payments": "Ödemeler",
+                "Exchange": "Takas",
+                "Earn": "Kazan",
+                "Vesting": "Vesting",
+                "Function Call": "Fonksiyon Çağrısı",
+                "Change Policy": "Politika Değişikliği",
+                "Settings": "Ayarlar",
+                "Confidential": "Gizli"
+            },
+            "voteStatus": {
+                "Approved": "Onaylandı",
+                "Rejected": "Reddedildi",
+                "No Voted": "Oy Verilmedi"
+            },
+            "requestsType": "Talep Türü",
+            "createdDate": "Oluşturma Tarihi",
+            "recipient": "Alıcı",
+            "token": "Token",
+            "requester": "Talep Eden",
+            "approver": "Onaylayan",
+            "myVoteStatus": "Oy Durumum",
+            "all": "TÜMÜ",
+            "amount": "Miktar",
+            "from": "Kimden",
+            "to": "Kime",
+            "min": "Min",
+            "max": "Maks",
+            "invalidDate": "Geçersiz tarih",
+            "operationIsNot": " değil",
+            "operationBefore": " öncesi",
+            "operationAfter": " sonrası",
+            "operationContains": " içeriyor",
+            "searchByAddress": "Adrese göre ara",
+            "loadingMembers": "Üyeler yükleniyor...",
+            "noMembersFound": "Üye bulunamadı. \"{query}\" eklemek için Enter tuşuna basın",
+            "noMembersAvailable": "Kullanılabilir üye yok",
+            "reset": "Sıfırla",
+            "clear": "Temizle",
+            "addFilter": "Filtre Ekle"
+        },
+        "tabs": {
+            "all": "Tümü",
+            "pending": "Beklemede",
+            "executed": "Yürütüldü",
+            "rejected": "Reddedildi",
+            "expired": "Süresi Doldu",
+            "failed": "Başarısız"
+        },
+        "searchPlaceholder": "Talebi ada veya kimliğe göre ara",
+        "searchPlaceholderShort": "Ad veya kimliğe göre ara",
+        "errorLoading": "Öneriler yüklenirken hata oluştu. Lütfen tekrar deneyin.",
+        "empty": {
+            "title": "İlk talebinizi oluşturun",
+            "description": "Ödeme, takas ve diğer eylemler için talepler oluşturulduktan sonra burada görünecek.",
+            "send": "Gönder",
+            "exchange": "Takas"
+        },
+        "actions": {
+            "approve": "Onayla",
+            "reject": "Reddet",
+            "deposit": "Para Yatır",
+            "viewRequest": "Talebi Görüntüle"
+        },
+        "table": {
+            "selectAll": "Tümünü seç",
+            "selectRow": "Satırı seç",
+            "request": "Talep",
+            "transaction": "İşlem",
+            "requester": "Talep Eden",
+            "voting": "Oylama",
+            "votingTooltip": "İlk sayı alınan onayları gösterir. İkinci sayı yürütme için gereken onayları gösterir.",
+            "status": "Durum",
+            "notPending": "Öneri beklemede değil.",
+            "noPermissionVote": "Bu talep için oy kullanma izniniz yok.",
+            "alreadyVoted": "Bu talep için zaten oy kullandınız.",
+            "noResults": "Filtrelerinize uyan talep bulunamadı.",
+            "allCaughtUp": "Hepsi tamam!",
+            "noPending": "Bekleyen talep yok.",
+            "send": "Gönder",
+            "exchange": "Takas",
+            "requestsSelected": "{count, plural, one {# Talep Seçildi} other {# Talep Seçildi}}",
+            "bulkApproveDisabled": "Bu talep onaylanamaz çünkü hazinenin bakiyesi yetersiz."
+        },
+        "pending": {
+            "title": "Bekleyen Talepler",
+            "viewAll": "Tümünü Görüntüle",
+            "emptyTitle": "Hepsi tamam!",
+            "emptyDescription": "Bekleyen talep yok."
+        }
+    },
+    "proposals": {
+        "status": {
+            "pending": "Beklemede",
+            "approved": "Onaylandı",
+            "rejected": "Reddedildi",
+            "executed": "Yürütüldü",
+            "expired": "Süresi Doldu",
+            "failed": "Başarısız",
+            "removed": "Kaldırıldı",
+            "inProgress": "Devam Ediyor"
+        },
+        "statusTooltip": {
+            "pending": "Bu talep hâlâ beklemede ve yürütme için gereken oy sayısına henüz ulaşmadı.",
+            "executed": "{required} üyeden {approved} tanesi talebi onayladıktan sonra yürütüldü.",
+            "rejected": "{required} üyeden {rejected} tanesi talebi reddetmek için oy kullandıktan sonra reddedildi.",
+            "expired": "Yürütülmek için yeterli oyu alamadığı için süresi doldu.",
+            "failed": "Talep tamamlanamadı. İşlem ayrıntılarını <link>buradan</link> kontrol edin.",
+            "failedPlain": "Talep tamamlanamadı. İşlem ayrıntılarını buradan kontrol edin."
+        },
+        "votes": {
+            "approved": "Onaylandı",
+            "rejected": "Reddedildi",
+            "pending": "Beklemede"
+        },
+        "voteModal": {
+            "confirmTitle": "Oyunuzu Onaylayın",
+            "removeTitle": "Talebi Kaldır",
+            "bulkBody": "Birden çok talebi {action} etmek üzeresiniz. Gönderildikten sonra bu karar değiştirilemez.",
+            "singleBody": "Bu talebi {action} etmek üzeresiniz. Onaylandığında bu işlem geri alınamaz.",
+            "actionApprove": "onaylama",
+            "actionReject": "reddetme",
+            "actionRemove": "kaldırma",
+            "insufficientBalance": "<highlight>{ids}</highlight> talepleri yetersiz bakiye nedeniyle onaylanamaz. Onayınız yalnızca kalan taleplere uygulanacak.",
+            "remove": "Kaldır",
+            "confirm": "Onayla"
+        },
+        "expanded": {
+            "recipient": "Alıcı",
+            "amount": "Miktar",
+            "networkFee": "Ağ Ücreti",
+            "notes": "Notlar",
+            "sent": "Gönderildi",
+            "received": "Alındı",
+            "priceDifference": "Fiyat Farkı",
+            "priceDifferenceTooltip": "Teklif oranı ile mevcut piyasa oranı arasındaki fark. Pozitif değerler piyasadan daha iyi bir oranı gösterir.",
+            "slippageTolerance": "Kayma Toleransı",
+            "estimatedTime": "Tahmini Süre",
+            "seconds": "{count} saniye",
+            "description": "Açıklama",
+            "methodName": "Metot Adı",
+            "args": "Argümanlar",
+            "deposit": "Para Yatır",
+            "gas": "Gas",
+            "totalDeposit": "Toplam Depozito",
+            "totalGas": "Toplam Gas",
+            "receiverId": "Alıcı Kimliği",
+            "contractId": "Sözleşme Kimliği",
+            "actionsCount": "{count, plural, one {# eylem} other {# eylem}}",
+            "functionCallsCount": "{count, plural, one {# fonksiyon çağrısı} other {# fonksiyon çağrısı}}",
+            "showLess": "Daha az göster",
+            "showMore": "Daha fazla göster",
+            "stakingPool": "Staking Havuzu",
+            "validator": "Doğrulayıcı",
+            "action": "Eylem",
+            "stake": "Stake Et",
+            "unstake": "Stake'i Kaldır",
+            "withdraw": "Çek",
+            "lockupOwner": "Lockup sahibi",
+            "lockupDuration": "Lockup süresi",
+            "cliff": "Cliff",
+            "releaseDuration": "Serbest bırakma süresi",
+            "vestingSchedule": "Vesting planı",
+            "cancellable": "İptal Edilebilir",
+            "allowEarn": "Staking'e izin ver",
+            "yes": "Evet",
+            "no": "Hayır",
+            "notSet": "Ayarlanmadı",
+            "from": "Kimden",
+            "to": "Kime",
+            "paymentsCount": "{count, plural, one {# ödeme} other {# ödeme}}",
+            "sourceWallet": "Kaynak Cüzdan",
+            "allNear": "Tüm NEAR",
+            "startDate": "Başlangıç Tarihi",
+            "endDate": "Bitiş Tarihi",
+            "cliffDate": "Cliff Tarihi",
+            "allowCancellation": "İptale İzin Ver",
+            "allowStaking": "Staking'e İzin Ver",
+            "loadingHistorical": "Geçmiş yapılandırma yükleniyor...",
+            "name": "Ad",
+            "purpose": "Amaç",
+            "logo": "Logo",
+            "logoAlt": "Logo",
+            "primaryColor": "Birincil Renk",
+            "noChangesCurrent": "Mevcut duruma kıyasla yapılandırmada değişiklik tespit edilmedi.",
+            "noChangesHistorical": "Geçmiş duruma kıyasla yapılandırmada değişiklik tespit edilmedi.",
+            "method": "Metot",
+            "arguments": "Argümanlar",
+            "contract": "Sözleşme",
+            "actionNumber": "Eylem {number}",
+            "actions": "Eylemler",
+            "collapseAll": "Tümünü daralt",
+            "expandAll": "Tümünü genişlet",
+            "send": "Gönder",
+            "receive": "Al",
+            "rate": "Oran",
+            "priceSlippageLimit": "Fiyat Kayması Limiti",
+            "slippageTooltip": "Bu, bu talep için tanımlanan kayma limitidir. Yürütme sırasında piyasa oranı bu eşiğin ötesinde değişirse, talep otomatik olarak başarısız olur.",
+            "estimatedTimeTooltip": "Depozito işlemi onaylandıktan sonra takasın yürütülmesi için tahmini süre.",
+            "minReceive": "Min. Alınacak",
+            "minimumReceived": "Alınacak Minimum",
+            "minReceiveTooltip": "Bu, talep için ayarlanan kayma limitine göre bu takastan alacağınız minimum miktardır.",
+            "depositAddress": "Depozito Adresi",
+            "depositAddressTooltip": "Zincirler arası takas yürütme için tokenlerin gönderileceği 1Click depozito adresi.",
+            "quoteSignature": "Teklif İmzası",
+            "quoteSignatureTooltip": "Bu teklifi doğrulayan 1Click API'sinden gelen kriptografik imza.",
+            "quoteDeadline": "1-Click Teklif Son Tarihi",
+            "quoteDeadlineTooltip": "Depozito adresinin pasif hale geldiği ve fonların kaybolabileceği zaman.",
+            "status": "Durum",
+            "transactionLink": "İşlem Bağlantısı",
+            "viewTransaction": "İşlemi Görüntüle",
+            "recipientNumber": "Alıcı {number}",
+            "oopsTitle": "Hay aksi! Bir şeyler ters gitti",
+            "oopsDescription": "Burada gösterilecek herhangi bir veri bulamadık.",
+            "totalAmount": "Toplam Miktar",
+            "recipients": "Alıcılar",
+            "recipientsCount": "{count, plural, one {# alıcı} other {# alıcı}}",
+            "unsupportedProposal": "Desteklenmeyen öneri türü",
+            "requestDetails": "Talep Ayrıntıları",
+            "linkCopied": "Bağlantı panoya kopyalandı",
+            "copyLink": "Bağlantıyı Kopyala",
+            "openRequestPage": "Talep Sayfasını Aç",
+            "deleteRequest": "Talebi Sil",
+            "unknownRecipients": "Bilinmeyen alıcılar",
+            "loadingConfig": "Yapılandırma yükleniyor...",
+            "historicalData": "Geçmiş veriler...",
+            "generalUpdate": "Genel Güncelleme",
+            "detailsUnavailable": "Ayrıntılar mevcut değil",
+            "changesCount": "{count, plural, one {# Değişiklik} other {# Değişiklik}}",
+            "policyUpdate": "Politika Güncellemesi",
+            "noChangesDetected": "Değişiklik tespit edilmedi",
+            "loadingPolicy": "Politika yükleniyor...",
+            "roleChanges": "Rol Değişiklikleri",
+            "policyParameters": "Politika Parametreleri",
+            "defaultVotePolicy": "Varsayılan Oylama Politikası",
+            "policyRoleChanges": "Politika ve Rol Değişiklikleri",
+            "membersAdded": "{count, plural, one {# üye eklendi} other {# üye eklendi}}",
+            "membersRemoved": "{count, plural, one {# üye kaldırıldı} other {# üye kaldırıldı}}",
+            "membersUpdated": "{count, plural, one {# üye güncellendi} other {# üye güncellendi}}",
+            "rolesModified": "{count, plural, one {# rol değiştirildi} other {# rol değiştirildi}}",
+            "parametersChanged": "{count, plural, one {# parametre değiştirildi} other {# parametre değiştirildi}}",
+            "defaultVotePolicyPart": "varsayılan oylama politikası",
+            "onReceiver": "{receiver} üzerinde",
+            "toPrefix": "Kime:",
+            "validatorPrefix": "Doğrulayıcı:",
+            "validatorSubtitle": "Doğrulayıcı: {address}",
+            "impactTitle": "Oylama Süresini Değiştirmenin Etkisi",
+            "impactBody": "Oylama süresini güncellemek üzeresiniz. Bu, aşağıdaki mevcut talepleri etkileyecek.",
+            "activeRequestsBullet": "{count, plural, one {# talep, bu değişiklikten sonra güncellenmiş son kullanma tarihleri ile oylama için aktif olacak.} other {# talep, bu değişiklikten sonra güncellenmiş son kullanma tarihleri ile oylama için aktif olacak.}}",
+            "expiringRequestsBullet": "{count, plural, one {# talep, yeni oylama süresi altında \"Süresi Doldu\" olarak işaretlenecek.} other {# talep, yeni oylama süresi altında \"Süresi Doldu\" olarak işaretlenecek.}}",
+            "remainActiveHeading": "Yeni son kullanma tarihiyle oylama için aktif kalacak talepler",
+            "willExpireHeading": "\"Süresi Dolacak\" olarak işaretlenecek talepler",
+            "tableRequest": "Talep",
+            "tableTransaction": "İşlem",
+            "tableNewExpiry": "Yeni Son Kullanma",
+            "expireInDays": "{count, plural, one {# günde sona erer} other {# günde sona erer}}",
+            "today": "Bugün",
+            "uponApproval": "Onay üzerine",
+            "yesContinue": "Evet, Devam Et",
+            "transactionCreated": "İşlem Oluşturuldu",
+            "voting": "Oylama",
+            "approvalsReceived": "{received}/{required} onay alındı",
+            "expiresAt": "Sona Erme",
+            "expiredAt": "Sona Erdi",
+            "exchangingTokens": "Token'lar Takas Ediliyor",
+            "exchangingTokensBody": "Bu talep ekip tarafından onaylandı. Token takası şu anda devam ediyor ve biraz zaman alabilir.",
+            "requestFailed": "Talep Başarısız",
+            "requestFailedBody": "Ekip bu talebi onayladı, ancak oran dalgalanmaları nedeniyle başarısız oldu. Lütfen yeni bir talep oluşturun ve tekrar deneyin.",
+            "votingPeriod24h": "Oylama süresi: 24 saat",
+            "votingPeriod24hBody": "Bu takas talebinin 24 saatlik oylama süresi vardır. Bu süre içinde talebi onaylayın, aksi takdirde talebin süresi dolar.",
+            "reject": "Reddet",
+            "approve": "Onayla"
+        },
+        "insufficientBalance": {
+            "noAsset": "Bu talep onaylanamaz çünkü gerekli token hazinede mevcut değil.",
+            "bond": "Bu talep onaylanamaz çünkü hazinenin <token>{symbol}</token> bakiyesi yetersiz. Öneri teminat maliyetlerini karşılamak için <token>{amount} {symbol}</token> ekleyin.",
+            "continue": "Bu talep onaylanamaz çünkü hazinenin <token>{symbol}</token> bakiyesi yetersiz. Devam etmek için <token>{amount} {symbol}</token> ekleyin.",
+            "modalTitle": "Yetersiz NEAR Bakiyesi",
+            "modalBodyVote": "Bu oyu kullanmak için cüzdanınızda yeterli NEAR token'ı yok. Oy kullanmak en az <amount>{required} NEAR</amount> bakiye gerektirir. Lütfen cüzdanınıza NEAR ekleyin ve tekrar deneyin.",
+            "modalBodyProposal": "Bu talebi oluşturmak için cüzdanınızda yeterli NEAR token'ı yok. Talep oluşturmak en az <amount>{required} NEAR</amount> bakiye gerektirir. Lütfen cüzdanınıza NEAR ekleyin ve tekrar deneyin.",
+            "gotIt": "Anladım"
+        }
+    },
+    "members": {
+        "title": "Üyeler",
+        "description": "Ekip üyelerini ve izinleri yönetin",
+        "permissions": "İzinler",
+        "member": "Üye",
+        "activeMembers": "Aktif Üyeler",
+        "noActiveMembers": "Aktif üye bulunamadı.",
+        "addNewMember": "Yeni Üye Ekle",
+        "membersSelected": "{count, plural, =0 {üye yok} one {# üye} other {# üye}} seçildi",
+        "remove": "Kaldır",
+        "edit": "Düzenle",
+        "requestorOnlyTooltip": "Bu üye için yalnızca Talep Eden rolünü ekleyebilirsiniz, çünkü NEARN'den ödeme talepleri oluşturmaktan sorumludurlar.",
+        "memberModal": {
+            "editRoles": "Rolleri Düzenle",
+            "addNewMember": "Yeni Üye Ekle",
+            "validatingAddresses": "Adresler doğrulanıyor...",
+            "creatingProposal": "Öneri oluşturuluyor...",
+            "reviewRequest": "Talebi İncele",
+            "noChanges": "Üye rollerinde herhangi bir değişiklik yapılmadı"
+        },
+        "previewModal": {
+            "title": "Talebinizi İnceleyin",
+            "youAreEditing": "Düzenliyorsunuz",
+            "youAreAdding": "Ekliyorsunuz",
+            "membersCount": "{count, plural, one {# üye} other {# üye}}",
+            "newMembersCount": "{count, plural, one {# yeni üye} other {# yeni üye}}",
+            "updatedMembers": "Güncellenmiş Üyeler",
+            "newMembers": "Yeni Üyeler",
+            "creatingProposal": "Öneri Oluşturuluyor...",
+            "confirmSubmit": "Onayla ve Talebi Gönder"
+        },
+        "removeDialog": {
+            "title": "Talebi Kaldır",
+            "nearnBody": "Onaylandıktan sonra, {account} hazineden kalıcı olarak kaldırılacak ve ilgili tüm izinler iptal edilecek. Kaldırıldıktan sonra, bu hesap NEARN'den artık talep oluşturamayacak.",
+            "genericBody": "Onaylandıktan sonra, bu işlem <bold>{accounts}</bold> üyesini hazineden kalıcı olarak kaldıracak ve atanan tüm izinleri iptal edecek.",
+            "creatingProposal": "Öneri Oluşturuluyor..."
+        },
+        "validation": {
+            "accountIdRequired": "Hesap kimliği gereklidir",
+            "invalidNearAddress": "Geçersiz NEAR adresi.",
+            "atLeastOneRole": "En az bir rol seçilmelidir",
+            "atLeastOneMember": "En az bir üye gereklidir",
+            "alreadyAdded": "Bu üye yukarıda zaten eklenmiş",
+            "alreadyInTreasury": "Bu üye zaten hazinede mevcut",
+            "cannotRemoveRoleAfter": "Bu üyeden {role} rolünü kaldıramazsınız. Tüm değişikliklerinizden sonra, bu role atanan tek kişi olacaklar.",
+            "cannotRemoveRoleAfterGov": "Bu üyeden {role} rolünü kaldıramazsınız. Tüm değişikliklerinizden sonra, tek {role} üyesi olacaklar ve bu rol olmadan ekip üyelerini yönetemez veya oylamayı yapılandıramazsınız."
+        },
+        "policy": {
+            "addMembers": "Politikayı Güncelle - Yeni Üyeler Ekle",
+            "addMembersSuccess": "Yeni üye talebi başarıyla oluşturuldu",
+            "editMember": "Politikayı Güncelle - Üye İzinlerini Düzenle",
+            "editMembers": "Politikayı Güncelle - Birden Çok Üyeyi Düzenle",
+            "editMemberSuccess": "Üye rolleri güncelleme talebi başarıyla oluşturuldu",
+            "editMembersSuccess": "Toplu üye rolleri güncelleme talebi başarıyla oluşturuldu",
+            "removeMember": "Politikayı Güncelle - Üye Kaldır",
+            "removeMembers": "Politikayı Güncelle - Üyeleri Kaldır",
+            "removeMemberSuccess": "Üye kaldırma talebi başarıyla oluşturuldu"
+        }
+    },
+    "settings": {
+        "tabs": {
+            "general": "Genel",
+            "voting": "Oylama",
+            "preferences": "Tercihler",
+            "integrations": "Entegrasyonlar"
+        },
+        "general": {
+            "validation": {
+                "displayNameRequired": "Görünen ad gereklidir",
+                "displayNameMax": "Görünen ad 100 karakterden az olmalıdır"
+            },
+            "proposalDescriptionTitle": "Yapılandırmayı Güncelle - Tema ve logo",
+            "proposalSubmitted": "Yapılandırmayı güncelleme talebi gönderildi",
+            "treasuryNotFound": "Hazine bulunamadı",
+            "treasuryName": "Hazine Adı",
+            "treasuryNameDescription": "Hazinenizin adı. Bu, uygulama genelinde görüntülenecek.",
+            "displayName": "Görünen Ad",
+            "displayNamePlaceholder": "Görünen adı girin",
+            "accountName": "Hesap Adı",
+            "logo": "Logo",
+            "logoDescription": "Hazineniz için bir logo yükleyin. Önerilen SVG, PNG veya JPG (256x256 px).",
+            "treasuryLogoAlt": "Hazine logosu",
+            "uploading": "Yükleniyor...",
+            "uploadLogo": "Logo Yükle",
+            "removeLogo": "Logoyu Kaldır",
+            "logoUploaded": "Logo başarıyla yüklendi",
+            "uploadError": "Resim yüklenirken hata oluştu, lütfen tekrar deneyin.",
+            "invalidLogo": "Geçersiz logo. Lütfen tam olarak 256x256 px boyutunda bir PNG, JPG veya SVG dosyası yükleyin",
+            "invalidImage": "Geçersiz resim dosyası. Lütfen geçerli bir resim yükleyin.",
+            "fileReadError": "Dosya okunurken hata oluştu. Lütfen tekrar deneyin.",
+            "primaryColor": "Birincil Renk",
+            "primaryColorDescription": "Hazinenizin arayüz öğeleri için birincil rengi ayarlayın. Bu renk hem açık hem de karanlık modlarda kullanılacak, bu nedenle nötr tonlar seçerken kontrastı göz önünde bulundurun.",
+            "selectColorLabel": "{color} rengini seç"
+        },
+        "voting": {
+            "validation": {
+                "required": "Oylama süresi gereklidir",
+                "validNumber": "Oylama süresi geçerli bir sayı olmalıdır",
+                "min": "Oylama süresi en az 1 gün olmalıdır",
+                "max": "Oylama süresi 1000 günden az olmalıdır",
+                "whole": "Oylama süresi tam gün olmalıdır"
+            },
+            "missingData": "Gerekli veri eksik",
+            "thresholdProposalTitle": "Politikayı Güncelle - Oylama Eşikleri",
+            "thresholdProposalSummary": "{account} oylama eşiğini {oldValue} yerine {newValue} olarak değiştirmeyi talep etti.",
+            "thresholdSubmitted": "Oylama eşiğini güncelleme talebi gönderildi",
+            "createProposalFailed": "Öneri oluşturulamadı",
+            "durationProposalTitle": "Politikayı Güncelle - Oylama Süresi",
+            "durationProposalSummary": "{account} oylama süresini {oldValue} yerine {newValue} olarak değiştirmeyi talep etti.",
+            "durationSubmitted": "Talep başarıyla oluşturuldu",
+            "pendingTitle": "Aktif Oylama Eşiği Talebi",
+            "pendingBody": "Çakışmaları önlemek için, devam etmeden önce mevcut bekleyen talepleri tamamlamanız veya çözmeniz gerekir. Bu talepler şu anda aktif ve önce onaylanmalı veya reddedilmelidir.",
+            "viewRequest": "Talebi Görüntüle",
+            "thresholdHeading": "Oylama Eşiği",
+            "thresholdDescriptionApprovers": "Ödeme ve ekiple ilgili taleplerin onaylanması için kaç oy gerektiğini tanımlayın. Onaylayanlar ve Yönetişim için eşikleri ayrı yapılandırın.",
+            "thresholdDescriptionGeneric": "Taleplerin onaylanması için kaç oy gerektiğini tanımlayın. Sorumluluklarına göre her rol için eşikleri yapılandırın.",
+            "membersWhoCanVote": "Oy kullanabilen üyeler",
+            "votesRequired": "Talepleri onaylamak için oy gereklidir",
+            "durationHeading": "Oylama Süresi",
+            "durationDescription": "Bir önerinin oylama için açık kalacağı süre (gün cinsinden). Bu süre içinde oylama tamamlanmazsa karar süresi dolar.",
+            "durationApprovers": " Bu süre hem Yönetişim hem de Onaylayan rolleri için eşit olarak geçerlidir.",
+            "durationGeneric": " Bu süre tüm hazine rolleri arasında tutarlıdır.",
+            "days": "Gün"
+        },
+        "preferences": {
+            "timeZone": "Saat Dilimi",
+            "timeZoneDescription": "Doğru tarih ve saat görüntüleme için yerel saat diliminizi ayarlayın.",
+            "timeFormat": "Saat Formatı",
+            "hour12": "12 saat (1:00 ÖS)",
+            "hour24": "24 saat (13:00)",
+            "autoTimezone": "Saat dilimini konumunuzu kullanarak otomatik ayarla",
+            "timezone": "Saat Dilimi",
+            "loadingTimezones": "Saat dilimleri yükleniyor...",
+            "selectTimezone": "Saat Dilimi Seç",
+            "searchTimezones": "Saat dilimlerini ara...",
+            "noTimezones": "Saat dilimi bulunamadı",
+            "save": "Kaydet",
+            "savedToast": "Tercihler başarıyla kaydedildi",
+            "saveFailed": "Tercihler kaydedilemedi",
+            "loadFailed": "Saat dilimleri yüklenemedi"
+        }
+    },
+    "addressBook": {
+        "emptyTitle": "İlk alıcınızı ekleyin",
+        "emptyDescription": "Daha hızlı, hatasız ödemeler için sık kullanılan adresleri kaydedin. Kişileriniz gizli kalır ve yalnızca ekibinize görünür.",
+        "import": "İçe Aktar",
+        "addRecipient": "Alıcı Ekle",
+        "recipientsHeading": "Alıcılar",
+        "recipientsSelected": "{count, plural, =0 {alıcı yok} one {# alıcı} other {# alıcı}} seçildi",
+        "sectionHeading": "Alıcılar",
+        "privacyNote": "Kayıtlı adresler gizlidir ve yalnızca ekibinize görünür.",
+        "searchPlaceholder": "Alıcıyı ada göre ara",
+        "searchPlaceholderShort": "Ara",
+        "review": {
+            "header": "Ayrıntıları İncele",
+            "youAreAdding": "Ekliyorsunuz",
+            "newRecipients": "{count, plural, one {# yeni alıcı} other {# yeni alıcı}}",
+            "onNetworks": "{count, plural, one {# ağda} other {# ağda}}",
+            "recipients": "Alıcılar",
+            "allDuplicates": "İçe aktarılan tüm alıcılar adres defterinizde zaten var. Farklı bir liste yüklemek için geri dönün veya bu incelemeden tekrarları kaldırın.",
+            "someDuplicates": "Toplam {total} alıcıdan {duplicates} tanesi tekrarlanmış. Yalnızca yeni alıcıları yüklemek için devam edin.",
+            "duplicated": "Tekrarlandı",
+            "notePlaceholder": "Bu alıcıyı tanımlamaya yardımcı olacak bir not ekleyin (örn. yüklenici ödemesi, vesting dağıtımı).",
+            "skipDuplicates": "Tekrarları atla ve yalnızca yenileri içe aktar.",
+            "allDuplicatesTooltip": "İçe aktarılan tüm alıcılar zaten adres defterinizde, bu nedenle içe aktarılacak yeni bir şey yok.",
+            "duplicateActionTooltip": "Devam etmek için tekrar atlamayı etkinleştirin veya tekrarlanan alıcıları kaldırın.",
+            "adding": "Ekleniyor…",
+            "nothingNew": "İçe Aktarılacak Yeni Bir Şey Yok",
+            "addRecipientsButton": "{count, plural, one {Alıcı Ekle} other {Alıcı Ekle}}"
+        },
+        "removeDialog": {
+            "title": "Alıcıyı Kaldır",
+            "bulk": "Bu, adres defterinizden <bold>{count, plural, one {# alıcıyı} other {# alıcıyı}}</bold> kaldıracak. Onları istediğiniz zaman tekrar ekleyebilirsiniz.",
+            "single": "Bu, adres defterinizden <bold>{name}</bold> kişisini kaldıracak. Bu alıcıyı istediğiniz zaman tekrar ekleyebilirsiniz."
+        },
+        "importFlow": {
+            "title": "Alıcıları İçe Aktar",
+            "description": "Adres defterinize alıcı adreslerinin bir listesini yükleyin.",
+            "foundSummary": "{networkCount, plural, one {# ağda} other {# ağda}} {count, plural, one {# alıcı} other {# alıcı}} bulundu",
+            "uploadPrompt": "Alıcı verilerini yükleyin veya yapıştırın",
+            "fixErrors": "Devam etmek için hataları düzeltin",
+            "continueReview": "İncelemeye Devam Et"
+        },
+        "form": {
+            "editRecipient": "Alıcıyı Düzenle",
+            "addRecipient": "Alıcı Ekle",
+            "import": "İçe Aktar",
+            "recipientName": "Alıcı Adı",
+            "namePlaceholder": "Alice",
+            "recipientAddress": "Alıcı Adresi",
+            "network": "Ağ",
+            "networkInfo": "Bu adresle uyumlu ağlar",
+            "enterAddressFirst": "Önce alıcı adresini girin",
+            "selectNetwork": "Ağ seçin",
+            "selectNetworksTitle": "Ağları Seçin",
+            "searchNetworksPlaceholder": "Ağları ara…",
+            "done": "Tamam",
+            "edit": "Düzenle",
+            "remove": "Kaldır",
+            "incomplete": "Tamamlanmadı",
+            "addAnother": "Başka Bir Alıcı Ekle",
+            "fillAllTooltip": "Bir alıcı eklemek için tüm alanları doldurmanız gerekir.",
+            "reviewDetails": "Ayrıntıları İncele",
+            "reviewTooltip": "İncelemeden önce tüm alıcılar tamamlanmalıdır.",
+            "invalidAddress": "Geçersiz adres",
+            "noCompatibleNetworks": "Bu adres için uyumlu ağ yok"
+        },
+        "parsing": {
+            "rowPrefix": "Satır {row}: {message}",
+            "missingName": "Alıcı adı eksik. Lütfen bir ad ekleyin.",
+            "missingAddress": "Alıcı adresi eksik. Lütfen bir cüzdan adresi ekleyin.",
+            "invalidAddressFormat": "\"{address}\" adresi desteklenen herhangi bir ağ için geçerli bir formatta değil.",
+            "unknownNetwork": "Bilinmeyen ağ \"{network}\". Desteklenen ağlar: {available}.",
+            "incompatibleNetwork": "\"{address}\" adresi {network} ile uyumlu değil. Uyumlu ağlar: {compatible}.",
+            "noDataFound": "Veri bulunamadı. Lütfen alıcıları şu formatta ekleyin: Ad, Adres, Ağ, Not",
+            "headerColumnsNotFound": "Başlık satırı tespit ettik, ancak 'Name' ve 'Address' sütunlarını bulamadık. Lütfen bu sütun adlarını kullanın veya başlık satırını kaldırın.",
+            "failedToParseCsv": "CSV verisi ayrıştırılamadı"
+        }
+    },
+    "payments": {
+        "validation": {
+            "recipientMin": "Alıcı en az 2 karakter olmalıdır",
+            "recipientMax": "Alıcı 128 karakterden az olmalıdır",
+            "amountPositive": "Miktar 0'dan büyük olmalıdır",
+            "recipientTokenSame": "Alıcı ve token adresi aynı olamaz"
+        },
+        "newPayment": "Yeni Ödeme",
+        "reviewYourPayment": "Ödemenizi İnceleyin",
+        "reviewButton": "Ödemeyi İncele",
+        "reviewButtonDisabled": "Miktar ve adres girin",
+        "comingSoon": "Yakında",
+        "bulkPayments": "Toplu Ödemeler",
+        "summaryRecipients": "{count, plural, one {# alıcıya} other {# alıcıya}}",
+        "networkFee": "Ağ Ücreti",
+        "networkFeeInfo": "Ağ ücreti bilgisi",
+        "commentPlaceholder": "Yorum ekleyin (isteğe bağlı)...",
+        "preparingRoute": "1Click transfer rotası hazırlanıyor...",
+        "confirmSubmit": "Onayla ve Talebi Gönder",
+        "useDifferentAddress": "Farklı bir adres kullan",
+        "failed1ClickQuote": "1Click transfer teklifi oluşturulamadı",
+        "paymentSubmitted": "Ödeme gönderme talebi gönderildi"
+    },
+    "bulkPayment": {
+        "comingSoonToast": "Toplu ödemeler yakında geliyor!",
+        "submittingList": "Toplu ödeme listesi gönderiliyor",
+        "submittingProposal": "Öneri gönderiliyor",
+        "proposalSubmitted": "Toplu ödeme önerisi gönderildi",
+        "submitListFailed": "Ödeme listesi gönderilemedi",
+        "submitFailed": "Toplu ödeme gönderilemedi",
+        "upload": {
+            "pleaseUploadCsv": "Lütfen bir CSV dosyası yükleyin",
+            "fileSizeLimit": "Dosya boyutu 1.5 MB'dan az olmalıdır",
+            "headerTitle": "Toplu Ödeme Talepleri",
+            "headerSubtitle": "Tek bir öneri ile birden çok alıcıya ödeme yapın.",
+            "creditsUsed": "Tüm kredilerinizi kullandınız",
+            "bulkPaymentsUsed": "Tüm toplu ödemelerinizi kullandınız",
+            "upgradeTrial": "Devam etmek için planınızı yükseltin",
+            "upgradePaid": "Daha fazla erişim için planınızı yükseltin veya limitleriniz gelecek ay sıfırlanana kadar bekleyin.",
+            "selectAsset": "Varlık Seç",
+            "disableTokenMessage": "Bu tokenler için toplu ödemeler yakında geliyor.",
+            "providePaymentData": "Ödeme Verilerini Sağla",
+            "uploadFile": "Dosya Yükle",
+            "provideData": "Veri Sağla",
+            "chooseFile": "Dosya Seç",
+            "orDragDrop": "veya sürükleyip bırakın",
+            "maxFileSize": "en fazla 1 dosya, 1.5 MB'a kadar, yalnızca CSV dosyası",
+            "noFilePrompt": "Yüklenecek dosyanız yok mu?",
+            "downloadTemplate": "Şablon indir",
+            "requirements": "Toplu Ödeme Gereksinimleri",
+            "maxTransactions": "İçe aktarma başına maksimum {max} işlem",
+            "singleTokenNetwork": "Tek token ve ağ",
+            "limitsUsed": "Tüm limitlerinizi kullandınız",
+            "selectAndProvide": "Varlık seçin ve ödeme verilerini sağlayın",
+            "continueToReview": "İncelemeye Devam Et",
+            "selectTokenError": "Lütfen bir token seçin",
+            "providePaymentDataError": "Lütfen ödeme verilerini sağlayın"
+        },
+        "editStep": {
+            "title": "Ödemeyi Düzenle",
+            "saveChanges": "Değişiklikleri Kaydet"
+        },
+        "parsing": {
+            "rowPrefix": "Satır {row}: {message}",
+            "missingRecipientFirstColumn": "Alıcı adresi eksik. Lütfen ilk sütuna bir adres ekleyin.",
+            "invalidNearAddress": "\"{address}\" adresi geçerli bir NEAR hesabı değil.",
+            "invalidChainAddress": "\"{address}\" adresi geçerli bir {chain} hesabı değil.",
+            "rowNeedsAmountRecipient": "Her satırın virgülle ayrılmış bir miktar ve alıcıya ihtiyacı vardır. Örnek: 100, alice.near",
+            "missingRecipientBeforeComma": "Alıcı adresi eksik. Lütfen virgülden önce bir adres ekleyin.",
+            "missingAmountAfterComma": "Miktar eksik. Lütfen virgülden sonra bir sayı ekleyin. Örnek: {recipient}, 100",
+            "invalidAmountNumber": "\"{amountStr}\" miktarı geçerli bir sayı değil. Lütfen yalnızca sayılar ve ondalıklar kullanın (örn. 100 veya 100.50).",
+            "amountGreaterThanZero": "Miktar 0'dan büyük olmalıdır. \"{amountStr}\" girdiniz.",
+            "amountTooLarge": "\"{amountStr}\" miktarı çok büyük. Lütfen daha küçük bir sayı kullanın.",
+            "invalidAmountFallback": "Geçersiz miktar. Lütfen yalnızca sayılar ve ondalıklar kullanın (örn. 100 veya 100.50).",
+            "pleaseRemoveChars": "Lütfen şu karakterleri kaldırın: {chars}. Yalnızca sayılar, virgüller ve noktalar kullanılabilir.",
+            "amountCannotBeEmpty": "Miktar boş olamaz.",
+            "tokenMismatch": "\"{provided}\" girdiniz ancak yukarıda {expected} seçili. Token sembolünü kaldırın veya açılır menüden {suggested} seçin.",
+            "multipleTokenSymbols": "Birden çok token sembolü kullanıyorsunuz ({symbols}). Lütfen dosyanız boyunca yalnızca bir token türü kullanın veya token sembollerini kaldırın ve token'ı yukarıdaki seçim belirlesin.",
+            "noPaymentDataFound": "Ödeme verisi bulunamadı. Lütfen ödemelerinizi şu formatta ekleyin: alıcı, miktar",
+            "exceedsRecipientLimit": "{count} alıcınız var, ancak limit batch başına {limit}'dir. Lütfen {excess, plural, one {# alıcıyı} other {# alıcıyı}} kaldırın veya birden çok batch'e bölün.",
+            "noPaymentDataProvided": "Ödeme verisi sağlanmadı. Lütfen ödemelerinizi şu formatta girin: alıcı, miktar",
+            "headerColumnsNotFound": "Başlık satırı tespit ettik, ancak 'Recipient' ve 'Amount' sütunlarını bulamadık. Lütfen bu sütun adlarını kullanın veya başlık satırını kaldırın.",
+            "failedToParseCsv": "CSV verisi ayrıştırılamadı",
+            "failedToParsePaste": "Yapıştırılan veri ayrıştırılamadı",
+            "failedToValidateAccount": "Hesap doğrulanamadı",
+            "feeEstimationFailed": "Bu miktar için ağ ücreti tahmin edilemedi. Lütfen doğrulayın ve tekrar deneyin.",
+            "feeEstimationFailedRow": "Satır {row} ({recipient}): Bu miktar için ağ ücreti tahmin edilemedi. Lütfen doğrulayın ve tekrar deneyin."
+        },
+        "recipients": "Alıcılar",
+        "insufficientTokens": "Yetersiz token. Talebi gönderebilir ve onaydan önce yükleyebilirsiniz.",
+        "removeRecipient": "Alıcıyı Kaldır",
+        "removeRecipientConfirm": "<strong>{recipient}</strong> kişisine yapılan ödemeyi kaldırmak istediğinizden emin misiniz? Bu işlem geri alınamaz.",
+        "remove": "Kaldır",
+        "edit": "Düzenle"
+    },
+    "bulkPaymentCredits": {
+        "title": "Toplu Ödemeler",
+        "unlimited": "Sınırsız",
+        "creditsPerPeriod": "{amount} / {period}",
+        "oneTimeTrial": "tek seferlik deneme",
+        "month": "ay",
+        "moreFlexibility": "Daha fazla esneklik mi arıyorsunuz?",
+        "contactUs": "Bize Ulaşın"
+    },
+    "exchange": {
+        "validation": {
+            "amountPositive": "Miktar 0'dan büyük olmalıdır"
+        },
+        "requestSubmitted": "Takas talebi gönderildi",
+        "heading": "Takas",
+        "sell": "Sat",
+        "receive": "Al",
+        "slippageTolerance": "Kayma Toleransı",
+        "disabled": {
+            "differentTokens": "Tokenler farklı olmalıdır",
+            "enterAmount": "Takas etmek için bir miktar girin"
+        },
+        "review": "Takası İncele",
+        "poweredBy": "Destekleyen",
+        "info": {
+            "priceDifference": "Fiyat Farkı",
+            "priceDifferenceTooltip": "Teklif oranı ile mevcut piyasa oranı arasındaki fark. Pozitif değerler piyasadan daha iyi bir oranı gösterir.",
+            "estimatedTime": "Tahmini Süre",
+            "estimatedTimeValue": "{seconds} saniye",
+            "estimatedTimeTooltip": "Takası tamamlamak için yaklaşık süre.",
+            "minimumReceived": "Alınacak Minimum",
+            "minimumReceivedTooltip": "Bu, talep için ayarlanan kayma limitine göre bu takastan alacağınız minimum miktardır.",
+            "depositAddress": "Depozito Adresi",
+            "depositAddressCopied": "Depozito adresi kopyalandı",
+            "quoteExpires": "Teklif Sona Erme",
+            "exchangeFee": "Takas Ücreti",
+            "exchangeFeeTooltip": "Burada uygulanan %0,70 ücret, işleminizi kolaylaştırmak için NEAR Intents protokol maliyetlerini ve Trezu widget ücretini karşılar. Bu miktar, teklif edilen oranınıza otomatik olarak hesaplanır."
+        },
+        "approveWithin24h": "Lütfen bu talebi 24 saat içinde onaylayın, aksi takdirde süresi dolacaktır. Mümkün olan en kısa sürede onaylamanızı öneririz.",
+        "confirmSubmit": "Onayla ve Talebi Gönder",
+        "refreshingIn": "Takas oranı {seconds}sn içinde yenilenecek"
+    },
+    "vesting": {
+        "validation": {
+            "amountMin": "Miktar 3.5'ten büyük veya eşit olmalıdır",
+            "startBeforeEnd": "Başlangıç tarihi bitiş tarihinden önce olmalıdır",
+            "cliffBetween": "Cliff tarihi şu aralıkta olmalıdır:"
+        },
+        "stepTitles": {
+            "details": "Ayrıntılar",
+            "settings": "Ayarlar",
+            "review": "İnceleme"
+        },
+        "proposalTitle": "{address} için vesting planı oluştur",
+        "scheduleSubmitted": "Vesting planı oluşturma talebi gönderildi",
+        "heading": "Yeni Vesting Planı",
+        "amount": "Miktar",
+        "startDate": "Başlangıç Tarihi",
+        "endDate": "Bitiş Tarihi",
+        "noteOptional": "Not (isteğe bağlı)",
+        "continue": "Devam Et",
+        "advancedSettings": "Gelişmiş Ayarlar",
+        "allowCancellation": "İptale İzin Ver",
+        "allowCancellationDescription": "NEAR Foundation'ın lockup'ı istediği zaman iptal etmesine izin verir. İptal edilemeyen lockup'lar cliff tarihleriyle uyumlu değildir.",
+        "cliffDate": "Cliff Tarihi",
+        "allowEarn": "Kazanca İzin Ver",
+        "allowEarnDescription": "Lockup sahibinin lockup'taki tokenlerin tamamını stake etmesine izin verir (cliff tarihinden önce bile).",
+        "commentPlaceholder": "Bu vesting planı için bir yorum ekleyin (isteğe bağlı)...",
+        "reviewRequest": "Talebi İncele",
+        "reviewHeading": "Vesting Planınızı İnceleyin",
+        "confirmSubmit": "Onayla ve Talebi Gönder",
+        "review": {
+            "recipient": "Alıcı",
+            "startDate": "Başlangıç Tarihi",
+            "endDate": "Bitiş Tarihi",
+            "cliffDate": "Cliff Tarihi",
+            "cancelable": "İptal Edilebilir",
+            "allowEarn": "Kazanca İzin Ver",
+            "na": "Yok"
+        }
+    },
+    "earn": {
+        "placeholder": "Kazanç fırsatlarını ve staking ödüllerini keşfedin."
+    },
+    "createTreasury": {
+        "validation": {
+            "nameMin": "Hazine adı en az 2 karakter olmalıdır",
+            "nameMax": "Hazine adı 64 karakterden az olmalıdır",
+            "accountMin": "Hesap adı en az 2 karakter olmalıdır",
+            "accountMax": "Hesap adı 64 karakterden az olmalıdır",
+            "accountChars": "Hesap adı yalnızca Latin harfleri, sayılar ve tireler içerebilir",
+            "accountTaken": "Bu hesap adı zaten alınmış"
+        },
+        "votingNote": "Oylama ayarlarını değiştirmek için daha fazla üyeye ihtiyacınız var. Oylamayı yapılandırmak için başka bir üye ekleyin.",
+        "minimumVoteNote": "En az bir onay oyu gereklidir.",
+        "heading": "Hazine Oluştur",
+        "addMembers": "Üye Ekle",
+        "addMembersInfo": "Şimdi üye ekleyebilir veya güncelleyebilir ve daha sonra istediğiniz zaman düzenleyebilirsiniz.",
+        "treasuryName": "Hazine Adı",
+        "treasuryNamePlaceholder": "Hazinem",
+        "accountName": "Hesap Adı",
+        "accountNameInfo": "Bu, hesabınızın benzersiz adıdır. Hazine URL'nizde kullanılacak ve ödemeyi kimin gönderdiğini tanımlamak için işlemlerde gösterilecek. Hesabınız için kısa, tanınabilir bir ad seçin.",
+        "accountPlaceholder": "hazinem",
+        "continue": "Devam Et",
+        "votingThreshold": "Oylama Eşiği",
+        "thresholdDescription": "Talepleri onaylamak için kaç oy gerektiğini ayarlayın:",
+        "financial": "Finansal",
+        "financialDescription": "Ödeme ve takas taleplerini onaylama.",
+        "governance": "Yönetişim",
+        "governanceDescription": "Ayarları, üyeleri ve oylama yapılandırmasını onaylama.",
+        "confidential": "Gizli",
+        "public": "Açık",
+        "anyone": "Herkes",
+        "teamOnly": "Yalnızca Ekip",
+        "soon": "Yakında",
+        "publicDescription": "Tüm bakiyeler, etkinlikler ve işlemler blok zincirinde herkese görünür. Bu seçenek şeffaf organizasyonlar ve genel DAO'lar için en uygunudur.",
+        "balanceTransactions": "Bakiye, İşlemler",
+        "membersVoting": "Üyeler, Oylama",
+        "allFeatures": "Tüm özellikler kullanılabilir",
+        "confidentialDescription": "Tüm bakiyeler, etkinlikler ve transferler blok zincirinde gizlidir. Yalnızca ekibiniz bu bilgileri görüntüleyebilir. Özel şirketler, aile ofisleri veya finansal gizlilik isteyen ekipler için en iyisidir.",
+        "recentTransactionsExport": "Son İşlemler Dışa Aktarma",
+        "bulkPayment": "Toplu Ödeme",
+        "treasuryType": "Hazine Türü",
+        "treasuryTypeWarning": "Hazine başına yalnızca bir kez seçim yapabilirsiniz ve daha sonra değiştiremezsiniz.",
+        "select": "Seç",
+        "visibleOnChain": "Zincirde görünür",
+        "featuresAvailable": "Kullanılabilir özellikler",
+        "mostFeaturesSupported": "Çoğu özellik destekleniyor",
+        "reviewTreasury": "Hazineyi İncele",
+        "membersLabel": "Üyeler",
+        "financialThreshold": "Finansal Eşik",
+        "governanceThreshold": "Yönetişim Eşiği",
+        "noDeploymentFee": "🎉 Dağıtım ücreti yok",
+        "noDeploymentFeeDescription": "Yeni projeleri desteklemek için TREZU, tüm tek seferlik dağıtım ve ağ depolama ücretlerini karşılar.",
+        "createButton": "Hazine Oluştur",
+        "connectWalletCreate": "Hazine Oluşturmak İçin Cüzdan Bağla",
+        "unexpectedError": "Beklenmedik bir hata oluştu",
+        "creationFailed": "Hazine oluşturulamadı. Lütfen tekrar deneyin.",
+        "stepTitles": {
+            "aboutYou": "Hakkınızda",
+            "details": "Ayrıntılar",
+            "members": "Üyeler",
+            "treasuryType": "Hazine Türü",
+            "review": "İnceleme"
+        },
+        "steps": {
+            "creatingNear": "Hazineniz NEAR üzerinde oluşturuluyor",
+            "registeringKey": "Genel anahtar kaydediliyor",
+            "settingUpConfidential": "Gizli işlemler ayarlanıyor",
+            "configuringMembers": "Hazine üyeleri yapılandırılıyor",
+            "finalizingSetup": "Kurulum tamamlanıyor"
+        }
+    },
+    "manageTreasuries": {
+        "warningOne": "En az bir hazine kullanılabilir kalmalıdır",
+        "warningOnePeriod": "En az bir hazine kullanılabilir kalmalıdır.",
+        "activeHeading": "Aktif Hazineler",
+        "activeDescription": "Hesaplar listenizde şu anda görünen hazineler.",
+        "activeEmpty": "Aktif hazine yok.",
+        "hiddenHeading": "Gizli Hazineler",
+        "hiddenDescription": "Hesaplar listenizden gizlenmiş hazineler.",
+        "removeGuestTitle": "Misafir Hazineyi Kaldır",
+        "removeDialog": "<bold>{name}</bold> hazinesini kaldırmak üzeresiniz. Onaylandıktan sonra bu işlem geri alınamaz.",
+        "tooltips": {
+            "removeFromList": "Listenizden kaldır",
+            "viewTreasury": "Hazineyi görüntüle",
+            "hideFromList": "Listenizden gizle",
+            "showInList": "Listenizde göster"
+        }
+    },
+    "wallet": {
+        "proposal": {
+            "transfer": "Harici dApp'tan öneri: {receiverId} adresine NEAR transferi",
+            "functionCall": "Harici dApp'tan öneri: {receiverId} üzerinde {methods}",
+            "unsupportedAction": "Desteklenmeyen eylem türü \"{type}\". Yalnızca Transfer ve FunctionCall eylemleri Trezu önerilerine dönüştürülebilir."
+        },
+        "loading": "Yükleniyor...",
+        "connectPrompt": "Devam etmek için NEAR cüzdanınızı bağlayın. Ardından adına hareket edeceğiniz bir hazine seçeceksiniz.",
+        "connectWallet": "Cüzdan Bağla",
+        "cancel": "İptal",
+        "connectedAs": "<strong>{account}</strong> olarak bağlanıldı",
+        "loadingTreasuries": "Hazineler yükleniyor...",
+        "selectSignIn": "Olarak oturum açmak için bir hazine seçin:",
+        "selectSignTx": "Üzerinde öneri oluşturmak için bir hazine seçin:",
+        "notMember": "Hiçbir hazinenin üyesi değilsiniz.",
+        "actingAs": "Olarak hareket ediyor",
+        "signedBy": "{account} tarafından imzalandı",
+        "createsNProposals": "Bu, şunun için {count, plural, one {bir Trezu önerisi} other {# Trezu önerisi}} oluşturacak:",
+        "proposalDescriptionLabel": "Öneri açıklaması (isteğe bağlı)",
+        "proposalDescriptionPlaceholder": "Bu öneriyi açıklayın...",
+        "createProposal": "Öneri Oluştur",
+        "creatingProposal": "Öneri oluşturuluyor...",
+        "confirmInWallet": "Lütfen cüzdanınızda onaylayın",
+        "proposalSubmitted": "Öneri Gönderildi",
+        "shareProposal": "Öneriniz oluşturuldu. Oy kullanmak için aşağıdaki bağlantıyı hazine üyeleriyle paylaşın.",
+        "proposalLink": "{daoId} — Öneri #{id}",
+        "checking": "Kontrol ediliyor...",
+        "proposalApprovedProceed": "Öneri Onaylandı. Devam Et",
+        "signedInSuccess": "Başarıyla oturum açıldı",
+        "proposalCreatedSuccess": "Öneri başarıyla oluşturuldu",
+        "closeWindow": "Bu pencereyi kapatabilirsiniz.",
+        "errorGeneric": "Bir hata oluştu",
+        "tryAgain": "Tekrar dene",
+        "errors": {
+            "parseTx": "İşlem talebi ayrıştırılamadı. Lütfen tekrar deneyin.",
+            "fetchTreasuries": "Hazineleriniz alınamadı. Lütfen tekrar deneyin.",
+            "connectFailed": "Cüzdan bağlanamadı",
+            "createProposalFailed": "Öneri oluşturulamadı",
+            "stillPending": "Öneri hâlâ onay bekliyor. Lütfen hazine üyelerinin oy kullanmasını bekleyin.",
+            "wasStatus": "Öneri #{id} {status}",
+            "awaitIndex": "Öneri onaylandı ancak yürütme işlemi henüz indekslenmedi. Lütfen bir an sonra tekrar deneyin.",
+            "checkStatusFailed": "Öneri durumu kontrol edilemedi",
+            "userCancelled": "Kullanıcı iptal etti",
+            "proposalWasStatus": "Öneri {status}"
+        }
+    },
+    "telegram": {
+        "tagPill": "Telegram",
+        "invalidLinkTitle": "Geçersiz bağlantı",
+        "invalidLinkDescription": "Bu Telegram bağlantı linkinde token eksik. Yeni bir bağlantı oluşturmak için Telegram'da Connect Treasury'ye tekrar tıklayın.",
+        "successTitle": "Başarıyla bağlandı",
+        "successDescription": "Hazineler bu Telegram sohbetine bağlandı.",
+        "successToast": "Hazineler başarıyla bağlandı",
+        "goToApp": "Uygulamaya Git",
+        "linkExpiredTitle": "Bağlantı süresi doldu",
+        "linkExpiredDescription": "Bu bağlantının süresi dolmuş veya zaten kullanılmış. Telegram'da, bağlantı akışını yeniden başlatmak için aşağıdaki komutu yazın.",
+        "commandCopied": "Komut kopyalandı",
+        "copy": "Kopyala",
+        "unableToLoadTitle": "Sohbet yüklenemedi",
+        "unableToLoadDescription": "Sohbet ayrıntıları şu anda yüklenemedi. Lütfen Telegram'dan tekrar deneyin.",
+        "signInTitle": "Devam etmek için oturum açın",
+        "signInDescription": "Önce NEAR cüzdanınızı bağlayın, ardından bu Telegram sohbetine hangi hazinelerin bağlanacağını seçin.",
+        "connectWallet": "Cüzdan Bağla",
+        "selectTreasuriesTitle": "Hazineleri Seç",
+        "selectTreasuriesDescription": "Bu Telegram sohbetine bağlanacak hazineleri seçin.",
+        "telegramChat": "Telegram sohbeti",
+        "chatIdFallback": "Sohbet #{id}",
+        "failedToConnect": "Hazineler bağlanamadı. Lütfen tekrar deneyin.",
+        "relinking": "{count, plural, one {# seçili hazine başka bir Telegram sohbetine bağlı. Bağlanmak yeniden bağlayacak ve sohbet kimliği bağlantısını bu sohbete değiştirecek.} other {# seçili hazine başka Telegram sohbetlerine bağlı. Bağlanmak yeniden bağlayacak ve sohbet kimliği bağlantılarını bu sohbete değiştirecek.}}",
+        "alreadyConnected": "Bu sohbete zaten bağlı",
+        "connectedToAnother": "Başka bir sohbete bağlı",
+        "notMember": "Hiçbir hazinenin politika üyesi değilsiniz.",
+        "connecting": "Bağlanıyor…",
+        "connect": "Bağlan"
+    },
+    "systemStatus": {
+        "underMaintenance": "Bakım Altında",
+        "maintenanceMessage": "Şu anda bakım gerçekleştiriyoruz. Bazı özellikler geçici olarak kullanılamayabilir. Lütfen kısa süre sonra tekrar kontrol edin."
+    },
+    "creditsQuota": {
+        "available": "{count} Kullanılabilir",
+        "used": "{count} Kullanıldı",
+        "resetOn": "Limit {date} tarihinde sıfırlanacak"
+    },
+    "approvalInfo": {
+        "infoText": "Ödemeyle ilgili talepleri onaylamak için gereken oylar. Oylama ayarlarında düzenlenebilir.",
+        "thresholdPill": "{total}'dan {required} eşiği",
+        "alertBody": "Bu ödeme yürütülmeden önce <bold>{required}</bold> hazine üyesinin onayını gerektirecek."
+    },
+    "guestBadge": {
+        "title": "Misafir",
+        "tooltip": "Bu hazinenin misafirisiniz. Yalnızca verileri görüntüleyebilirsiniz."
+    },
+    "exportButton": {
+        "confidentialTooltip": "Dışa aktarma henüz gizli modda kullanılamıyor. Bu özellik yakında geliyor!"
+    },
+    "sponsoredActions": {
+        "titleExhausted": "Sponsorlu Eylemler Kullanıldı",
+        "titleAlmost": "Ekibinizin sponsorlu eylemleri neredeyse bitti",
+        "closeNotice": "Bildirimi kapat",
+        "teamUsage": "Ekip kullanımı: ayda {total} eylem",
+        "available": "{count} Kullanılabilir",
+        "used": "{count} Kullanıldı",
+        "exhaustedBody": "Ekibiniz aylık sponsorlu eylemlere ulaştı. {date} tarihinden sonra devam edebilir veya bizimle iletişime geçebilirsiniz",
+        "almostBody": "TREZU şu anda talep oluşturma ve oy kullanma gibi tüm ekip eylemleri için depolama maliyetlerini sponsor oluyor. Ekibiniz aylık sponsorlu limite ulaşmaya yakın.",
+        "contactUs": "Bize Ulaşın",
+        "nextMonthlyReset": "bir sonraki aylık sıfırlamanız",
+        "sidebarBody": "Ekibiniz aylık sponsorlu eylemlere ulaştı. {date} tarihinden sonra devam edebilirsiniz veya ⬇️"
+    },
+    "acceptTerms": {
+        "title": "Devam Etmek İçin Şartları Kabul Edin",
+        "privacyTitle": "Trezu'da Gizliliğiniz",
+        "privacyBody": "Trezu, saklamaya dayalı olmayan bir arayüzdür. Platformun güvenli ve işlevsel kalmasını sağlarken gizliliğinize öncelik veriyoruz.",
+        "minimalTitle": "Minimum Veri",
+        "minimalBody": "Arayüzü işletmek ve geliştirmek için genel cüzdan adresleri, IP adresleri ve kullanım analizleri gibi sınırlı bilgiler topluyoruz.",
+        "noCustodyTitle": "Saklama Yok",
+        "noCustodyBody": "Özel anahtarlarınıza, kurtarma ifadelerinize veya dijital varlıklarınıza asla erişmiyoruz.",
+        "publicTitle": "Genel Kayıtlar",
+        "publicBody": "Tüm blok zinciri işlemlerinin doğal olarak genel olduğunu ve tarafımızdan kontrol edilmediğini unutmayın.",
+        "responsibilityTitle": "Sorumluluğunuz",
+        "responsibilityBody": "Cüzdan etkinliğinizi izlemekten ve kimlik bilgilerinizi güvende tutmaktan yalnızca siz sorumlusunuz.",
+        "futureTitle": "Gelecekteki Güncellemeler",
+        "futureBody": "Gelecekteki bildirimlere (e-posta veya Telegram gibi) abone olursanız, bu verileri yalnızca sizi bilgilendirmek için kullanacağız.",
+        "agreement": "<terms>Hizmet Şartları</terms> ve <privacy>Gizlilik Politikası</privacy>'nı okudum ve kabul ediyorum",
+        "accepting": "Kabul ediliyor...",
+        "continue": "Devam Et"
+    },
+    "confidentialBanner": {
+        "label": "Gizli",
+        "description": "Bakiyeler, etkinlik ve transferler yalnızca ekibinize görünür — genel blok zincirine değil."
+    },
+    "supportCenter": {
+        "title": "Destek Merkezi",
+        "resources": "Kaynaklar",
+        "support": "Destek",
+        "websiteTitle": "Trezu Web Sitesi",
+        "websiteDescription": "Trezu hakkında daha fazla bilgi edinin ve blogumuzu okuyun.",
+        "demo": "Trezu Demo",
+        "demoTitle": "Açık Sürümü Keşfedin",
+        "demoDescription": "Canlı bir açık hesabı işlerken görün.",
+        "confidentialDemoTitle": "Gizli Sürümü Keşfedin",
+        "confidentialDemoDescription": "Canlı bir gizli hesabı işlerken keşfedin.",
+        "videoTitle": "Demoyu İzleyin",
+        "videoDescription": "Trezu'nun nasıl çalıştığını gösteren kısa bir video izleyin.",
+        "xTitle": "Bizi X'te Takip Edin",
+        "xDescription": "En son sürümlerimiz ve bilgilerimizden haberdar olun.",
+        "statsTitle": "İstatistikler",
+        "statsDescription": "Tüm sputnik DAO'lar genelinde yönetim altındaki toplam varlıkları görüntüleyin.",
+        "docsTitle": "Belgeler",
+        "docsDescription": "Tüm özellikler hakkında belgelerden bilgi edinin.",
+        "productSupportTitle": "Ürün Desteği",
+        "productSupportDescription": "Yardım için destek ekibimizle iletişime geçin."
+    },
+    "progressModal": {
+        "titleCreating": "Hazine Oluşturuluyor...",
+        "titleDone": "Hazine Oluşturuldu",
+        "titleFailed": "Hazine Oluşturulamadı",
+        "viewTreasury": "Hazineyi Görüntüle"
+    },
+    "memberValidation": {
+        "noManagePermission": "Üyeleri yönetme izniniz yok",
+        "pendingRequest": "Aktif bir talep varken üyeleri yönetemezsiniz",
+        "rolesAnd": "{first} ve {second}",
+        "rolesMany": "{list} ve {last}",
+        "cannotRemoveMember": "Bu üye kaldırılamaz. {roles} {count, plural, one {rolüne} other {rollerine}} atanan tek kişiler.",
+        "cannotRemoveMemberGov": "Bu üye kaldırılamaz. {roles} {count, plural, one {rolüne, ki bu rol} other {rollerine, ki bu roller}} atanan tek kişiler ve ekip üyelerini yönetmek ve oylamayı yapılandırmak için gereklidir.",
+        "cannotBulkRemove": "Bu üyeler kaldırılamaz. Bu, {roles} {count, plural, one {rolünü} other {rollerini}} boş bırakacaktır.",
+        "cannotBulkRemoveGov": "Bu üyeler kaldırılamaz. Bu, ekip üyelerini yönetmek ve oylamayı yapılandırmak için gereken {roles} {count, plural, one {rolünü} other {rollerini}} boş bırakacaktır.",
+        "cannotRemoveRole": "Bu üyeden {role} rolünü kaldıramazsınız. Bu role atanan tek kişiler.",
+        "cannotRemoveRoleGov": "Bu üyeden {role} rolünü kaldıramazsınız. Tek {role} üyesi olacaklar ve bu rol olmadan ekip üyelerini yönetemez veya oylamayı yapılandıramazsınız."
+    },
+    "roleSelector": {
+        "setRole": "Rol Ayarla",
+        "allRoles": "Tüm Roller",
+        "roles": {
+            "governance": {
+                "title": "Yönetişim",
+                "description": "Yönetişim, üyeler, izinler ve hazine görünümü dahil ekiple ilgili hazine ayarları üzerinde oluşturma ve oylama yapabilir."
+            },
+            "requestor": {
+                "title": "Talep Eden",
+                "description": "Talep Eden, oylama veya onay hakları olmadan ödemeyle ilgili işlem talepleri oluşturabilir."
+            },
+            "financial": {
+                "title": "Finansal",
+                "description": "Finansal, ödemeyle ilgili işlem talepleri üzerinde oy kullanabilir ancak bunları oluşturamaz."
+            }
+        }
+    },
+    "memberInput": {
+        "creatorYou": "Oluşturan (siz)",
+        "memberAddress": "Üye Adresi",
+        "addNewMember": "Yeni Üye Ekle",
+        "validation": {
+            "rolesRequired": "En az bir rol gereklidir",
+            "duplicateAddress": "Adres zaten bir üye"
+        }
+    },
+    "recipientInput": {
+        "title": "Kime",
+        "placeholder": "Alıcı adresi"
+    },
+    "accountInput": {
+        "failedValidation": "Adres doğrulanamadı",
+        "invalidNearFormat": "Geçersiz NEAR hesap formatı",
+        "invalidChainAddress": "Lütfen geçerli bir {chain} adresi girin.",
+        "validating": "Adres doğrulanıyor...",
+        "validAddress": "Geçerli adres",
+        "placeholderWithExample": "Alıcı adresi (örn.: {example})",
+        "placeholderNoExample": "Alıcı adresi",
+        "nearExample": "alice.near, 0x... veya 64 karakterli hex",
+        "near": {
+            "required": "Adres gereklidir",
+            "length": "Adres 2 ile 64 karakter arasında olmalıdır",
+            "missingTld": "Adlandırılmış hesaplar .near, .aurora veya .tg ile bitmelidir",
+            "invalidChars": "Adres yalnızca küçük harfler, rakamlar ve ayırıcılar (., -, _) içerebilir",
+            "accountMissing": "Hesap NEAR blok zincirinde mevcut değil",
+            "verifyFailed": "Hesap varlığı doğrulanamadı"
+        }
+    },
+    "csvUpload": {
+        "uploadFile": "Dosya Yükle",
+        "provideData": "Veri Sağla",
+        "chooseFile": "Dosya Seç",
+        "orDragDrop": "veya sürükleyip bırakın",
+        "maxFileSize": "en fazla 1 dosya, {maxSize} MB'a kadar, yalnızca CSV dosyası",
+        "noFilePrompt": "Yüklenecek dosyanız yok mu?",
+        "downloadTemplate": "Şablon indir"
+    },
+    "tokenSelect": {
+        "selectToken": "Token seç",
+        "searchPlaceholder": "Tokenleri ara...",
+        "noTokensFound": "Token bulunamadı"
+    },
+    "filterOperations": {
+        "is": "Şudur",
+        "isNot": "Şu Değildir",
+        "before": "Öncesi",
+        "after": "Sonrası",
+        "between": "Arasında",
+        "equal": "Eşit",
+        "moreThan": "Daha Fazla",
+        "lessThan": "Daha Az",
+        "contains": "İçeriyor"
+    },
+    "copyButton": {
+        "copied": "Panoya kopyalandı",
+        "failed": "Kopyalanamadı"
+    },
+    "recipientForm": {
+        "validation": {
+            "nameRequired": "Ad gereklidir",
+            "nameMax": "Alıcı {max} karakterden az olmalıdır",
+            "addressRequired": "Adres gereklidir",
+            "networksRequired": "En az bir ağ seçin"
+        }
+    },
+    "paymentForm": {
+        "validation": {
+            "recipientMin": "Alıcı en az 2 karakter olmalıdır",
+            "recipientMax": "Alıcı 128 karakterden az olmalıdır",
+            "amountGreaterThanZero": "Miktar 0'dan büyük olmalıdır",
+            "recipientSameAsToken": "Alıcı ve token adresi aynı olamaz",
+            "selectToken": "Lütfen bir token seçin",
+            "recipientMax64": "Alıcı 64 karakterden az olmalıdır",
+            "amountMinLockup": "Miktar 3.5'ten büyük veya eşit olmalıdır",
+            "startDateRequired": "Başlangıç tarihi gereklidir",
+            "endDateRequired": "Bitiş tarihi gereklidir",
+            "cliffDateRequired": "Cliff tarihi gereklidir",
+            "startBeforeEnd": "Başlangıç tarihi bitiş tarihinden önce olmalıdır",
+            "cliffBetween": "Cliff tarihi {start} ile {end} arasında olmalıdır"
+        }
+    },
+    "exportToasts": {
+        "downloadFailed": "Dışa aktarma indirilemedi",
+        "invalidDateRange": "Geçersiz tarih aralığı",
+        "invalidDateRangeDescription": "Lütfen dışa aktarma için geçerli bir tarih aralığı seçin.",
+        "exportSuccess": "Dışa aktarma başarılı!",
+        "exportSuccessDescription": "{type} dosyanız indirildi. Ayrıntılar için dışa aktarma geçmişinizi kontrol edin.",
+        "exportFailed": "Dışa aktarma başarısız",
+        "exportFailedFallback": "Veri dışa aktarılamadı. Lütfen tekrar deneyin.",
+        "noDownloadPermission": "Dosyayı indirme izniniz yok.",
+        "noExportPermission": "Dışa aktarma izniniz yok",
+        "quotaUsed": "Tüm kotanızı kullandınız",
+        "exporting": "Dışa Aktarılıyor...",
+        "export": "Dışa Aktar",
+        "columnSubmissionTime": "Gönderim Zamanı",
+        "columnDateRange": "Tarih Aralığı",
+        "columnGeneratedBy": "Oluşturan",
+        "columnStatus": "Durum",
+        "typeAll": "Tüm Türler",
+        "typeSent": "Gönderildi",
+        "typeReceived": "Alındı",
+        "typeStakingRewards": "Staking Ödülleri",
+        "allAssets": "Tüm Varlıklar",
+        "upgradeTrial": "Devam etmek için planınızı yükseltin",
+        "upgradePaid": "Daha fazla erişim için planınızı yükseltin veya limitleriniz gelecek ay sıfırlanana kadar bekleyin.",
+        "selectDateRange": "Tarih aralığı seçin",
+        "noExportsTitle": "Henüz dışa aktarma yok",
+        "noExportsDescription": "Son aydaki dışa aktarılmış dosyalarınız oluşturulduklarında burada görünecek.",
+        "quotaTitle": "Dışa Aktarma Kotası",
+        "unlimited": "Sınırsız",
+        "creditsPerMonth": "{total} / ay",
+        "requirementsTitle": "Dışa Aktarma Gereksinimleri",
+        "exportFromPeriod": "{period} dönemindeki verileri dışa aktarabilirsiniz.",
+        "availableFor48Hours": "Dışa aktarılan dosyalar 48 saat boyunca indirilebilir.",
+        "moreFlexibility": "Daha fazla esneklik mi arıyorsunuz?",
+        "contactUs": "Bize Ulaşın",
+        "last1Year": "Son 1 yıl",
+        "last2Years": "Son 2 yıl",
+        "invalidEmail": "Lütfen geçerli bir e-posta adresi girin"
+    },
+    "proposalKinds": {
+        "Batch Payment Request": "Toplu Ödeme Talebi",
+        "Payment Request": "Ödeme Talebi",
+        "Confidential Request": "Gizli Talep",
+        "Exchange": "Takas",
+        "Function Call": "Fonksiyon Çağrısı",
+        "Change Policy": "Politika Değişikliği",
+        "Update General Settings": "Genel Ayarları Güncelle",
+        "Earn NEAR": "NEAR Kazan",
+        "Unstake NEAR": "NEAR Stake'ini Kaldır",
+        "Vesting": "Vesting",
+        "Withdraw Earnings": "Kazançları Çek",
+        "Members": "Üyeler",
+        "Upgrade": "Yükseltme",
+        "Set Staking Contract": "Staking Sözleşmesini Ayarla",
+        "Bounty": "Ödül",
+        "Vote": "Oy",
+        "Factory Info Update": "Fabrika Bilgisi Güncellemesi",
+        "Unsupported": "Desteklenmiyor"
+    },
+    "paymentFormSection": {
+        "selectRecipient": "Alıcı Seç",
+        "searchByNameOrAddress": "Ad veya adrese göre ara",
+        "restrictedRecipientTitle": "İşleme izin verilmiyor",
+        "restrictedRecipientMessage": "Bu adres güvenlik kontrolleri nedeniyle şu anda kısıtlanmış. Bu adrese izin verilmesi gerektiğine inanıyorsanız, <link>beyaz listeye eklenmesini talep edebilirsiniz</link>.",
+        "send": "Gönder",
+        "to": "Kime"
+    },
+    "recipientNetworkSelect": {
+        "label": "Alıcı Ağı",
+        "placeholder": "Alıcı ağını seçin",
+        "enterAddressFirst": "Önce alıcı adresini girin",
+        "noCompatibleNetwork": "Bu adresle eşleşen ağ yok",
+        "selectPlaceholder": "Ağ seçin",
+        "title": "Ağ Seç",
+        "available": "Kullanılabilir",
+        "fromAddressBook": "Adres Defterinden",
+        "otherAvailable": "Diğer Kullanılabilir",
+        "incompatible": "Uyumsuz",
+        "comingSoon": "Yakında",
+        "nearComName": "near.com",
+        "nearComDescription": "near.com ve trezu için Dahili Ağ"
+    },
+    "addressBookTable": {
+        "emptyTitle": "Henüz alıcı yok",
+        "emptyDescription": "Daha hızlı ödemeler için bu adres defterine alıcılar ekleyin.",
+        "selectAll": "Tüm alıcıları seç",
+        "selectEntry": "{name} kişisini seç",
+        "recipient": "Alıcı",
+        "network": "Ağ",
+        "addedBy": "Ekleyen",
+        "note": "Not",
+        "added": "Eklendi",
+        "remove": "Kaldır",
+        "send": "Gönder"
+    },
+    "publicDashboard": {
+        "updatesDaily": "Günlük güncellenir",
+        "noDataTitle": "Henüz veri yok",
+        "noDataDescription": "İstatistikler ilk günlük anlık görüntü hesaplandıktan sonra görünecek.",
+        "assetsSecured": "Sputnik DAO Sözleşmesi ile Güvence Altına Alınan Varlıklar",
+        "acrossDaos": "<bold>{count, plural, one {# DAO} other {# DAO}}</bold> genelinde",
+        "updatedOn": "{date} tarihinde güncellendi",
+        "topAssets": "En İyi 20 Varlık",
+        "noAssetsTitle": "Henüz varlık yok",
+        "noAssetsDescription": "Token verileri günlük anlık görüntü hesaplandığında görünecek.",
+        "tableToken": "Token",
+        "tableTotalValue": "Toplam Değer"
+    },
+    "telegramConnectInstructions": {
+        "title": "Telegram Bağla",
+        "subtitle": "Önerileriniz ve etkinliğiniz hakkında Telegram'da bildirim alın.",
+        "step3": "Start'a basın ve talimatları izleyin.",
+        "success": "Hepsi tamam!",
+        "copyBotTooltip": "Bot tanıtıcısını kopyala",
+        "botCopiedToast": "Bot tanıtıcısı kopyalandı",
+        "openInTelegram": "{bot} Telegram'da aç"
+    },
+    "transactionHashCell": {
+        "copyHash": "Hash'i kopyala",
+        "hashCopied": "Hash kopyalandı",
+        "openInExplorer": "Gezginde aç"
+    },
+    "treasurySelector": {
+        "select": "Hazine seç",
+        "connectWalletTooltip": "Hazineleri görüntülemek için cüzdan bağla",
+        "manageTreasuries": "Hazineleri Yönet",
+        "createTreasury": "Hazine Oluştur",
+        "memberOf": "Üyesi Olduğunuz",
+        "guestTreasuries": "Misafir Hazineler"
+    },
+    "selectModal": {
+        "searchByName": "İsme göre ara",
+        "noResults": "Sonuç bulunamadı"
+    },
+    "selectList": {
+        "noResults": "Sonuç bulunamadı"
+    },
+    "datePicker": {
+        "pickDate": "Tarih seçin",
+        "timezone": "Saat Dilimi"
+    },
+    "datePresets": {
+        "today": "Bugün",
+        "yesterday": "Dün",
+        "last3Days": "Son 3 gün",
+        "last7Days": "Son 7 gün",
+        "last14Days": "Son 14 gün",
+        "lastMonth": "Geçen ay",
+        "last3Months": "Son 3 ay",
+        "last6Months": "Son 6 ay"
+    },
+    "input": {
+        "openSearch": "Aramayı aç"
+    },
+    "pagination": {
+        "previous": "Geri",
+        "next": "İleri"
+    },
+    "confidentialState": {
+        "title": "Gizli",
+        "description": "Yalnızca hazine üyelerinin erişimi var."
+    },
+    "exchangeRate": {
+        "rate": "Oran",
+        "clickToReverse": "Oranı tersine çevirmek için tıklayın"
+    },
+    "exchangeSettings": {
+        "title": "Takas Ayarları",
+        "slippageTolerance": "Kayma Toleransı",
+        "custom": "Özel",
+        "customPlaceholder": "örn: %2",
+        "slippageRange": "Kayma %0,01 ile %100 arasında olmalıdır",
+        "enterSlippage": "Lütfen bir kayma toleransı girin",
+        "slippageHelp": "Fiyat bu yüzdeden fazla değişirse, fonlarınızı korumak için işlem iptal edilecektir.",
+        "save": "Kaydet"
+    },
+    "assetsPage": {
+        "title": "Varlıklar",
+        "noAssetsTitle": "Henüz varlık yok",
+        "noAssetsDescription": "Başlamak için para yatırarak Hazinenize varlıklar ekleyin."
+    },
+    "newBadge": {
+        "label": "Yeni"
+    },
+    "numberBadge": {
+        "pendingRequests": "{count, plural, one {# bekleyen talep} other {# bekleyen talep}}"
+    },
+    "balanceWithGraph": {
+        "allTokens": "Tüm Tokenler",
+        "deposit": "Para Yatır",
+        "send": "Gönder",
+        "exchange": "Takas",
+        "chartNow": "Şimdi",
+        "totalBalance": "Toplam Bakiye",
+        "excludedTokens": "Hariç tutulan tokenler:",
+        "noPriceHistory": "Fiyat geçmişi yok. Bakiye değişikliklerini görmek için bir token seçin.",
+        "bucketAvailable": "Kullanılabilir",
+        "bucketLocked": "Kilitli",
+        "bucketEarning": "Kazanç",
+        "period": {
+            "1W": "1H",
+            "1M": "1A",
+            "3M": "3A",
+            "1Y": "1Y"
+        }
+    },
+    "changePolicyExpanded": {
+        "proposalBond": "Öneri Teminatı",
+        "proposalPeriod": "Öneri Dönemi",
+        "bountyBond": "Ödül Teminatı",
+        "bountyForgivenessPeriod": "Ödül Affetme Dönemi",
+        "votesCount": "{count} Oy",
+        "weightKind": "Ağırlık Türü",
+        "quorum": "Yeter Sayı",
+        "threshold": "Eşik",
+        "defaultThreshold": "Varsayılan Eşik",
+        "roleThreshold": "{role} Eşiği",
+        "member": "Üye",
+        "members": "Üyeler",
+        "permissions": "İzinler",
+        "oldPermissions": "Eski İzinler",
+        "newPermissions": "Yeni İzinler",
+        "category": "Kategori",
+        "transactionDetails": "İşlem Ayrıntıları",
+        "addNewMember": "Yeni Üye Ekle",
+        "addNewMembers": "Yeni Üyeler Ekle",
+        "removeMember": "Üyeyi Kaldır",
+        "removeMembers": "Üyeleri Kaldır",
+        "updateMemberPermissions": "Üye İzinlerini Güncelle",
+        "updateMembersPermissions": "Üyelerin İzinlerini Güncelle",
+        "memberIndex": "Üye {index}",
+        "membersCount": "{count} üye",
+        "collapseAll": "Tümünü daralt",
+        "expandAll": "Tümünü genişlet",
+        "loadingHistorical": "Geçmiş politika yükleniyor...",
+        "unableToDiff": "Bu öneri için farklılıklar hesaplanamıyor.",
+        "noChangesCurrent": "Değişiklik tespit edilmedi - önerilen politika mevcut politikayla aynı.",
+        "noChangesHistorical": "Değişiklik tespit edilmedi - önerilen politika geçmiş politikayla aynı."
+    },
+    "balanceChart": {
+        "usdValue": "USD Değeri",
+        "tokenBalance": "Token Bakiyesi",
+        "emptyTitle": "Henüz gösterilecek bir şey yok",
+        "emptyDescription": "Portföyünüzü takip etmeye başlamak için varlıklar ekleyin."
+    },
+    "user": {
+        "saveToAddressBook": "Adres defterine kaydet",
+        "walletCopiedToast": "Cüzdan adresi panoya kopyalandı",
+        "copyWalletAddress": "Cüzdan Adresini Kopyala"
+    },
+    "infoDisplay": {
+        "viewLess": "Daha Az Görüntüle",
+        "viewAllDetails": "Tüm Ayrıntıları Görüntüle"
+    },
+    "amountSummary": {
+        "defaultTitle": "Toplam göndereceğiniz miktar"
+    },
+    "residency": {
+        "vestedToken": "Vested Token",
+        "staked": "Stake Edildi",
+        "fungibleToken": "Fungible Token",
+        "intentsToken": "Intents Token",
+        "nativeToken": "Native Token"
+    },
+    "exchangeErrors": {
+        "noRoute": "Takas bulunamadı. Daha küçük bir miktar veya farklı bir token deneyin.",
+        "amountTooLow": "Takas için miktar çok düşük. Zincirler arası takaslar ağ ücretlerini karşılamak için daha yüksek bir minimum gerektirir.",
+        "insufficientBalance": "Bu takas için yetersiz bakiye.",
+        "networkError": "Ağ hatası. Lütfen bağlantınızı kontrol edin ve tekrar deneyin.",
+        "fetchFailed": "Teklif alınamadı"
+    },
+    "tokenSelectDialog": {
+        "selectToken": "Token seç",
+        "selectAsset": "Varlık Seç",
+        "selectNetworkFor": "{asset} için ağ seçin",
+        "searchByName": "İsme göre ara",
+        "noTokensWithBalance": "Bakiyesi olan token bulunamadı",
+        "noTokensFound": "Token bulunamadı",
+        "yourAssets": "Varlıklarınız",
+        "otherAssets": "Diğer Varlıklar",
+        "networksWithAssets": "Varlıkları olan ağlar",
+        "supportedNetworks": "Desteklenen Ağlar",
+        "comingSoon": "Yakında"
+    },
+    "intentsQuote": {
+        "initializing": "Teklif servisi hâlâ başlatılıyor. Lütfen tekrar deneyin.",
+        "noRoute": "Şu anda bir ödeme rotası hazırlanamıyor. Lütfen tekrar deneyin.",
+        "fetchFailed": "Şu anda bir ödeme rotası hazırlanamıyor. Lütfen tekrar deneyin.",
+        "amountTooLow": "Miktar ağ ücretlerini karşılamak için çok düşük. Daha yüksek bir miktar girin ve tekrar deneyin.",
+        "amountTooLowWithMin": "Miktar ağ ücretlerini karşılamak için çok düşük. En az {min} {token} girin.",
+        "networkFeeTooltip": "Bu ücret, seçili zincirde işlemi gerçekleştirmek için kullanılır."
+    },
+    "pageTours": {
+        "paymentsBulk": "Toplu oluşturma burada! Birkaç adımda birden çok talep oluşturun.",
+        "paymentsPending": "Onay bekleyen talepleri burada görüntüleyin.",
+        "exchangeSettings": "Burada kabul etmeye hazır olduğunuz fiyat değişikliğini ayarlayabilirsiniz.",
+        "membersPending": "Onay bekleyen aktif talepleri görmek için tıklayın.",
+        "guestSaveIntro": "Bu hazinenin misafirisiniz. Yalnızca verileri görüntüleyebilirsiniz.",
+        "guestSaveAction": "Bu misafir hazineyi hazinelerinize kaydedebilirsiniz.",
+        "newFeatureRich": "Yeni! 🎉 Daha hızlı, hatasız ödemeler için sık kullanılan adresleri kaydedin.<br></br> Kişileriniz gizli kalır ve yalnızca ekibinize görünür.",
+        "newFeatureCta": "Deneyin"
+    },
+    "statusDate": {
+        "expires": "Sona Erer",
+        "created": "Oluşturuldu",
+        "expired": "Süresi Doldu",
+        "removed": "Kaldırıldı"
+    },
+    "relativeTime": {
+        "justNow": "Az önce",
+        "moments": "anlar"
+    },
+    "amount": {
+        "network": "Ağ: {network}"
+    },
+    "activityLabels": {
+        "exchangePending": "Takas Beklemede",
+        "exchangeRequest": "Takas Talebi",
+        "exchangeFulfillment": "Takas Gerçekleştirme",
+        "stakingRewards": "Staking Ödülleri",
+        "proposalAction": "Öneri Eylemi",
+        "deposit": "{symbol} Yatırma",
+        "paymentSent": "Ödeme Gönderildi",
+        "transaction": "İşlem",
+        "fallbackToken": "Token",
+        "viaIntents": "NEAR Intents üzerinden",
+        "from": "{account} hesabından",
+        "to": "{account} hesabına",
+        "viewAll": "Tüm işlem geçmişinizi görüntüleyin",
+        "sentReceived": "Gönderilen ve alınan işlemler ({duration})",
+        "unlimitedHistory": "sınırsız geçmiş",
+        "oneYear": "1 yıl",
+        "yearsCount": "{count} yıl",
+        "monthsCount": "{count} ay",
+        "lastDuration": "son {duration}"
+    },
+    "nearStore": {
+        "connectAndAcceptTerms": "Devam etmek için lütfen cüzdanı bağlayın ve şartları kabul edin.",
+        "transactionNotApproved": "İşlem cüzdanınızda onaylanmadı.",
+        "failedSubmitVote": "Oy gönderilemedi",
+        "failedSubmitVotes": "Oylar gönderilemedi",
+        "viewRequest": "Talebi Görüntüle",
+        "proposalRemoved": "Öneriniz kaldırıldı",
+        "voteSubmitted": "Oyunuz gönderildi",
+        "votesSubmitted": "Oylarınız gönderildi"
+    },
+    "tokenInput": {
+        "max": "MAX",
+        "insufficientTokens": "Yetersiz token. Talebi gönderebilir ve onaydan önce yükleyebilirsiniz.",
+        "balance": "Bakiye: {amount} {symbol}"
+    },
+    "createRequestButton": {
+        "idle": "Talep Oluştur",
+        "noPermission": "Talep oluşturma izniniz yok"
+    },
+    "address": {
+        "copied": "Adres panoya kopyalandı"
+    },
+    "memberAvatars": {
+        "membersWhoCanVote": "Oy kullanabilen üyeler",
+        "moreMembers": "+{count, plural, one {# üye} other {# üye}}"
+    },
+    "accountIdInput": {
+        "minLength": "Hesap kimliği en az 2 karakter olmalıdır",
+        "maxLength": "Hesap kimliği 64 karakterden az olmalıdır",
+        "charset": "Hesap kimliği yalnızca küçük harfler, rakamlar, noktalar, tireler ve alt çizgiler içermelidir, başında veya sonunda ayırıcı bulunmamalıdır",
+        "doesNotExist": "Hesap kimliği mevcut değil"
+    },
+    "addressBookMutations": {
+        "addedToast": "{count, plural, one {Alıcı eklendi} other {# alıcı eklendi}}",
+        "addedSingleToast": "Alıcı eklendi",
+        "addFailedToast": "Alıcılar eklenemedi",
+        "addSingleFailedToast": "Alıcı eklenemedi",
+        "removedToast": "{count, plural, one {Alıcı kaldırıldı} other {# alıcı kaldırıldı}}",
+        "removeFailedToast": "Alıcılar kaldırılamadı",
+        "exportFailedToast": "Alıcılar dışa aktarılamadı"
+    },
+    "treasuryMutations": {
+        "savedToast": "Hazine listenize kaydedildi",
+        "saveFailedToast": "Hazine kaydedilemedi",
+        "hiddenToast": "Hazine listeden gizlendi",
+        "hideFailedToast": "Hazine gizlenemedi",
+        "unhiddenToast": "Hazine tekrar görünür",
+        "unhideFailedToast": "Hazine gösterilemedi",
+        "removedToast": "Hazine kaydedilen listeden kaldırıldı",
+        "removeFailedToast": "Hazine kaydedilen listeden kaldırılamadı"
+    },
+    "telegramSettings": {
+        "title": "Telegram",
+        "connectedTo": "{chat} sohbetine bağlı",
+        "chatNumber": "Sohbet #{id}",
+        "fallbackChat": "bir Telegram sohbeti",
+        "disconnect": "Bağlantıyı Kes",
+        "connect": "Bağlan",
+        "connectDescription": "Bildirim almak için hazinenizi bir Telegram sohbetine bağlayın.",
+        "noTreasuryDescription": "Hazinelerinizi bir Telegram sohbetine bağlayın.",
+        "openSettingsHint": "Entegrasyonları yönetmek için bir hazineden ayarları açın.",
+        "disconnectedToast": "Bu hazine için Telegram bağlantısı kesildi",
+        "disconnectFailedToast": "Telegram bağlantısı kesilemedi. Tekrar deneyin."
+    },
+    "assetsTable": {
+        "noAssetsFound": "Varlık bulunamadı.",
+        "assetDetails": "Varlık Ayrıntıları",
+        "coinPrice": "Coin Fiyatı",
+        "weight": "Ağırlık",
+        "balance": "Bakiye",
+        "lockedBalance": "Kilitli Bakiye",
+        "totalBalance": "Toplam Bakiye",
+        "source": "Kaynak",
+        "balanceByInvestors": "{count, plural, one {Yatırımcıya} other {Yatırımcılara}} Göre Bakiye",
+        "investors": "{count, plural, one {Yatırımcı} other {Yatırımcılar}}",
+        "poolBreakdown": "Havuz Dökümü",
+        "unlockedToken": "Kilitsiz Token",
+        "lockupStakingPool": "Lockup staking havuzu",
+        "exchange": "Takas",
+        "send": "Gönder",
+        "details": "Ayrıntılar",
+        "columnToken": "Token",
+        "columnLocked": "Kilitli",
+        "columnUnlocked": "Kilitsiz",
+        "columnTotalAllocated": "Toplam Tahsis Edilen",
+        "columnAvailableToWithdraw": "Çekilebilir",
+        "viewAvailable": "Kullanılabilir",
+        "viewLocked": "Kilitli",
+        "viewEarning": "Kazanç",
+        "fullAllocatedBalance": "Tahsis edilen tam bakiyeniz",
+        "partAllocatedBalance": "Tahsis edilen bakiyenizin bir kısmı",
+        "currentlyEarning": "({amount} {symbol}) şu anda kazanıyor.",
+        "willAppearHere": " Kazanmayı durdurduğunuzda burada görünecek.",
+        "seeInEarningTab": "Kazanç sekmesinde gör",
+        "seeInEarning": "Kazanç'ta gör"
+    },
+    "earningDetails": {
+        "title": "Kazanç Ayrıntıları",
+        "totalStaked": "Toplam Stake Edilen",
+        "earningOverview": "Kazanç Genel Görünümü",
+        "poolBreakdown": "Havuz Dökümü ({count, plural, one {# havuz} other {# havuz}})",
+        "almostReady": "Kazan neredeyse hazır!",
+        "finalizingFeature": "Bu özelliği tamamlıyoruz<br></br>böylece kısa süre içinde token kazanmaya başlayabilirsiniz.",
+        "comingSoon": "Yakında",
+        "goToEarn": "Kazanca Git",
+        "readyToWithdraw": "Çekmeye hazır",
+        "unstaking": "Stake'i kaldırma",
+        "overview": {
+            "staked": "Stake Edildi",
+            "stakedInfo": "Şu anda doğrulayıcılara delege edilmiş ve ödül kazanan tokenler.",
+            "pendingRelease": "Bekleyen Serbest Bırakma",
+            "pendingReleaseInfo": "Stake'i kaldırılmış ancak hâlâ kilit açma süresinde olan tokenler (genellikle 2-3 gün).",
+            "availableForWithdraw": "Çekilebilir",
+            "availableForWithdrawInfo": "Kilit açma süresini tamamlamış ve çekilebilen stake'i kaldırılmış tokenler."
+        }
+    },
+    "lockupDetails": {
+        "title": "Lockup Ayrıntıları",
+        "balance": "Bakiye",
+        "reservedForStorage": "Depolama İçin Ayrılmış",
+        "reservedForStorageInfo": "Lockup hesabı tarafından depolama maliyetlerini ödemek için ayrılan NEAR.",
+        "tokenBreakdown": "Token Dökümü",
+        "allocatedAmount": "Tahsis Edilen Miktar",
+        "earned": "Kazanılan",
+        "progress": "İlerleme",
+        "unlocked": "Kilidi Açıldı",
+        "locked": "Kilitli",
+        "schedule": "Plan",
+        "startDate": "Başlangıç Tarihi",
+        "endDate": "Bitiş Tarihi",
+        "rounds": "Turlar",
+        "releaseInterval": "Serbest Bırakma Aralığı",
+        "nextUnlockDate": "Sonraki Kilit Açma Tarihi",
+        "allEarning": "Lockup'ınızdan tüm {amount} {symbol} şu anda kazanıyor.",
+        "partEarning": "Lockup'ınızın bir kısmı ({amount} {symbol}) şu anda kazanıyor.",
+        "stopEarningFirst": "Kilidi açılmış tokenleri kullanmak için önce kazanmayı durdurun ve onları çekin.",
+        "howGrantWorks": "Hibeniz nasıl çalışır",
+        "ftStep1": "Belirli bir süre için bir hibe alırsınız. Tüm miktarı bir kerede almak yerine, varlıklar zaman içinde parçalar halinde kullanılabilir hale gelir.",
+        "ftStep2": "Bir sonraki serbest bırakma tarihi geldiğinde, bu token bölümü otomatik olarak kilidi açılır ve hazine bakiyenize taşınır.",
+        "ftStep3": "Bakiyenizde göründüklerinde, ödemeler, transferler veya diğer işlemler için hemen kullanabilirsiniz.",
+        "nearStep1": "Tanımlanmış bir başlangıç ve bitiş tarihi olan belirli bir süre için bir hibe alırsınız.",
+        "nearStep2": "Tokenlerin kilidi açıldıkça, otomatik olarak hazine bakiyenizde kullanılabilir hale gelirler.",
+        "nearStep3": "Kilidi açılmış tokenleri ödemeler, transferler veya diğer işlemler için hemen kullanabilirsiniz.",
+        "notAvailable": "Yok",
+        "everyMonth": "Her ay",
+        "everyQuarter": "Her çeyrek",
+        "everyUnit": "Her {unit}",
+        "everyMultiple": "Her {text}",
+        "completed": "Tamamlandı",
+        "unit": {
+            "year": "{count, plural, one {# yıl} other {# yıl}}",
+            "day": "{count, plural, one {# gün} other {# gün}}",
+            "hour": "{count, plural, one {# saat} other {# saat}}",
+            "minute": "{count, plural, one {# dakika} other {# dakika}}",
+            "second": "{count, plural, one {# saniye} other {# saniye}}"
+        }
+    },
+    "vestingDetails": {
+        "title": "Vesting Ayrıntıları",
+        "availableToUse": "Kullanılabilir",
+        "vestingPeriod": "Vesting Dönemi",
+        "vestingPeriodDescription": "Tokenler bu dönem boyunca günlük olarak kilidi açılır.",
+        "startDate": "Başlangıç Tarihi",
+        "endDate": "Bitiş Tarihi",
+        "tokenBreakdown": "Token Dökümü",
+        "originalVestedAmount": "Orijinal Vested Miktar",
+        "reservedForStorage": "Depolama İçin Ayrılmış",
+        "reservedForStorageInfo": "Vesting'i aktif tutmak ve depolama maliyetlerini karşılamak için gereken küçük miktarda token.",
+        "percentVested": "%{percent} Hak Edildi",
+        "vestedOf": "{total} {symbol}'den {vested}",
+        "send": "Gönder"
+    },
+    "earningPoolDetails": {
+        "balance": "Bakiye",
+        "apy": "APY",
+        "fee": "Ücret",
+        "notAvailable": "Yok",
+        "lockupStakingPool": "Lockup staking havuzu",
+        "lockupAssetsNote": "Bu pozisyondaki tüm varlıklar lockup'ınızdan gelir. Kazanmayı durdurduktan sonra, bazı tokenler hâlâ kilitli ve kullanılamaz olabilir - ne zaman kilidi açılacağını görmek için lockup planınızı kontrol edin."
+    },
+    "onboardingQuestions": {
+        "stepTitle": "Başlamak için birkaç hızlı soru.",
+        "other": "Diğer",
+        "placeholders": {
+            "describeRole": "Rolünüzü tanımlayın (isteğe bağlı)",
+            "describeUseCase": "Kullanım durumunuzu tanımlayın (isteğe bağlı)",
+            "networkName": "Ağ adını girin (isteğe bağlı)",
+            "currentChallenge": "Mevcut zorluğunuzu girin (isteğe bağlı)",
+            "describeOther": "Diğer'i tanımlayın (isteğe bağlı)"
+        },
+        "questions": {
+            "role": "Rolünüzü en iyi ne tanımlar?",
+            "useCases": "Trezu'yu ne için kullanmayı planlıyorsunuz?",
+            "teamSize": "Hazineyi kaç kişi yönetecek?",
+            "networks": "En sık hangi ağları kullanıyorsunuz?",
+            "multisigExperience": "Multisig konusundaki deneyiminiz nedir?",
+            "currentTools": "Şu anda finansları yönetmek için hangi araçları kullanıyorsunuz?",
+            "monthlyVolume": "Yaklaşık aylık işlem hacmi?",
+            "biggestChallenges": "Şu anda en büyük zorluğunuz nedir?"
+        },
+        "options": {
+            "role": {
+                "founder": "Kurucu",
+                "co-founder": "Eş Kurucu",
+                "cfo-finance-lead": "CFO / Finans Lideri",
+                "operations-manager": "Operasyon Yöneticisi",
+                "treasury-manager": "Hazine Yöneticisi",
+                "other": "Diğer"
+            },
+            "useCases": {
+                "team-payroll-grants": "Ekip bordro ve hibeleri",
+                "company-assets-management": "Şirket varlık yönetimi",
+                "dao-treasury-management": "DAO hazine yönetimi",
+                "investment-portfolio": "Yatırım portföyü",
+                "operational-spending": "Operasyonel harcama",
+                "other": "Diğer"
+            },
+            "teamSize": {
+                "just-me": "Sadece ben",
+                "2-5-people": "2-5 kişi",
+                "6-15-people": "6-15 kişi",
+                "15-plus-people": "15+"
+            },
+            "networks": {
+                "near": "NEAR",
+                "bitcoin": "Bitcoin",
+                "ethereum": "Ethereum",
+                "solana": "Solana",
+                "arbitrum": "Arbitrum",
+                "base": "Base",
+                "optimism": "Optimism",
+                "polygon": "Polygon",
+                "gnosis": "Gnosis",
+                "avalanche": "Avalanche",
+                "bnb-chain": "BNB Chain",
+                "other": "Diğer"
+            },
+            "multisigExperience": {
+                "never-heard-of-it": "Hiç duymadım",
+                "heard-about-it": "Duydum",
+                "never-used-it": "Hiç kullanmadım",
+                "used-gnosis-safe-or-similar": "Gnosis Safe veya benzerini kullandım",
+                "experienced": "Deneyimli",
+                "looking-for-a-better-option": "Daha iyi bir seçenek arıyorum"
+            },
+            "currentTools": {
+                "gnosis-safe": "Gnosis Safe",
+                "fireblocks": "Fireblocks",
+                "tholos": "Tholos",
+                "squads-multisig": "Squads Multisig",
+                "mpc-vault": "MPC Vault",
+                "other": "Diğer"
+            },
+            "monthlyVolume": {
+                "under-10k": "10.000 $ altı",
+                "10k-100k": "10.000 $ - 100.000 $",
+                "100k-1m": "100.000 $ - 1 M $",
+                "1m-plus": "1 M $+"
+            },
+            "biggestChallenges": {
+                "slow-approvals-and-signing": "Yavaş onaylar ve imzalama",
+                "lack-of-transparency-in-the-team": "Ekipte şeffaflık eksikliği",
+                "hard-to-track-spending-and-balances": "Harcamaları ve bakiyeleri takip etmek zor",
+                "security-and-access-control": "Güvenlik ve erişim kontrolü",
+                "no-good-web3-tool-yet": "Henüz iyi bir Web3 aracı yok",
+                "looking-for-crypto-earnings": "Kripto kazançları arıyorum",
+                "other": "Diğer"
+            }
+        }
+    },
+    "onboarding": {
+        "tour": {
+            "addAssets": "Para yatırarak Hazinenize varlıklar ekleyin.",
+            "makeRequests": "Varlık göndermeniz gerektiğinde ödeme talepleri oluşturun.",
+            "exchangeAssets": "Burada varlıklarınızı takas edebilirsiniz.",
+            "addMembers": "Hazinenize üyeler ekleyin ve onlara roller atayın.",
+            "newTreasury": "Yeni bir Hazine kurmak ister misiniz? Birkaç tıklamayla burada yapabilirsiniz.",
+            "helpSupport": "İhtiyacınız olduğunda yardım ve destek alın."
+        },
+        "tourCard": {
+            "close": "Kapat",
+            "stepProgress": "{total} adımdan {current}",
+            "gotIt": "Anladım",
+            "done": "Tamam",
+            "next": "İleri"
+        },
+        "progress": {
+            "title": "Hazineyi Keşfetmek İçin Hızlı Adımları İzleyin",
+            "createTreasuryTitle": "Hazine hesabı oluştur",
+            "createTreasuryDescription": "Hesabınızı başarıyla kurdunuz. Harika bir başlangıç!",
+            "addAssetsTitle": "Varlıklarınızı Ekleyin",
+            "addAssetsDescription": "Onları iş başında görmek için varlıklar ekleyerek başlayın.",
+            "deposit": "Para Yatır",
+            "createPaymentTitle": "Ödeme Talebi Oluşturun",
+            "createPaymentDescription": "Kurulumunuzu tamamlamak için bir ödeme talebi oluşturun.",
+            "send": "Gönder"
+        },
+        "welcome": {
+            "heading": "🎉 Hoş Geldiniz!",
+            "subheading": "Hazinenin kısa bir turuna katılın",
+            "body": "Merhaba! Trezu'nuz hazır - desteklenen ağlardan varlıklar ekleyerek portföyünüzü oluşturmaya başlayın.",
+            "progress": "{total} adımdan {current}",
+            "next": "İleri",
+            "body2": "Nasıl para yatıracağınızı, talep oluşturacağınızı ve yeni bir hesap kuracağınızı görün.",
+            "noThanks": "Hayır, teşekkürler",
+            "letsGo": "Hadi başlayalım"
+        },
+        "congrats": {
+            "heading": "🎉 Tebrikler!",
+            "body": "Hazine kurulumunuzu tamamladınız. Varlıklarınızı kolayca yönetmenin tadını çıkarın.",
+            "letsGo": "Hadi başlayalım!"
+        },
+        "createBanner": {
+            "close": "Kapat",
+            "title": "Trezu'yu Keşfet",
+            "description": "Trezu'nun tüm özelliklerine ve avantajlarına izin almak için bir hesap oluşturun.",
+            "cta": "Hazine Oluştur"
+        },
+        "questionnaire": {
+            "continue": "Devam Et",
+            "skip": "Atla"
+        },
+        "createPrompt": {
+            "title": "Neredeyse hazırsınız",
+            "description": "Cüzdanınız bağlı, ancak henüz bir hazine oluşturmadınız. Trezu'yu kullanmaya başlamak için bir hesap oluşturun veya {suffix}",
+            "suffixDemo": "demoyu inceleyin.",
+            "suffixExploring": "keşfetmeye devam edin.",
+            "createCta": "Hazine Oluştur",
+            "viewDemo": "Demoyu Görüntüle",
+            "keepExploring": "Keşfetmeye Devam Et"
+        },
+        "infoBox": {
+            "title": "Trezu'dan daha fazlasını alın",
+            "close": "Kapat",
+            "description": "Diğerlerinin Hazineyi nasıl kullandığını keşfedin, demoyu deneyin ve özellikleri öğrenmek için belgeleri kontrol edin.",
+            "demoTitle": "Trezu Demosunu Keşfet",
+            "demoDescription": "Canlı bir demo hesabını işlerken görün.",
+            "docsTitle": "Belgeler",
+            "docsDescription": "Tüm özellikler hakkında belgelerden bilgi edinin.",
+            "videoTitle": "Demoyu İzleyin",
+            "videoDescription": "Trezu'nun nasıl çalıştığını gösteren kısa bir video izleyin."
+        }
+    }
+}

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -44,7 +44,16 @@
         "english": "English",
         "spanish": "Español",
         "ukrainian": "Українська",
-        "hebrew": "עברית"
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
     },
     "header": {
         "toggleSidebar": "Перемкнути бічну панель",
@@ -512,7 +521,7 @@
             "description": "Опис",
             "methodName": "Назва методу",
             "args": "Аргументи",
-            "deposit": "Депозит",
+            "deposit": "Поповнити",
             "gas": "Газ",
             "totalDeposit": "Загальний депозит",
             "totalGas": "Загальний газ",
@@ -634,7 +643,6 @@
             "approvalsReceived": "{received}/{required} отримано схвалень",
             "expiresAt": "Спливає",
             "expiredAt": "Спливло",
-            "viewTransaction": "Переглянути транзакцію",
             "exchangingTokens": "Обмін токенів",
             "exchangingTokensBody": "Цей запит схвалила команда. Обмін токенів триває і може зайняти деякий час.",
             "requestFailed": "Запит не виконано",
@@ -642,7 +650,6 @@
             "votingPeriod24h": "Період голосування: 24 години",
             "votingPeriod24hBody": "Цей запит на обмін має 24-годинний період голосування. Схваліть його за цей час, інакше запит спливе.",
             "reject": "Відхилити",
-            "deposit": "Поповнити",
             "approve": "Схвалити"
         },
         "insufficientBalance": {

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -1,0 +1,2101 @@
+{
+    "common": {
+        "loading": "Đang tải...",
+        "notAvailable": "N/A",
+        "connecting": "Đang kết nối...",
+        "save": "Lưu",
+        "cancel": "Hủy",
+        "submit": "Gửi",
+        "close": "Đóng",
+        "back": "Quay lại",
+        "seeDemo": "Xem Demo Trezu",
+        "search": "Tìm kiếm",
+        "filter": "Lọc",
+        "filterActive": "Lọc (đang hoạt động)",
+        "export": "Xuất",
+        "exporting": "Đang xuất",
+        "import": "Nhập",
+        "remove": "Xóa",
+        "removing": "Đang xóa...",
+        "edit": "Chỉnh sửa",
+        "continue": "Tiếp tục",
+        "select": "Chọn",
+        "all": "Tất cả",
+        "none": "Không có",
+        "retry": "Thử lại",
+        "tryAgain": "Vui lòng thử lại.",
+        "confirm": "Xác nhận",
+        "next": "Tiếp",
+        "previous": "Trước",
+        "yes": "Có",
+        "no": "Không",
+        "approve": "Phê duyệt",
+        "reject": "Từ chối",
+        "copy": "Sao chép",
+        "copied": "Đã sao chép",
+        "viewAll": "Xem tất cả",
+        "viewDetails": "Xem chi tiết",
+        "noResults": "Không tìm thấy kết quả",
+        "add": "Thêm"
+    },
+    "languageSwitcher": {
+        "label": "Ngôn ngữ",
+        "select": "Chọn ngôn ngữ",
+        "english": "English",
+        "spanish": "Español",
+        "ukrainian": "Українська",
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
+    },
+    "header": {
+        "toggleSidebar": "Bật/tắt thanh bên",
+        "toggleTheme": "Chuyển đổi giao diện"
+    },
+    "nav": {
+        "dashboard": "Bảng điều khiển",
+        "requests": "Yêu cầu",
+        "payments": "Thanh toán",
+        "exchange": "Trao đổi",
+        "addressBook": "Sổ địa chỉ",
+        "members": "Thành viên",
+        "settings": "Cài đặt",
+        "helpSupport": "Trợ giúp & Hỗ trợ",
+        "saveGuestTreasury": "Lưu ngân quỹ khách này vào danh sách ngân quỹ của bạn."
+    },
+    "signIn": {
+        "connect": "Kết nối",
+        "connectWallet": "Kết nối ví",
+        "wallet": "Ví",
+        "termsOfService": "Điều khoản dịch vụ",
+        "privacyPolicy": "Chính sách bảo mật",
+        "disconnect": "Ngắt kết nối"
+    },
+    "auth": {
+        "noWallet": "Kết nối ví của bạn",
+        "noPermission": "Bạn không có quyền thực hiện hành động này",
+        "noVote": "Bạn đã bỏ phiếu cho đề xuất này",
+        "noSponsoredTransactions": "Không còn giao dịch được tài trợ"
+    },
+    "landing": {
+        "welcome": "Chào mừng đến với Trezu",
+        "chooseOption": "Chọn một tùy chọn bên dưới để bắt đầu.",
+        "newUserTitle": "Tôi mới biết đến Trezu",
+        "newUserDescription": "Tôi đã nghe về Trezu nhưng chưa có ngân quỹ.",
+        "existingUserTitle": "Tôi đã sử dụng Trezu",
+        "existingUserDescription": "Tôi đã có tài khoản và đang quản lý một ngân quỹ.",
+        "gradientTagline": "Bảo mật multisig liên chuỗi để quản lý tài sản số",
+        "waitlistTitle": "Tham gia danh sách chờ Trezu",
+        "waitlistSubmittedTitle": "Bạn đã có trong danh sách 🎉",
+        "waitlistSubmittedDescription": "Cảm ơn! Chúng tôi sẽ thông báo cho bạn ngay khi có thể tạo ngân quỹ.",
+        "waitlistDescription": "Chúng tôi đã đạt giới hạn tạo ngân quỹ hôm nay. Đừng lo - hãy thử lại sau hoặc để lại thông tin liên hệ để vào danh sách chờ. Chúng tôi sẽ báo cho bạn khi có chỗ trống.",
+        "waitlistInputPlaceholder": "Địa chỉ email hoặc Telegram (ví dụ: @username)",
+        "waitlistPrivacyNote": "Chúng tôi chỉ sử dụng thông tin này để thông báo cho bạn",
+        "waitlistSubmit": "Tham gia danh sách chờ",
+        "waitlistSubmitFailed": "Gửi không thành công. Vui lòng thử lại.",
+        "welcomeAlt": "chào mừng"
+    },
+    "blocked": {
+        "title": "Dịch vụ không khả dụng tại quốc gia của bạn",
+        "description": "Do các hạn chế, dịch vụ này hiện không khả dụng tại khu vực của bạn."
+    },
+    "notFound": {
+        "title": "Rất tiếc, trang này không còn nữa...",
+        "description": "Có vẻ như bạn đã đi theo một liên kết không còn hoạt động. Hãy thử quay lại hoặc trở về Bảng điều khiển.",
+        "backToDashboard": "Quay lại Bảng điều khiển"
+    },
+    "treasuryInfo": {
+        "logoAlt": "Logo Ngân quỹ"
+    },
+    "dateInput": {
+        "placeholder": "dd/mm/yyyy"
+    },
+    "thresholdSlider": {
+        "warningSingleMember": "Ngưỡng 1-trên-{memberCount} có nghĩa là bất kỳ thành viên nào cũng có thể thực thi giao dịch. Điều này làm giảm tính bảo mật.",
+        "infoBalanced": "Ngưỡng {currentThreshold}-trên-{memberCount} mang lại sự cân bằng tốt giữa bảo mật và linh hoạt vận hành."
+    },
+    "intentsFee": {
+        "amountTooLowForFee": "{prefix}Số tiền quá thấp so với phí mạng ({fee} {symbol}). Hãy thêm ít nhất {addMore} {symbol}."
+    },
+    "metadata": {
+        "treasuryTitle": "Bảng điều khiển | Trezu",
+        "landingTitle": "Trezu | Quản lý ngân quỹ liên chuỗi",
+        "description": "Quản lý vốn của đội bạn trong vài phút từ một bảng điều khiển duy nhất mà không cần từ bỏ khóa của mình.",
+        "ogTitle": "Trezu | Một multisig. Mọi loại crypto. Toàn quyền kiểm soát."
+    },
+    "pages": {
+        "dashboard": {
+            "title": "Bảng điều khiển",
+            "description": "Tổng quan về tài sản và hoạt động của ngân quỹ",
+            "descriptionLong": "Quản lý tài sản ngân quỹ và theo dõi hoạt động"
+        },
+        "activity": {
+            "title": "Giao dịch gần đây",
+            "descriptionDetails": "Chi tiết yêu cầu",
+            "descriptionList": "Giao dịch gần đây trên tất cả tài sản"
+        },
+        "requests": {
+            "title": "Yêu cầu",
+            "description": "Xem và quản lý tất cả yêu cầu multisig đang chờ",
+            "detailDescription": "Chi tiết yêu cầu",
+            "detailTitle": "Yêu cầu #{id}"
+        },
+        "members": {
+            "title": "Thành viên",
+            "description": "Quản lý thành viên đội và quyền hạn"
+        },
+        "settings": {
+            "title": "Cài đặt",
+            "description": "Điều chỉnh cài đặt ứng dụng của bạn"
+        },
+        "addressBook": {
+            "title": "Sổ địa chỉ",
+            "description": "Quản lý người nhận đã lưu của bạn"
+        },
+        "payments": {
+            "title": "Thanh toán",
+            "description": "Gửi và nhận tiền một cách an toàn"
+        },
+        "exchange": {
+            "title": "Trao đổi",
+            "description": "Trao đổi token một cách an toàn và hiệu quả"
+        },
+        "vesting": {
+            "title": "Vesting",
+            "description": "Tạo lịch vesting nhanh chóng và dễ dàng"
+        },
+        "earn": {
+            "title": "Thu nhập",
+            "description": "Kiếm phần thưởng từ tài sản của bạn",
+            "placeholder": "Khám phá cơ hội thu nhập và phần thưởng staking."
+        },
+        "createTreasury": {
+            "title": "Tạo Ngân quỹ",
+            "description": "Thiết lập một ngân quỹ multisig mới cho đội của bạn"
+        },
+        "manageTreasuries": {
+            "title": "Quản lý Ngân quỹ",
+            "description": "Kiểm soát các ngân quỹ hiển thị trong tài khoản của bạn"
+        },
+        "stats": {
+            "title": "Thống kê",
+            "description": "Tài sản đang quản lý theo thời gian thực trên tất cả ngân quỹ sputnik DAO."
+        },
+        "telegram": {
+            "title": "Kết nối Ngân quỹ",
+            "description": "Liên kết ngân quỹ của bạn với một cuộc trò chuyện Telegram",
+            "metaTitle": "Trezu — Kết nối Telegram",
+            "metaDescription": "Kết nối ngân quỹ Trezu của bạn với một cuộc trò chuyện Telegram"
+        },
+        "wallet": {
+            "title": "Ví Trezu",
+            "description": "Ký các đề xuất ngân quỹ thông qua Trezu"
+        }
+    },
+    "depositModal": {
+        "validation": {
+            "selectAsset": "Vui lòng chọn một tài sản",
+            "selectNetwork": "Vui lòng chọn một mạng"
+        },
+        "sections": {
+            "supportedNetworks": "Mạng được hỗ trợ",
+            "networksWithAssets": "Mạng có tài sản",
+            "yourAssets": "Tài sản của bạn",
+            "otherAssets": "Tài sản khác"
+        },
+        "errors": {
+            "addressUnavailable": "Không thể lấy địa chỉ nạp tiền cho tài sản và mạng đã chọn.",
+            "fetchFailed": "Không thể lấy địa chỉ nạp tiền. Vui lòng thử lại."
+        },
+        "title": "Nạp tiền",
+        "subtitle": "Chọn tài sản và mạng để xem địa chỉ nạp tiền",
+        "assetLabel": "Tài sản",
+        "networkLabel": "Mạng",
+        "selectAsset": "Chọn tài sản",
+        "selectNetwork": "Chọn mạng",
+        "otherAssetName": "Khác",
+        "otherNetworkInfo": "Bạn có thể nạp bất kỳ token nào không có trong danh sách tài sản, nhưng chỉ qua mạng NEAR.",
+        "depositAddressHeading": "Địa chỉ nạp tiền",
+        "depositAddressSubtitle": "Hãy luôn kiểm tra kỹ địa chỉ nạp tiền của bạn.",
+        "addressLabel": "Địa chỉ",
+        "addressCopied": "Đã sao chép địa chỉ vào bộ nhớ tạm",
+        "memoLabel": "Memo",
+        "memoCopied": "Đã sao chép memo vào bộ nhớ tạm",
+        "memoWarning": "Bạn <bold>phải</bold> thêm memo khi gửi tiền đến địa chỉ này. Gửi mà không có memo có thể dẫn đến mất tiền vĩnh viễn.",
+        "onlyDeposit": "Chỉ nạp <symbolTag>{symbol}</symbolTag> từ mạng <networkTag>{network}</networkTag>. Chúng tôi khuyên bạn bắt đầu với một giao dịch thử nhỏ để đảm bảo mọi thứ hoạt động chính xác trước khi gửi toàn bộ số tiền.",
+        "minimumDeposit": "Số tiền nạp tối thiểu là <amountTag>{amount} {symbol}</amountTag>",
+        "searchByName": "Tìm theo tên"
+    },
+    "assetDetails": {
+        "coinPrice": "Giá Coin",
+        "weight": "Trọng số",
+        "source": "Nguồn",
+        "send": "Gửi",
+        "exchange": "Trao đổi",
+        "comingSoon": "Sắp ra mắt",
+        "vesting": "Vesting",
+        "vestedPercent": "Đã vesting {percent}%",
+        "frozen": "Đã đóng băng",
+        "frozenTooltip": "Token bị đóng băng đã bị khóa và không thể sử dụng. Chúng có thể bị khóa do được dùng cho lưu trữ, staking, hoặc chưa được vesting.",
+        "vested": "Đã vesting"
+    },
+    "dashboard": {
+        "overview": "Tổng quan về tài sản và hoạt động ngân quỹ của bạn",
+        "assets": "Tài sản",
+        "balance": "Số dư",
+        "totalBalance": "Tổng số dư",
+        "deposit": "Nạp tiền",
+        "addAssets": "Thêm tài sản",
+        "hidden": "Đã ẩn",
+        "confidentialHidden": "Số dư bị ẩn đối với ngân quỹ bảo mật",
+        "recentActivity": "Hoạt động gần đây",
+        "viewAllTransactions": "Xem tất cả giao dịch"
+    },
+    "activity": {
+        "filters": {
+            "createdDate": "Ngày tạo",
+            "token": "Token",
+            "from": "Từ",
+            "to": "Đến"
+        },
+        "tabs": {
+            "all": "Tất cả",
+            "sent": "Đã gửi",
+            "received": "Đã nhận",
+            "stakingRewards": "Phần thưởng Staking",
+            "exchange": "Trao đổi"
+        },
+        "searchPlaceholder": "Tìm theo hash giao dịch",
+        "searchPlaceholderShort": "Hash giao dịch",
+        "fromPool": "từ {pool}",
+        "table": {
+            "type": "LOẠI",
+            "transaction": "GIAO DỊCH",
+            "from": "TỪ",
+            "to": "ĐẾN",
+            "transactionHash": "HASH GIAO DỊCH",
+            "hashTooltip": "Định danh duy nhất (hash) của giao dịch này"
+        },
+        "empty": {
+            "title": "Không tìm thấy giao dịch nào",
+            "description": "Giao dịch của bạn sẽ xuất hiện ở đây khi chúng diễn ra"
+        },
+        "emptyDashboard": {
+            "title": "Chưa có gì để hiển thị",
+            "description": "Giao dịch và các hành động của bạn sẽ xuất hiện ở đây khi chúng diễn ra"
+        },
+        "recentTitle": "Giao dịch gần đây",
+        "details": {
+            "title": "Chi tiết giao dịch",
+            "copyAddress": "Sao chép địa chỉ",
+            "addressCopied": "Đã sao chép địa chỉ vào bộ nhớ tạm",
+            "sell": "Bán",
+            "receive": "Nhận",
+            "pending": "Đang chờ",
+            "type": "Loại",
+            "date": "Ngày",
+            "from": "Từ",
+            "to": "Đến",
+            "method": "Phương thức",
+            "contract": "Hợp đồng",
+            "transaction": "Giao dịch"
+        }
+    },
+    "export": {
+        "types": {
+            "csv": ".CSV",
+            "json": ".JSON",
+            "xlsx": ".XLSX"
+        },
+        "transactionTypes": {
+            "all": "Tất cả loại",
+            "sent": "Đã gửi",
+            "received": "Đã nhận",
+            "stakingRewards": "Phần thưởng Staking"
+        },
+        "validation": {
+            "invalidEmail": "Vui lòng nhập một địa chỉ email hợp lệ"
+        },
+        "columns": {
+            "submissionTime": "Thời gian gửi",
+            "dateRange": "Khoảng ngày",
+            "generatedBy": "Tạo bởi",
+            "status": "Trạng thái"
+        },
+        "status": {
+            "generating": "Đang tạo",
+            "expired": "Đã hết hạn",
+            "failed": "Thất bại"
+        },
+        "noPermission": "Bạn không có quyền tải tệp này.",
+        "download": "Tải xuống",
+        "heading": "Xuất các giao dịch gần đây",
+        "teamOnly": "Việc tạo và tải xuống bản xuất chỉ dành cho thành viên đội.",
+        "creditsUsed": "Bạn đã dùng hết tín dụng",
+        "exportsUsed": "Bạn đã dùng hết lượt xuất",
+        "upgradePrompt": "Nâng cấp gói của bạn để có thêm và tiếp tục",
+        "resetPrompt": "Nâng cấp gói để có thêm quyền truy cập, hoặc đợi đến khi giới hạn của bạn được đặt lại vào tháng sau.",
+        "tabs": {
+            "generate": "Tạo bản xuất",
+            "history": "Lịch sử"
+        },
+        "fields": {
+            "documentType": "Loại tài liệu",
+            "timeRange": "Khoảng thời gian",
+            "selectDateRange": "Chọn khoảng ngày",
+            "asset": "Tài sản",
+            "allAssets": "Tất cả tài sản",
+            "transactionType": "Loại giao dịch"
+        },
+        "buttons": {
+            "noPermissionExport": "Bạn không có quyền xuất",
+            "quotaExhausted": "Bạn đã dùng hết hạn mức",
+            "exporting": "Đang xuất...",
+            "export": "Xuất"
+        },
+        "empty": {
+            "title": "Chưa có bản xuất nào",
+            "description": "Các tệp đã xuất trong tháng vừa qua sẽ xuất hiện ở đây sau khi được tạo."
+        },
+        "requirements": {
+            "heading": "Yêu cầu xuất",
+            "canExportFrom": "Bạn có thể xuất dữ liệu từ",
+            "availability": "Các tệp đã xuất khả dụng để tải trong 48 giờ."
+        },
+        "quota": {
+            "heading": "Hạn mức xuất",
+            "unlimited": "Không giới hạn",
+            "perMonth": "{count} / tháng",
+            "flexibilityPrompt": "Cần thêm sự linh hoạt?",
+            "contactUs": "Liên hệ với chúng tôi"
+        }
+    },
+    "requests": {
+        "filters": {
+            "proposalTypes": {
+                "Payments": "Thanh toán",
+                "Exchange": "Trao đổi",
+                "Earn": "Thu nhập",
+                "Vesting": "Vesting",
+                "Function Call": "Gọi hàm",
+                "Change Policy": "Thay đổi chính sách",
+                "Settings": "Cài đặt",
+                "Confidential": "Bảo mật"
+            },
+            "voteStatus": {
+                "Approved": "Đã phê duyệt",
+                "Rejected": "Đã từ chối",
+                "No Voted": "Chưa bỏ phiếu"
+            },
+            "requestsType": "Loại yêu cầu",
+            "createdDate": "Ngày tạo",
+            "recipient": "Người nhận",
+            "token": "Token",
+            "requester": "Người yêu cầu",
+            "approver": "Người phê duyệt",
+            "myVoteStatus": "Trạng thái phiếu của tôi",
+            "all": "TẤT CẢ",
+            "amount": "Số tiền",
+            "from": "Từ",
+            "to": "Đến",
+            "min": "Tối thiểu",
+            "max": "Tối đa",
+            "invalidDate": "Ngày không hợp lệ",
+            "operationIsNot": " không phải là",
+            "operationBefore": " trước",
+            "operationAfter": " sau",
+            "operationContains": " chứa",
+            "searchByAddress": "Tìm theo địa chỉ",
+            "loadingMembers": "Đang tải thành viên...",
+            "noMembersFound": "Không tìm thấy thành viên. Nhấn Enter để thêm \"{query}\"",
+            "noMembersAvailable": "Không có thành viên khả dụng",
+            "reset": "Đặt lại",
+            "clear": "Xóa",
+            "addFilter": "Thêm bộ lọc"
+        },
+        "tabs": {
+            "all": "Tất cả",
+            "pending": "Đang chờ",
+            "executed": "Đã thực thi",
+            "rejected": "Đã từ chối",
+            "expired": "Đã hết hạn",
+            "failed": "Thất bại"
+        },
+        "searchPlaceholder": "Tìm yêu cầu theo tên hoặc ID",
+        "searchPlaceholderShort": "Tìm theo tên hoặc ID",
+        "errorLoading": "Lỗi khi tải đề xuất. Vui lòng thử lại.",
+        "empty": {
+            "title": "Tạo yêu cầu đầu tiên của bạn",
+            "description": "Yêu cầu thanh toán, trao đổi và các hành động khác sẽ xuất hiện ở đây khi được tạo.",
+            "send": "Gửi",
+            "exchange": "Trao đổi"
+        },
+        "actions": {
+            "approve": "Phê duyệt",
+            "reject": "Từ chối",
+            "deposit": "Nạp tiền",
+            "viewRequest": "Xem yêu cầu"
+        },
+        "table": {
+            "selectAll": "Chọn tất cả",
+            "selectRow": "Chọn hàng",
+            "request": "Yêu cầu",
+            "transaction": "Giao dịch",
+            "requester": "Người yêu cầu",
+            "voting": "Bỏ phiếu",
+            "votingTooltip": "Số đầu tiên cho biết số phê duyệt đã nhận. Số thứ hai cho biết số phê duyệt cần để thực thi.",
+            "status": "Trạng thái",
+            "notPending": "Đề xuất không ở trạng thái chờ.",
+            "noPermissionVote": "Bạn không có quyền bỏ phiếu cho yêu cầu này.",
+            "alreadyVoted": "Bạn đã bỏ phiếu cho yêu cầu này.",
+            "noResults": "Không tìm thấy yêu cầu nào phù hợp với bộ lọc của bạn.",
+            "allCaughtUp": "Đã xử lý hết!",
+            "noPending": "Không có yêu cầu đang chờ nào.",
+            "send": "Gửi",
+            "exchange": "Trao đổi",
+            "requestsSelected": "{count, plural, other {# yêu cầu đã chọn}}",
+            "bulkApproveDisabled": "Yêu cầu này không thể được phê duyệt vì ngân quỹ không đủ số dư."
+        },
+        "pending": {
+            "title": "Yêu cầu đang chờ",
+            "viewAll": "Xem tất cả",
+            "emptyTitle": "Đã xử lý hết!",
+            "emptyDescription": "Không có yêu cầu đang chờ nào."
+        }
+    },
+    "proposals": {
+        "status": {
+            "pending": "Đang chờ",
+            "approved": "Đã phê duyệt",
+            "rejected": "Đã từ chối",
+            "executed": "Đã thực thi",
+            "expired": "Đã hết hạn",
+            "failed": "Thất bại",
+            "removed": "Đã xóa",
+            "inProgress": "Đang xử lý"
+        },
+        "statusTooltip": {
+            "pending": "Yêu cầu này vẫn đang chờ và chưa đạt được số phiếu cần thiết để thực thi.",
+            "executed": "Đã thực thi sau khi {approved} trên {required} thành viên phê duyệt yêu cầu.",
+            "rejected": "Đã từ chối sau khi {rejected} trên {required} thành viên bỏ phiếu từ chối yêu cầu.",
+            "expired": "Đã hết hạn vì không nhận đủ số phiếu để thực thi.",
+            "failed": "Yêu cầu không thể hoàn tất. Kiểm tra chi tiết giao dịch <link>tại đây</link>.",
+            "failedPlain": "Yêu cầu không thể hoàn tất. Kiểm tra chi tiết giao dịch tại đây."
+        },
+        "votes": {
+            "approved": "Đã phê duyệt",
+            "rejected": "Đã từ chối",
+            "pending": "Đang chờ"
+        },
+        "voteModal": {
+            "confirmTitle": "Xác nhận phiếu của bạn",
+            "removeTitle": "Xóa yêu cầu",
+            "bulkBody": "Bạn sắp {action} nhiều yêu cầu. Sau khi gửi, quyết định này không thể thay đổi.",
+            "singleBody": "Bạn sắp {action} yêu cầu này. Sau khi xác nhận, hành động này không thể hoàn tác.",
+            "actionApprove": "phê duyệt",
+            "actionReject": "từ chối",
+            "actionRemove": "xóa",
+            "insufficientBalance": "Yêu cầu <highlight>{ids}</highlight> không thể phê duyệt do số dư không đủ. Phê duyệt của bạn sẽ chỉ áp dụng cho các yêu cầu còn lại.",
+            "remove": "Xóa",
+            "confirm": "Xác nhận"
+        },
+        "expanded": {
+            "recipient": "Người nhận",
+            "amount": "Số tiền",
+            "networkFee": "Phí mạng",
+            "notes": "Ghi chú",
+            "sent": "Đã gửi",
+            "received": "Đã nhận",
+            "priceDifference": "Chênh lệch giá",
+            "priceDifferenceTooltip": "Chênh lệch giữa tỷ giá báo và tỷ giá thị trường hiện tại. Giá trị dương cho biết tỷ giá tốt hơn thị trường.",
+            "slippageTolerance": "Dung sai trượt giá",
+            "estimatedTime": "Thời gian ước tính",
+            "seconds": "{count} giây",
+            "description": "Mô tả",
+            "methodName": "Tên phương thức",
+            "args": "Tham số",
+            "deposit": "Nạp tiền",
+            "gas": "Gas",
+            "totalDeposit": "Tổng số tiền nạp",
+            "totalGas": "Tổng Gas",
+            "receiverId": "ID Người nhận",
+            "contractId": "ID Hợp đồng",
+            "actionsCount": "{count, plural, other {# hành động}}",
+            "functionCallsCount": "{count, plural, other {# lệnh gọi hàm}}",
+            "showLess": "Thu gọn",
+            "showMore": "Xem thêm",
+            "stakingPool": "Pool Staking",
+            "validator": "Validator",
+            "action": "Hành động",
+            "stake": "Stake",
+            "unstake": "Bỏ stake",
+            "withdraw": "Rút tiền",
+            "lockupOwner": "Chủ sở hữu lockup",
+            "lockupDuration": "Thời gian lockup",
+            "cliff": "Cliff",
+            "releaseDuration": "Thời gian phát hành",
+            "vestingSchedule": "Lịch vesting",
+            "cancellable": "Có thể hủy",
+            "allowEarn": "Cho phép staking",
+            "yes": "Có",
+            "no": "Không",
+            "notSet": "Chưa đặt",
+            "from": "Từ",
+            "to": "Đến",
+            "paymentsCount": "{count, plural, other {# thanh toán}}",
+            "sourceWallet": "Ví nguồn",
+            "allNear": "Tất cả NEAR",
+            "startDate": "Ngày bắt đầu",
+            "endDate": "Ngày kết thúc",
+            "cliffDate": "Ngày Cliff",
+            "allowCancellation": "Cho phép hủy",
+            "allowStaking": "Cho phép staking",
+            "loadingHistorical": "Đang tải cấu hình lịch sử...",
+            "name": "Tên",
+            "purpose": "Mục đích",
+            "logo": "Logo",
+            "logoAlt": "Logo",
+            "primaryColor": "Màu chính",
+            "noChangesCurrent": "Không phát hiện thay đổi nào trong cấu hình so với trạng thái hiện tại.",
+            "noChangesHistorical": "Không phát hiện thay đổi nào trong cấu hình so với trạng thái lịch sử.",
+            "method": "Phương thức",
+            "arguments": "Tham số",
+            "contract": "Hợp đồng",
+            "actionNumber": "Hành động {number}",
+            "actions": "Hành động",
+            "collapseAll": "Thu gọn tất cả",
+            "expandAll": "Mở rộng tất cả",
+            "send": "Gửi",
+            "receive": "Nhận",
+            "rate": "Tỷ giá",
+            "priceSlippageLimit": "Giới hạn trượt giá",
+            "slippageTooltip": "Đây là giới hạn trượt giá được xác định cho yêu cầu này. Nếu tỷ giá thị trường thay đổi vượt ngưỡng này trong quá trình thực thi, yêu cầu sẽ tự động thất bại.",
+            "estimatedTimeTooltip": "Thời gian ước tính để hoán đổi được thực thi sau khi giao dịch nạp được xác nhận.",
+            "minReceive": "Tối thiểu nhận",
+            "minimumReceived": "Số tiền nhận tối thiểu",
+            "minReceiveTooltip": "Đây là số tiền tối thiểu bạn sẽ nhận từ giao dịch trao đổi này, dựa trên giới hạn trượt giá đã đặt cho yêu cầu.",
+            "depositAddress": "Địa chỉ nạp tiền",
+            "depositAddressTooltip": "Địa chỉ nạp tiền 1Click nơi token sẽ được gửi đến để thực thi hoán đổi liên chuỗi.",
+            "quoteSignature": "Chữ ký báo giá",
+            "quoteSignatureTooltip": "Chữ ký mã hóa từ API 1Click xác thực báo giá này.",
+            "quoteDeadline": "Hạn báo giá 1-Click",
+            "quoteDeadlineTooltip": "Thời gian khi địa chỉ nạp tiền trở nên không hoạt động và tiền có thể bị mất.",
+            "status": "Trạng thái",
+            "transactionLink": "Liên kết giao dịch",
+            "viewTransaction": "Xem giao dịch",
+            "recipientNumber": "Người nhận {number}",
+            "oopsTitle": "Rất tiếc! Đã xảy ra lỗi",
+            "oopsDescription": "Chúng tôi không thể tìm thấy dữ liệu nào để hiển thị tại đây.",
+            "totalAmount": "Tổng số tiền",
+            "recipients": "Người nhận",
+            "recipientsCount": "{count, plural, other {# người nhận}}",
+            "unsupportedProposal": "Loại đề xuất không được hỗ trợ",
+            "requestDetails": "Chi tiết yêu cầu",
+            "linkCopied": "Đã sao chép liên kết vào bộ nhớ tạm",
+            "copyLink": "Sao chép liên kết",
+            "openRequestPage": "Mở trang yêu cầu",
+            "deleteRequest": "Xóa yêu cầu",
+            "unknownRecipients": "Người nhận không xác định",
+            "loadingConfig": "Đang tải cấu hình...",
+            "historicalData": "Dữ liệu lịch sử...",
+            "generalUpdate": "Cập nhật chung",
+            "detailsUnavailable": "Chi tiết không khả dụng",
+            "changesCount": "{count, plural, other {# thay đổi}}",
+            "policyUpdate": "Cập nhật chính sách",
+            "noChangesDetected": "Không phát hiện thay đổi",
+            "loadingPolicy": "Đang tải chính sách...",
+            "roleChanges": "Thay đổi vai trò",
+            "policyParameters": "Tham số chính sách",
+            "defaultVotePolicy": "Chính sách bỏ phiếu mặc định",
+            "policyRoleChanges": "Thay đổi chính sách & vai trò",
+            "membersAdded": "{count, plural, other {# thành viên đã thêm}}",
+            "membersRemoved": "{count, plural, other {# thành viên đã xóa}}",
+            "membersUpdated": "{count, plural, other {# thành viên đã cập nhật}}",
+            "rolesModified": "{count, plural, other {# vai trò đã sửa}}",
+            "parametersChanged": "{count, plural, other {# tham số đã thay đổi}}",
+            "defaultVotePolicyPart": "chính sách bỏ phiếu mặc định",
+            "onReceiver": "trên {receiver}",
+            "toPrefix": "Đến:",
+            "validatorPrefix": "Validator:",
+            "validatorSubtitle": "Validator: {address}",
+            "impactTitle": "Tác động của việc thay đổi thời gian bỏ phiếu",
+            "impactBody": "Bạn sắp cập nhật thời gian bỏ phiếu. Điều này sẽ ảnh hưởng đến các yêu cầu hiện có sau đây.",
+            "activeRequestsBullet": "{count, plural, other {# yêu cầu sẽ vẫn hoạt động để bỏ phiếu sau khi thay đổi này, với ngày hết hạn được cập nhật.}}",
+            "expiringRequestsBullet": "{count, plural, other {# yêu cầu sẽ được đánh dấu là \"Đã hết hạn\" theo thời gian bỏ phiếu mới.}}",
+            "remainActiveHeading": "Yêu cầu vẫn hoạt động để bỏ phiếu với ngày hết hạn mới",
+            "willExpireHeading": "Yêu cầu sẽ được đánh dấu là \"Hết hạn\"",
+            "tableRequest": "Yêu cầu",
+            "tableTransaction": "Giao dịch",
+            "tableNewExpiry": "Hết hạn mới",
+            "expireInDays": "{count, plural, other {Hết hạn trong # ngày}}",
+            "today": "Hôm nay",
+            "uponApproval": "Khi phê duyệt",
+            "yesContinue": "Có, tiếp tục",
+            "transactionCreated": "Đã tạo giao dịch",
+            "voting": "Bỏ phiếu",
+            "approvalsReceived": "Đã nhận {received}/{required} phê duyệt",
+            "expiresAt": "Hết hạn vào",
+            "expiredAt": "Đã hết hạn vào",
+            "exchangingTokens": "Đang trao đổi token",
+            "exchangingTokensBody": "Yêu cầu này đã được đội phê duyệt. Việc trao đổi token đang diễn ra và có thể mất một chút thời gian.",
+            "requestFailed": "Yêu cầu thất bại",
+            "requestFailedBody": "Đội đã phê duyệt yêu cầu này, nhưng nó đã thất bại do biến động tỷ giá. Vui lòng tạo yêu cầu mới và thử lại.",
+            "votingPeriod24h": "Thời gian bỏ phiếu: 24 giờ",
+            "votingPeriod24hBody": "Yêu cầu trao đổi này có thời gian bỏ phiếu 24 giờ. Hãy phê duyệt yêu cầu trong khoảng thời gian này, nếu không yêu cầu sẽ hết hạn.",
+            "reject": "Từ chối",
+            "approve": "Phê duyệt"
+        },
+        "insufficientBalance": {
+            "noAsset": "Yêu cầu này không thể được phê duyệt vì token cần thiết không có sẵn trong ngân quỹ.",
+            "bond": "Yêu cầu này không thể được phê duyệt vì ngân quỹ không đủ số dư <token>{symbol}</token>. Hãy thêm <token>{amount} {symbol}</token> để chi trả phí bond đề xuất.",
+            "continue": "Yêu cầu này không thể được phê duyệt vì ngân quỹ không đủ số dư <token>{symbol}</token>. Hãy thêm <token>{amount} {symbol}</token> để tiếp tục.",
+            "modalTitle": "Số dư NEAR không đủ",
+            "modalBodyVote": "Bạn không có đủ token NEAR trong ví để bỏ phiếu này. Việc bỏ phiếu yêu cầu số dư tối thiểu là <amount>{required} NEAR</amount>. Vui lòng thêm NEAR vào ví và thử lại.",
+            "modalBodyProposal": "Bạn không có đủ token NEAR trong ví để tạo yêu cầu này. Việc tạo yêu cầu cần số dư tối thiểu là <amount>{required} NEAR</amount>. Vui lòng thêm NEAR vào ví và thử lại.",
+            "gotIt": "Đã hiểu"
+        }
+    },
+    "members": {
+        "title": "Thành viên",
+        "description": "Quản lý thành viên đội và quyền hạn",
+        "permissions": "Quyền",
+        "member": "Thành viên",
+        "activeMembers": "Thành viên đang hoạt động",
+        "noActiveMembers": "Không tìm thấy thành viên đang hoạt động.",
+        "addNewMember": "Thêm thành viên mới",
+        "membersSelected": "Đã chọn {count, plural, =0 {không có thành viên nào} other {# thành viên}}",
+        "remove": "Xóa",
+        "edit": "Chỉnh sửa",
+        "requestorOnlyTooltip": "Bạn chỉ có thể thêm vai trò Người yêu cầu cho thành viên này, vì họ chịu trách nhiệm tạo các yêu cầu thanh toán từ NEARN.",
+        "memberModal": {
+            "editRoles": "Chỉnh sửa vai trò",
+            "addNewMember": "Thêm thành viên mới",
+            "validatingAddresses": "Đang xác thực địa chỉ...",
+            "creatingProposal": "Đang tạo đề xuất...",
+            "reviewRequest": "Xem lại yêu cầu",
+            "noChanges": "Không có thay đổi nào đối với vai trò thành viên"
+        },
+        "previewModal": {
+            "title": "Xem lại yêu cầu của bạn",
+            "youAreEditing": "Bạn đang chỉnh sửa",
+            "youAreAdding": "Bạn đang thêm",
+            "membersCount": "{count, plural, other {# thành viên}}",
+            "newMembersCount": "{count, plural, other {# thành viên mới}}",
+            "updatedMembers": "Thành viên đã cập nhật",
+            "newMembers": "Thành viên mới",
+            "creatingProposal": "Đang tạo đề xuất...",
+            "confirmSubmit": "Xác nhận và gửi yêu cầu"
+        },
+        "removeDialog": {
+            "title": "Xóa yêu cầu",
+            "nearnBody": "Sau khi được phê duyệt, {account} sẽ bị xóa vĩnh viễn khỏi ngân quỹ và mọi quyền liên quan sẽ bị thu hồi. Sau khi xóa, tài khoản này sẽ không thể tạo yêu cầu từ NEARN nữa.",
+            "genericBody": "Sau khi phê duyệt, hành động này sẽ xóa vĩnh viễn <bold>{accounts}</bold> khỏi ngân quỹ và thu hồi tất cả quyền đã gán.",
+            "creatingProposal": "Đang tạo đề xuất..."
+        },
+        "validation": {
+            "accountIdRequired": "Bắt buộc nhập ID tài khoản",
+            "invalidNearAddress": "Địa chỉ NEAR không hợp lệ.",
+            "atLeastOneRole": "Phải chọn ít nhất một vai trò",
+            "atLeastOneMember": "Cần ít nhất một thành viên",
+            "alreadyAdded": "Thành viên này đã được thêm ở trên",
+            "alreadyInTreasury": "Thành viên này đã có trong ngân quỹ",
+            "cannotRemoveRoleAfter": "Bạn không thể xóa vai trò {role} của thành viên này. Sau tất cả các thay đổi, họ sẽ là người duy nhất được gán vai trò này.",
+            "cannotRemoveRoleAfterGov": "Bạn không thể xóa vai trò {role} của thành viên này. Sau tất cả các thay đổi, họ sẽ là thành viên {role} duy nhất, và không có vai trò này bạn sẽ không thể quản lý thành viên đội hay cấu hình bỏ phiếu."
+        },
+        "policy": {
+            "addMembers": "Cập nhật chính sách - Thêm thành viên mới",
+            "addMembersSuccess": "Đã tạo thành công yêu cầu thêm thành viên mới",
+            "editMember": "Cập nhật chính sách - Chỉnh sửa quyền thành viên",
+            "editMembers": "Cập nhật chính sách - Chỉnh sửa nhiều thành viên",
+            "editMemberSuccess": "Đã tạo thành công yêu cầu cập nhật vai trò thành viên",
+            "editMembersSuccess": "Đã tạo thành công yêu cầu cập nhật vai trò hàng loạt",
+            "removeMember": "Cập nhật chính sách - Xóa thành viên",
+            "removeMembers": "Cập nhật chính sách - Xóa các thành viên",
+            "removeMemberSuccess": "Đã tạo thành công yêu cầu xóa thành viên"
+        }
+    },
+    "settings": {
+        "tabs": {
+            "general": "Chung",
+            "voting": "Bỏ phiếu",
+            "preferences": "Tùy chọn",
+            "integrations": "Tích hợp"
+        },
+        "general": {
+            "validation": {
+                "displayNameRequired": "Bắt buộc nhập tên hiển thị",
+                "displayNameMax": "Tên hiển thị phải ít hơn 100 ký tự"
+            },
+            "proposalDescriptionTitle": "Cập nhật cấu hình - Giao diện & logo",
+            "proposalSubmitted": "Đã gửi yêu cầu cập nhật cấu hình",
+            "treasuryNotFound": "Không tìm thấy ngân quỹ",
+            "treasuryName": "Tên ngân quỹ",
+            "treasuryNameDescription": "Tên ngân quỹ của bạn. Tên này sẽ hiển thị trên toàn bộ ứng dụng.",
+            "displayName": "Tên hiển thị",
+            "displayNamePlaceholder": "Nhập tên hiển thị",
+            "accountName": "Tên tài khoản",
+            "logo": "Logo",
+            "logoDescription": "Tải lên logo cho ngân quỹ của bạn. Khuyến nghị SVG, PNG hoặc JPG (256x256 px).",
+            "treasuryLogoAlt": "Logo ngân quỹ",
+            "uploading": "Đang tải lên...",
+            "uploadLogo": "Tải lên logo",
+            "removeLogo": "Xóa logo",
+            "logoUploaded": "Đã tải lên logo thành công",
+            "uploadError": "Đã xảy ra lỗi khi tải lên hình ảnh, vui lòng thử lại.",
+            "invalidLogo": "Logo không hợp lệ. Vui lòng tải lên tệp PNG, JPG hoặc SVG có kích thước chính xác 256x256 px",
+            "invalidImage": "Tệp hình ảnh không hợp lệ. Vui lòng tải lên một hình ảnh hợp lệ.",
+            "fileReadError": "Lỗi khi đọc tệp. Vui lòng thử lại.",
+            "primaryColor": "Màu chính",
+            "primaryColorDescription": "Đặt màu chính cho các thành phần giao diện ngân quỹ. Màu này sẽ được dùng ở cả chế độ sáng và tối, nên hãy chú ý đến độ tương phản khi chọn các sắc trung tính.",
+            "selectColorLabel": "Chọn màu {color}"
+        },
+        "voting": {
+            "validation": {
+                "required": "Bắt buộc nhập thời gian bỏ phiếu",
+                "validNumber": "Thời gian bỏ phiếu phải là một số hợp lệ",
+                "min": "Thời gian bỏ phiếu phải ít nhất 1 ngày",
+                "max": "Thời gian bỏ phiếu phải ít hơn 1000 ngày",
+                "whole": "Thời gian bỏ phiếu phải là số ngày nguyên"
+            },
+            "missingData": "Thiếu dữ liệu bắt buộc",
+            "thresholdProposalTitle": "Cập nhật chính sách - Ngưỡng bỏ phiếu",
+            "thresholdProposalSummary": "{account} đã yêu cầu thay đổi ngưỡng bỏ phiếu từ {oldValue} thành {newValue}.",
+            "thresholdSubmitted": "Đã gửi yêu cầu cập nhật ngưỡng bỏ phiếu",
+            "createProposalFailed": "Không thể tạo đề xuất",
+            "durationProposalTitle": "Cập nhật chính sách - Thời gian bỏ phiếu",
+            "durationProposalSummary": "{account} đã yêu cầu thay đổi thời gian bỏ phiếu từ {oldValue} thành {newValue}.",
+            "durationSubmitted": "Đã tạo yêu cầu thành công",
+            "pendingTitle": "Yêu cầu ngưỡng bỏ phiếu đang hoạt động",
+            "pendingBody": "Để tránh xung đột, bạn cần hoàn tất hoặc giải quyết các yêu cầu đang chờ trước khi tiếp tục. Các yêu cầu này hiện đang hoạt động và phải được phê duyệt hoặc từ chối trước.",
+            "viewRequest": "Xem yêu cầu",
+            "thresholdHeading": "Ngưỡng bỏ phiếu",
+            "thresholdDescriptionApprovers": "Xác định số phiếu cần thiết để phê duyệt các yêu cầu liên quan đến thanh toán và đội. Cấu hình ngưỡng riêng cho Người phê duyệt và Quản trị.",
+            "thresholdDescriptionGeneric": "Xác định số phiếu cần thiết để phê duyệt yêu cầu. Cấu hình ngưỡng cho từng vai trò dựa trên trách nhiệm của họ.",
+            "membersWhoCanVote": "Thành viên có thể bỏ phiếu",
+            "votesRequired": "Số phiếu cần để phê duyệt yêu cầu",
+            "durationHeading": "Thời gian bỏ phiếu",
+            "durationDescription": "Khoảng thời gian (tính bằng ngày) một đề xuất sẽ vẫn mở để bỏ phiếu. Nếu việc bỏ phiếu không hoàn tất trong khoảng thời gian này, quyết định sẽ hết hạn.",
+            "durationApprovers": " Thời gian này áp dụng tương tự cho cả vai trò Quản trị và Người phê duyệt.",
+            "durationGeneric": " Thời gian này nhất quán trên tất cả các vai trò ngân quỹ.",
+            "days": "Ngày"
+        },
+        "preferences": {
+            "timeZone": "Múi giờ",
+            "timeZoneDescription": "Đặt múi giờ địa phương để hiển thị ngày giờ chính xác.",
+            "timeFormat": "Định dạng giờ",
+            "hour12": "12 giờ (1:00 PM)",
+            "hour24": "24 giờ (13:00)",
+            "autoTimezone": "Tự động đặt múi giờ theo vị trí của bạn",
+            "timezone": "Múi giờ",
+            "loadingTimezones": "Đang tải múi giờ...",
+            "selectTimezone": "Chọn múi giờ",
+            "searchTimezones": "Tìm múi giờ...",
+            "noTimezones": "Không tìm thấy múi giờ",
+            "save": "Lưu",
+            "savedToast": "Đã lưu tùy chọn thành công",
+            "saveFailed": "Không thể lưu tùy chọn",
+            "loadFailed": "Không thể tải múi giờ"
+        }
+    },
+    "addressBook": {
+        "emptyTitle": "Thêm người nhận đầu tiên của bạn",
+        "emptyDescription": "Lưu các địa chỉ thường dùng để chi trả nhanh hơn và không có lỗi. Liên hệ của bạn được giữ riêng tư và chỉ đội của bạn nhìn thấy.",
+        "import": "Nhập",
+        "addRecipient": "Thêm người nhận",
+        "recipientsHeading": "Người nhận",
+        "recipientsSelected": "Đã chọn {count, plural, =0 {không có người nhận nào} other {# người nhận}}",
+        "sectionHeading": "Người nhận",
+        "privacyNote": "Các địa chỉ đã lưu là riêng tư và chỉ đội của bạn nhìn thấy.",
+        "searchPlaceholder": "Tìm người nhận theo tên",
+        "searchPlaceholderShort": "Tìm kiếm",
+        "review": {
+            "header": "Xem lại chi tiết",
+            "youAreAdding": "Bạn đang thêm",
+            "newRecipients": "{count, plural, other {# người nhận mới}}",
+            "onNetworks": "trên {count, plural, other {# mạng}}",
+            "recipients": "Người nhận",
+            "allDuplicates": "Tất cả người nhận đã nhập đều đã có trong sổ địa chỉ của bạn. Quay lại để tải lên một danh sách khác hoặc xóa các bản trùng lặp khỏi đợt xem lại này.",
+            "someDuplicates": "{duplicates} người nhận trùng lặp trên tổng số {total} người nhận. Tiếp tục để chỉ tải lên những người nhận mới.",
+            "duplicated": "Trùng lặp",
+            "notePlaceholder": "Thêm ghi chú để giúp xác định người nhận này (ví dụ: thanh toán cho nhà thầu, phân phối vesting).",
+            "skipDuplicates": "Bỏ qua bản trùng lặp và chỉ nhập những bản mới.",
+            "allDuplicatesTooltip": "Tất cả người nhận đã nhập đều đã có trong sổ địa chỉ, nên không có gì mới để nhập.",
+            "duplicateActionTooltip": "Bật bỏ qua bản trùng lặp hoặc xóa người nhận trùng lặp để tiếp tục.",
+            "adding": "Đang thêm…",
+            "nothingNew": "Không có gì mới để nhập",
+            "addRecipientsButton": "{count, plural, one {Thêm người nhận} other {Thêm người nhận}}"
+        },
+        "removeDialog": {
+            "title": "Xóa người nhận",
+            "bulk": "Thao tác này sẽ xóa <bold>{count, plural, other {# người nhận}}</bold> khỏi sổ địa chỉ của bạn. Bạn có thể thêm lại bất kỳ lúc nào.",
+            "single": "Thao tác này sẽ xóa <bold>{name}</bold> khỏi sổ địa chỉ của bạn. Bạn có thể thêm lại người nhận này bất kỳ lúc nào."
+        },
+        "importFlow": {
+            "title": "Nhập người nhận",
+            "description": "Tải lên danh sách địa chỉ người nhận vào sổ địa chỉ của bạn.",
+            "foundSummary": "Tìm thấy {count, plural, other {# người nhận}} trên {networkCount, plural, other {# mạng}}",
+            "uploadPrompt": "Tải lên hoặc dán dữ liệu người nhận",
+            "fixErrors": "Sửa lỗi để tiếp tục",
+            "continueReview": "Tiếp tục xem lại"
+        },
+        "form": {
+            "editRecipient": "Chỉnh sửa người nhận",
+            "addRecipient": "Thêm người nhận",
+            "import": "Nhập",
+            "recipientName": "Tên người nhận",
+            "namePlaceholder": "Alice",
+            "recipientAddress": "Địa chỉ người nhận",
+            "network": "Mạng",
+            "networkInfo": "Các mạng tương thích với địa chỉ này",
+            "enterAddressFirst": "Hãy nhập địa chỉ người nhận trước",
+            "selectNetwork": "Chọn mạng",
+            "selectNetworksTitle": "Chọn các mạng",
+            "searchNetworksPlaceholder": "Tìm mạng…",
+            "done": "Xong",
+            "edit": "Chỉnh sửa",
+            "remove": "Xóa",
+            "incomplete": "Chưa hoàn tất",
+            "addAnother": "Thêm người nhận khác",
+            "fillAllTooltip": "Bạn phải điền tất cả các trường để thêm một người nhận.",
+            "reviewDetails": "Xem lại chi tiết",
+            "reviewTooltip": "Tất cả người nhận phải được hoàn tất trước khi xem lại.",
+            "invalidAddress": "Địa chỉ không hợp lệ",
+            "noCompatibleNetworks": "Không có mạng nào tương thích với địa chỉ này"
+        },
+        "parsing": {
+            "rowPrefix": "Hàng {row}: {message}",
+            "missingName": "Thiếu tên người nhận. Vui lòng thêm tên.",
+            "missingAddress": "Thiếu địa chỉ người nhận. Vui lòng thêm địa chỉ ví.",
+            "invalidAddressFormat": "Địa chỉ \"{address}\" không hợp lệ với bất kỳ mạng được hỗ trợ nào.",
+            "unknownNetwork": "Mạng không xác định \"{network}\". Các mạng được hỗ trợ bao gồm: {available}.",
+            "incompatibleNetwork": "Địa chỉ \"{address}\" không tương thích với {network}. Các mạng tương thích: {compatible}.",
+            "noDataFound": "Không tìm thấy dữ liệu. Vui lòng thêm người nhận theo định dạng: Name, Address, Network, Note",
+            "headerColumnsNotFound": "Chúng tôi đã phát hiện một hàng tiêu đề, nhưng không tìm thấy các cột 'Name' và 'Address'. Vui lòng dùng các tên cột này, hoặc xóa hàng tiêu đề.",
+            "failedToParseCsv": "Không thể phân tích dữ liệu CSV"
+        }
+    },
+    "payments": {
+        "validation": {
+            "recipientMin": "Người nhận phải có ít nhất 2 ký tự",
+            "recipientMax": "Người nhận phải ít hơn 128 ký tự",
+            "amountPositive": "Số tiền phải lớn hơn 0",
+            "recipientTokenSame": "Địa chỉ người nhận và token không thể giống nhau"
+        },
+        "newPayment": "Thanh toán mới",
+        "reviewYourPayment": "Xem lại thanh toán của bạn",
+        "reviewButton": "Xem lại thanh toán",
+        "reviewButtonDisabled": "Nhập số tiền và địa chỉ",
+        "comingSoon": "Sắp ra mắt",
+        "bulkPayments": "Thanh toán hàng loạt",
+        "summaryRecipients": "đến {count, plural, other {# người nhận}}",
+        "networkFee": "Phí mạng",
+        "networkFeeInfo": "Thông tin phí mạng",
+        "commentPlaceholder": "Thêm bình luận (tùy chọn)...",
+        "preparingRoute": "Đang chuẩn bị tuyến chuyển 1Click...",
+        "confirmSubmit": "Xác nhận và gửi yêu cầu",
+        "useDifferentAddress": "Dùng một địa chỉ khác",
+        "failed1ClickQuote": "Không thể tạo báo giá chuyển 1Click",
+        "paymentSubmitted": "Đã gửi yêu cầu thanh toán"
+    },
+    "bulkPayment": {
+        "comingSoonToast": "Thanh toán hàng loạt sắp ra mắt!",
+        "submittingList": "Đang gửi danh sách thanh toán hàng loạt",
+        "submittingProposal": "Đang gửi đề xuất",
+        "proposalSubmitted": "Đã gửi đề xuất thanh toán hàng loạt",
+        "submitListFailed": "Không thể gửi danh sách thanh toán",
+        "submitFailed": "Không thể gửi thanh toán hàng loạt",
+        "upload": {
+            "pleaseUploadCsv": "Vui lòng tải lên một tệp CSV",
+            "fileSizeLimit": "Kích thước tệp phải nhỏ hơn 1.5 MB",
+            "headerTitle": "Yêu cầu thanh toán hàng loạt",
+            "headerSubtitle": "Trả nhiều người nhận với một đề xuất duy nhất.",
+            "creditsUsed": "Bạn đã dùng hết tín dụng",
+            "bulkPaymentsUsed": "Bạn đã dùng hết lượt thanh toán hàng loạt",
+            "upgradeTrial": "Nâng cấp gói của bạn để có thêm và tiếp tục",
+            "upgradePaid": "Nâng cấp gói để có thêm quyền truy cập, hoặc đợi đến khi giới hạn của bạn được đặt lại vào tháng sau.",
+            "selectAsset": "Chọn tài sản",
+            "disableTokenMessage": "Thanh toán hàng loạt cho các token này sắp ra mắt.",
+            "providePaymentData": "Cung cấp dữ liệu thanh toán",
+            "uploadFile": "Tải lên tệp",
+            "provideData": "Cung cấp dữ liệu",
+            "chooseFile": "Chọn tệp",
+            "orDragDrop": "hoặc kéo và thả",
+            "maxFileSize": "tối đa 1 tệp lên đến 1.5 MB, chỉ chấp nhận tệp CSV",
+            "noFilePrompt": "Không có tệp để tải lên?",
+            "downloadTemplate": "Tải xuống mẫu",
+            "requirements": "Yêu cầu thanh toán hàng loạt",
+            "maxTransactions": "Tối đa {max} giao dịch mỗi lần nhập",
+            "singleTokenNetwork": "Một token và mạng duy nhất",
+            "limitsUsed": "Bạn đã dùng hết giới hạn",
+            "selectAndProvide": "Chọn tài sản và cung cấp dữ liệu thanh toán",
+            "continueToReview": "Tiếp tục xem lại",
+            "selectTokenError": "Vui lòng chọn một token",
+            "providePaymentDataError": "Vui lòng cung cấp dữ liệu thanh toán"
+        },
+        "editStep": {
+            "title": "Chỉnh sửa thanh toán",
+            "saveChanges": "Lưu thay đổi"
+        },
+        "parsing": {
+            "rowPrefix": "Hàng {row}: {message}",
+            "missingRecipientFirstColumn": "Thiếu địa chỉ người nhận. Vui lòng thêm địa chỉ vào cột đầu tiên.",
+            "invalidNearAddress": "Địa chỉ \"{address}\" không phải là tài khoản NEAR hợp lệ.",
+            "invalidChainAddress": "Địa chỉ \"{address}\" không phải là tài khoản {chain} hợp lệ.",
+            "rowNeedsAmountRecipient": "Mỗi hàng cần số tiền và người nhận, ngăn cách bởi dấu phẩy. Ví dụ: 100, alice.near",
+            "missingRecipientBeforeComma": "Thiếu địa chỉ người nhận. Vui lòng thêm địa chỉ trước dấu phẩy.",
+            "missingAmountAfterComma": "Thiếu số tiền. Vui lòng thêm một số sau dấu phẩy. Ví dụ: {recipient}, 100",
+            "invalidAmountNumber": "Số tiền \"{amountStr}\" không phải là một số hợp lệ. Vui lòng chỉ dùng số và phần thập phân (ví dụ: 100 hoặc 100.50).",
+            "amountGreaterThanZero": "Số tiền phải lớn hơn 0. Bạn đã nhập \"{amountStr}\".",
+            "amountTooLarge": "Số tiền \"{amountStr}\" quá lớn. Vui lòng dùng một số nhỏ hơn.",
+            "invalidAmountFallback": "Số tiền không hợp lệ. Vui lòng chỉ dùng số và phần thập phân (ví dụ: 100 hoặc 100.50).",
+            "pleaseRemoveChars": "Vui lòng xóa các ký tự sau: {chars}. Chỉ chấp nhận số, dấu phẩy và dấu chấm.",
+            "amountCannotBeEmpty": "Số tiền không được để trống.",
+            "tokenMismatch": "Bạn đã nhập \"{provided}\" nhưng {expected} đang được chọn ở trên. Hãy bỏ ký hiệu token hoặc chọn {suggested} từ danh sách thả xuống.",
+            "multipleTokenSymbols": "Bạn đang dùng nhiều ký hiệu token ({symbols}). Vui lòng chỉ dùng một loại token trong toàn bộ tệp, hoặc bỏ các ký hiệu token và để lựa chọn ở trên xác định token.",
+            "noPaymentDataFound": "Không tìm thấy dữ liệu thanh toán. Vui lòng thêm các khoản thanh toán theo định dạng: recipient, amount",
+            "exceedsRecipientLimit": "Bạn có {count} người nhận, nhưng giới hạn là {limit} mỗi đợt. Vui lòng xóa {excess, plural, other {# người nhận}} hoặc chia thành nhiều đợt.",
+            "noPaymentDataProvided": "Không có dữ liệu thanh toán nào được cung cấp. Vui lòng nhập các khoản thanh toán theo định dạng: recipient, amount",
+            "headerColumnsNotFound": "Chúng tôi đã phát hiện một hàng tiêu đề, nhưng không tìm thấy các cột 'Recipient' và 'Amount'. Vui lòng dùng các tên cột này, hoặc xóa hàng tiêu đề.",
+            "failedToParseCsv": "Không thể phân tích dữ liệu CSV",
+            "failedToParsePaste": "Không thể phân tích dữ liệu đã dán",
+            "failedToValidateAccount": "Không thể xác thực tài khoản",
+            "feeEstimationFailed": "Không thể ước tính phí mạng cho số tiền này. Vui lòng kiểm tra lại và thử lại.",
+            "feeEstimationFailedRow": "Hàng {row} ({recipient}): Không thể ước tính phí mạng cho số tiền này. Vui lòng kiểm tra lại và thử lại."
+        },
+        "recipients": "Người nhận",
+        "insufficientTokens": "Không đủ token. Bạn có thể gửi yêu cầu và nạp thêm trước khi phê duyệt.",
+        "removeRecipient": "Xóa người nhận",
+        "removeRecipientConfirm": "Bạn có chắc muốn xóa khoản thanh toán cho <strong>{recipient}</strong> không? Hành động này không thể hoàn tác.",
+        "remove": "Xóa",
+        "edit": "Chỉnh sửa"
+    },
+    "bulkPaymentCredits": {
+        "title": "Thanh toán hàng loạt",
+        "unlimited": "Không giới hạn",
+        "creditsPerPeriod": "{amount} / {period}",
+        "oneTimeTrial": "dùng thử một lần",
+        "month": "tháng",
+        "moreFlexibility": "Cần thêm sự linh hoạt?",
+        "contactUs": "Liên hệ với chúng tôi"
+    },
+    "exchange": {
+        "validation": {
+            "amountPositive": "Số tiền phải lớn hơn 0"
+        },
+        "requestSubmitted": "Đã gửi yêu cầu trao đổi",
+        "heading": "Trao đổi",
+        "sell": "Bán",
+        "receive": "Nhận",
+        "slippageTolerance": "Dung sai trượt giá",
+        "disabled": {
+            "differentTokens": "Token phải khác nhau",
+            "enterAmount": "Nhập số tiền để trao đổi"
+        },
+        "review": "Xem lại trao đổi",
+        "poweredBy": "Cung cấp bởi",
+        "info": {
+            "priceDifference": "Chênh lệch giá",
+            "priceDifferenceTooltip": "Chênh lệch giữa tỷ giá báo và tỷ giá thị trường hiện tại. Giá trị dương cho biết tỷ giá tốt hơn thị trường.",
+            "estimatedTime": "Thời gian ước tính",
+            "estimatedTimeValue": "{seconds} giây",
+            "estimatedTimeTooltip": "Thời gian xấp xỉ để hoàn tất giao dịch trao đổi.",
+            "minimumReceived": "Số tiền nhận tối thiểu",
+            "minimumReceivedTooltip": "Đây là số tiền tối thiểu bạn sẽ nhận từ giao dịch trao đổi này, dựa trên giới hạn trượt giá đã đặt cho yêu cầu.",
+            "depositAddress": "Địa chỉ nạp tiền",
+            "depositAddressCopied": "Đã sao chép địa chỉ nạp tiền",
+            "quoteExpires": "Hết hạn báo giá",
+            "exchangeFee": "Phí trao đổi",
+            "exchangeFeeTooltip": "Phí 0.70% phát sinh ở đây bao gồm chi phí giao thức NEAR Intents để hỗ trợ giao dịch của bạn và phí widget Trezu. Số tiền này được tự động tính vào tỷ giá đã báo của bạn."
+        },
+        "approveWithin24h": "Vui lòng phê duyệt yêu cầu này trong vòng 24 giờ, nếu không nó sẽ hết hạn. Chúng tôi khuyên bạn xác nhận càng sớm càng tốt.",
+        "confirmSubmit": "Xác nhận và gửi yêu cầu",
+        "refreshingIn": "Tỷ giá trao đổi sẽ làm mới trong {seconds}s"
+    },
+    "vesting": {
+        "validation": {
+            "amountMin": "Số tiền phải lớn hơn hoặc bằng 3.5",
+            "startBeforeEnd": "Ngày bắt đầu phải trước ngày kết thúc",
+            "cliffBetween": "Ngày Cliff phải nằm giữa"
+        },
+        "stepTitles": {
+            "details": "Chi tiết",
+            "settings": "Cài đặt",
+            "review": "Xem lại"
+        },
+        "proposalTitle": "Tạo lịch vesting cho {address}",
+        "scheduleSubmitted": "Đã gửi yêu cầu tạo lịch vesting",
+        "heading": "Lịch vesting mới",
+        "amount": "Số tiền",
+        "startDate": "Ngày bắt đầu",
+        "endDate": "Ngày kết thúc",
+        "noteOptional": "Ghi chú (tùy chọn)",
+        "continue": "Tiếp tục",
+        "advancedSettings": "Cài đặt nâng cao",
+        "allowCancellation": "Cho phép hủy",
+        "allowCancellationDescription": "Cho phép NEAR Foundation hủy lockup bất kỳ lúc nào. Lockup không thể hủy không tương thích với ngày Cliff.",
+        "cliffDate": "Ngày Cliff",
+        "allowEarn": "Cho phép thu nhập",
+        "allowEarnDescription": "Cho phép chủ sở hữu lockup stake toàn bộ số token trong lockup (kể cả trước ngày Cliff).",
+        "commentPlaceholder": "Thêm bình luận cho lịch vesting này (tùy chọn)...",
+        "reviewRequest": "Xem lại yêu cầu",
+        "reviewHeading": "Xem lại lịch vesting của bạn",
+        "confirmSubmit": "Xác nhận và gửi yêu cầu",
+        "review": {
+            "recipient": "Người nhận",
+            "startDate": "Ngày bắt đầu",
+            "endDate": "Ngày kết thúc",
+            "cliffDate": "Ngày Cliff",
+            "cancelable": "Có thể hủy",
+            "allowEarn": "Cho phép thu nhập",
+            "na": "N/A"
+        }
+    },
+    "earn": {
+        "placeholder": "Khám phá cơ hội thu nhập và phần thưởng staking."
+    },
+    "createTreasury": {
+        "validation": {
+            "nameMin": "Tên ngân quỹ phải có ít nhất 2 ký tự",
+            "nameMax": "Tên ngân quỹ phải ít hơn 64 ký tự",
+            "accountMin": "Tên tài khoản phải có ít nhất 2 ký tự",
+            "accountMax": "Tên tài khoản phải ít hơn 64 ký tự",
+            "accountChars": "Tên tài khoản chỉ có thể chứa chữ cái Latin, số và dấu gạch nối",
+            "accountTaken": "Tên tài khoản này đã được dùng"
+        },
+        "votingNote": "Bạn cần thêm thành viên để chỉnh sửa cài đặt bỏ phiếu. Hãy thêm thành viên khác để cấu hình bỏ phiếu.",
+        "minimumVoteNote": "Cần ít nhất một phiếu phê duyệt.",
+        "heading": "Tạo một Ngân quỹ",
+        "addMembers": "Thêm thành viên",
+        "addMembersInfo": "Bạn có thể thêm hoặc cập nhật thành viên ngay bây giờ và chỉnh sửa sau bất cứ lúc nào.",
+        "treasuryName": "Tên ngân quỹ",
+        "treasuryNamePlaceholder": "Ngân quỹ của tôi",
+        "accountName": "Tên tài khoản",
+        "accountNameInfo": "Đây là tên duy nhất của tài khoản bạn. Nó sẽ được dùng trong URL ngân quỹ của bạn và hiển thị trong các giao dịch để xác định người gửi tiền. Hãy chọn một cái tên ngắn và dễ nhận biết cho tài khoản.",
+        "accountPlaceholder": "my-treasury",
+        "continue": "Tiếp tục",
+        "votingThreshold": "Ngưỡng bỏ phiếu",
+        "thresholdDescription": "Đặt số phiếu cần thiết để phê duyệt yêu cầu:",
+        "financial": "Tài chính",
+        "financialDescription": "Phê duyệt các yêu cầu thanh toán & trao đổi.",
+        "governance": "Quản trị",
+        "governanceDescription": "Phê duyệt cài đặt, thành viên và cấu hình bỏ phiếu.",
+        "confidential": "Bảo mật",
+        "public": "Công khai",
+        "anyone": "Bất kỳ ai",
+        "teamOnly": "Chỉ đội",
+        "soon": "Sắp",
+        "publicDescription": "Tất cả số dư, hoạt động và giao dịch đều hiển thị với bất kỳ ai trên blockchain. Tùy chọn này phù hợp nhất với các tổ chức minh bạch và DAO công khai.",
+        "balanceTransactions": "Số dư, Giao dịch",
+        "membersVoting": "Thành viên, Bỏ phiếu",
+        "allFeatures": "Tất cả các tính năng có sẵn",
+        "confidentialDescription": "Tất cả số dư, hoạt động và chuyển khoản đều riêng tư trên blockchain. Chỉ đội của bạn có thể xem thông tin này. Phù hợp nhất cho công ty tư nhân, văn phòng gia đình hoặc các đội muốn quyền riêng tư về tài chính.",
+        "recentTransactionsExport": "Xuất giao dịch gần đây",
+        "bulkPayment": "Thanh toán hàng loạt",
+        "treasuryType": "Loại ngân quỹ",
+        "treasuryTypeWarning": "Bạn chỉ có thể chọn một lần cho mỗi ngân quỹ và không thể thay đổi sau này.",
+        "select": "Chọn",
+        "visibleOnChain": "Hiển thị trên chuỗi",
+        "featuresAvailable": "Các tính năng có sẵn",
+        "mostFeaturesSupported": "Hầu hết các tính năng được hỗ trợ",
+        "reviewTreasury": "Xem lại Ngân quỹ",
+        "membersLabel": "Thành viên",
+        "financialThreshold": "Ngưỡng tài chính",
+        "governanceThreshold": "Ngưỡng quản trị",
+        "noDeploymentFee": "🎉 Không phí triển khai",
+        "noDeploymentFeeDescription": "Để hỗ trợ các dự án mới, TREZU bao gồm tất cả phí triển khai một lần và phí lưu trữ mạng.",
+        "createButton": "Tạo Ngân quỹ",
+        "connectWalletCreate": "Kết nối ví để tạo ngân quỹ",
+        "unexpectedError": "Đã xảy ra lỗi không mong muốn",
+        "creationFailed": "Không thể tạo ngân quỹ. Vui lòng thử lại.",
+        "stepTitles": {
+            "aboutYou": "Về bạn",
+            "details": "Chi tiết",
+            "members": "Thành viên",
+            "treasuryType": "Loại ngân quỹ",
+            "review": "Xem lại"
+        },
+        "steps": {
+            "creatingNear": "Đang tạo ngân quỹ trên NEAR",
+            "registeringKey": "Đang đăng ký khóa công khai",
+            "settingUpConfidential": "Đang thiết lập giao dịch bảo mật",
+            "configuringMembers": "Đang cấu hình thành viên ngân quỹ",
+            "finalizingSetup": "Đang hoàn tất thiết lập"
+        }
+    },
+    "manageTreasuries": {
+        "warningOne": "Phải còn ít nhất một ngân quỹ khả dụng",
+        "warningOnePeriod": "Phải còn ít nhất một ngân quỹ khả dụng.",
+        "activeHeading": "Ngân quỹ đang hoạt động",
+        "activeDescription": "Các ngân quỹ hiện đang hiển thị trong danh sách tài khoản của bạn.",
+        "activeEmpty": "Không có ngân quỹ đang hoạt động.",
+        "hiddenHeading": "Ngân quỹ đã ẩn",
+        "hiddenDescription": "Các ngân quỹ đã ẩn khỏi danh sách tài khoản của bạn.",
+        "removeGuestTitle": "Xóa Ngân quỹ Khách",
+        "removeDialog": "Bạn sắp xóa <bold>{name}</bold>. Sau khi xác nhận, hành động này không thể hoàn tác.",
+        "tooltips": {
+            "removeFromList": "Xóa khỏi danh sách của bạn",
+            "viewTreasury": "Xem ngân quỹ",
+            "hideFromList": "Ẩn khỏi danh sách của bạn",
+            "showInList": "Hiển thị trong danh sách của bạn"
+        }
+    },
+    "wallet": {
+        "proposal": {
+            "transfer": "Đề xuất từ dApp bên ngoài: Chuyển NEAR cho {receiverId}",
+            "functionCall": "Đề xuất từ dApp bên ngoài: {methods} trên {receiverId}",
+            "unsupportedAction": "Loại hành động không được hỗ trợ \"{type}\". Chỉ có thể chuyển đổi hành động Transfer và FunctionCall thành đề xuất Trezu."
+        },
+        "loading": "Đang tải...",
+        "connectPrompt": "Kết nối ví NEAR của bạn để tiếp tục. Sau đó bạn sẽ chọn một ngân quỹ để hành động thay mặt.",
+        "connectWallet": "Kết nối ví",
+        "cancel": "Hủy",
+        "connectedAs": "Đã kết nối với tư cách <strong>{account}</strong>",
+        "loadingTreasuries": "Đang tải các ngân quỹ...",
+        "selectSignIn": "Chọn một ngân quỹ để đăng nhập với:",
+        "selectSignTx": "Chọn một ngân quỹ để tạo đề xuất trên:",
+        "notMember": "Bạn không phải là thành viên của ngân quỹ nào.",
+        "actingAs": "Đang hành động với tư cách",
+        "signedBy": "Được ký bởi {account}",
+        "createsNProposals": "Việc này sẽ tạo {count, plural, other {# đề xuất Trezu}} cho:",
+        "proposalDescriptionLabel": "Mô tả đề xuất (tùy chọn)",
+        "proposalDescriptionPlaceholder": "Mô tả đề xuất này...",
+        "createProposal": "Tạo đề xuất",
+        "creatingProposal": "Đang tạo đề xuất...",
+        "confirmInWallet": "Vui lòng xác nhận trong ví của bạn",
+        "proposalSubmitted": "Đã gửi đề xuất",
+        "shareProposal": "Đề xuất của bạn đã được tạo. Chia sẻ liên kết bên dưới với các thành viên ngân quỹ để bỏ phiếu.",
+        "proposalLink": "{daoId} — Đề xuất #{id}",
+        "checking": "Đang kiểm tra...",
+        "proposalApprovedProceed": "Đề xuất đã được phê duyệt. Tiếp tục",
+        "signedInSuccess": "Đăng nhập thành công",
+        "proposalCreatedSuccess": "Đã tạo đề xuất thành công",
+        "closeWindow": "Bạn có thể đóng cửa sổ này.",
+        "errorGeneric": "Đã xảy ra lỗi",
+        "tryAgain": "Thử lại",
+        "errors": {
+            "parseTx": "Không thể phân tích yêu cầu giao dịch. Vui lòng thử lại.",
+            "fetchTreasuries": "Không thể tải các ngân quỹ của bạn. Vui lòng thử lại.",
+            "connectFailed": "Không thể kết nối ví",
+            "createProposalFailed": "Không thể tạo đề xuất",
+            "stillPending": "Đề xuất vẫn đang chờ phê duyệt. Vui lòng đợi các thành viên ngân quỹ bỏ phiếu.",
+            "wasStatus": "Đề xuất #{id} đã {status}",
+            "awaitIndex": "Đề xuất đã được phê duyệt nhưng giao dịch thực thi chưa được lập chỉ mục. Vui lòng thử lại sau giây lát.",
+            "checkStatusFailed": "Không thể kiểm tra trạng thái đề xuất",
+            "userCancelled": "Người dùng đã hủy",
+            "proposalWasStatus": "Đề xuất đã {status}"
+        }
+    },
+    "telegram": {
+        "tagPill": "Telegram",
+        "invalidLinkTitle": "Liên kết không hợp lệ",
+        "invalidLinkDescription": "Liên kết kết nối Telegram này thiếu một token. Hãy nhấp lại Connect Treasury trong Telegram để tạo một liên kết mới.",
+        "successTitle": "Đã kết nối thành công",
+        "successDescription": "Các ngân quỹ đã được liên kết với cuộc trò chuyện Telegram này.",
+        "successToast": "Đã kết nối các ngân quỹ thành công",
+        "goToApp": "Đi tới ứng dụng",
+        "linkExpiredTitle": "Liên kết đã hết hạn",
+        "linkExpiredDescription": "Liên kết này đã hết hạn hoặc đã được sử dụng. Trong Telegram, hãy nhập lệnh bên dưới để khởi động lại quy trình kết nối.",
+        "commandCopied": "Đã sao chép lệnh",
+        "copy": "Sao chép",
+        "unableToLoadTitle": "Không thể tải cuộc trò chuyện",
+        "unableToLoadDescription": "Hiện không thể tải chi tiết cuộc trò chuyện. Vui lòng thử lại từ Telegram.",
+        "signInTitle": "Đăng nhập để tiếp tục",
+        "signInDescription": "Trước tiên, hãy kết nối ví NEAR, sau đó chọn các ngân quỹ để liên kết với cuộc trò chuyện Telegram này.",
+        "connectWallet": "Kết nối ví",
+        "selectTreasuriesTitle": "Chọn ngân quỹ",
+        "selectTreasuriesDescription": "Chọn các ngân quỹ để kết nối với cuộc trò chuyện Telegram này.",
+        "telegramChat": "Cuộc trò chuyện Telegram",
+        "chatIdFallback": "Trò chuyện #{id}",
+        "failedToConnect": "Không thể kết nối các ngân quỹ. Vui lòng thử lại.",
+        "relinking": "{count, plural, other {# ngân quỹ đã chọn được liên kết với các cuộc trò chuyện Telegram khác. Việc kết nối sẽ kết nối lại và thay đổi liên kết ID cuộc trò chuyện sang cuộc trò chuyện này.}}",
+        "alreadyConnected": "Đã kết nối với cuộc trò chuyện này",
+        "connectedToAnother": "Đã kết nối với một cuộc trò chuyện khác",
+        "notMember": "Bạn không phải là thành viên chính sách của bất kỳ ngân quỹ nào.",
+        "connecting": "Đang kết nối…",
+        "connect": "Kết nối"
+    },
+    "systemStatus": {
+        "underMaintenance": "Đang bảo trì",
+        "maintenanceMessage": "Chúng tôi đang thực hiện bảo trì. Một số tính năng có thể tạm thời không khả dụng. Vui lòng quay lại sau."
+    },
+    "creditsQuota": {
+        "available": "{count} khả dụng",
+        "used": "Đã dùng {count}",
+        "resetOn": "Giới hạn sẽ được đặt lại vào {date}"
+    },
+    "approvalInfo": {
+        "infoText": "Số phiếu cần để phê duyệt các yêu cầu liên quan đến thanh toán. Có thể chỉnh sửa trong cài đặt Bỏ phiếu.",
+        "thresholdPill": "Ngưỡng {required} trên {total}",
+        "alertBody": "Khoản thanh toán này sẽ cần phê duyệt từ <bold>{required}</bold> thành viên ngân quỹ trước khi thực thi."
+    },
+    "guestBadge": {
+        "title": "Khách",
+        "tooltip": "Bạn là khách của ngân quỹ này. Bạn chỉ có thể xem dữ liệu."
+    },
+    "exportButton": {
+        "confidentialTooltip": "Xuất chưa khả dụng ở chế độ bảo mật. Tính năng này sắp ra mắt!"
+    },
+    "sponsoredActions": {
+        "titleExhausted": "Đã sử dụng hết Hành động được tài trợ",
+        "titleAlmost": "Đội của bạn sắp hết các hành động được tài trợ",
+        "closeNotice": "Đóng thông báo",
+        "teamUsage": "Mức sử dụng của đội: {total} hành động mỗi tháng",
+        "available": "{count} khả dụng",
+        "used": "Đã dùng {count}",
+        "exhaustedBody": "Đội của bạn đã đạt số hành động được tài trợ trong tháng. Bạn có thể tiếp tục sau {date} hoặc liên hệ với chúng tôi",
+        "almostBody": "TREZU hiện tài trợ chi phí lưu trữ cho tất cả các hành động của đội, như tạo yêu cầu và bỏ phiếu cho chúng. Đội của bạn sắp đạt giới hạn được tài trợ trong tháng.",
+        "contactUs": "Liên hệ với chúng tôi",
+        "nextMonthlyReset": "lần đặt lại hàng tháng tiếp theo của bạn",
+        "sidebarBody": "Đội của bạn đã đạt số hành động được tài trợ trong tháng. Bạn có thể tiếp tục sau {date} hoặc ⬇️"
+    },
+    "acceptTerms": {
+        "title": "Chấp nhận điều khoản để tiếp tục",
+        "privacyTitle": "Quyền riêng tư của bạn tại Trezu",
+        "privacyBody": "Trezu là giao diện không lưu ký. Chúng tôi ưu tiên quyền riêng tư của bạn đồng thời đảm bảo nền tảng vẫn an toàn và hoạt động tốt.",
+        "minimalTitle": "Dữ liệu tối thiểu",
+        "minimalBody": "Chúng tôi thu thập thông tin hạn chế, như địa chỉ ví công khai, địa chỉ IP và phân tích sử dụng, để vận hành và cải thiện Giao diện.",
+        "noCustodyTitle": "Không lưu ký",
+        "noCustodyBody": "Chúng tôi không bao giờ có quyền truy cập vào khóa cá nhân, cụm từ khôi phục hay tài sản số của bạn.",
+        "publicTitle": "Hồ sơ công khai",
+        "publicBody": "Hãy nhớ rằng tất cả các giao dịch blockchain vốn đã công khai và không do chúng tôi kiểm soát.",
+        "responsibilityTitle": "Trách nhiệm của bạn",
+        "responsibilityBody": "Bạn hoàn toàn chịu trách nhiệm theo dõi hoạt động ví của mình và bảo mật thông tin xác thực.",
+        "futureTitle": "Cập nhật trong tương lai",
+        "futureBody": "Nếu bạn chọn nhận thông báo trong tương lai (như email hoặc Telegram), chúng tôi sẽ chỉ sử dụng dữ liệu đó để giữ cho bạn được cập nhật.",
+        "agreement": "Tôi đã đọc và đồng ý với <terms>Điều khoản dịch vụ</terms> và <privacy>Chính sách bảo mật</privacy>",
+        "accepting": "Đang chấp nhận...",
+        "continue": "Tiếp tục"
+    },
+    "confidentialBanner": {
+        "label": "Bảo mật",
+        "description": "Số dư, hoạt động và chuyển khoản chỉ hiển thị với đội của bạn — không phải blockchain công khai."
+    },
+    "supportCenter": {
+        "title": "Trung tâm hỗ trợ",
+        "resources": "Tài nguyên",
+        "support": "Hỗ trợ",
+        "websiteTitle": "Trang web Trezu",
+        "websiteDescription": "Tìm hiểu thêm về Trezu và đọc blog của chúng tôi.",
+        "demo": "Demo Trezu",
+        "demoTitle": "Khám phá phiên bản công khai",
+        "demoDescription": "Xem một tài khoản công khai trực tiếp đang hoạt động.",
+        "confidentialDemoTitle": "Khám phá phiên bản bảo mật",
+        "confidentialDemoDescription": "Khám phá một tài khoản bảo mật trực tiếp đang hoạt động.",
+        "videoTitle": "Xem demo",
+        "videoDescription": "Xem video ngắn cho thấy cách Trezu hoạt động.",
+        "xTitle": "Theo dõi chúng tôi trên X",
+        "xDescription": "Cập nhật các bản phát hành và thông tin chi tiết mới nhất của chúng tôi.",
+        "statsTitle": "Thống kê",
+        "statsDescription": "Xem tổng tài sản đang quản lý trên tất cả các sputnik DAO.",
+        "docsTitle": "Tài liệu",
+        "docsDescription": "Tìm hiểu về tất cả tính năng trong tài liệu.",
+        "productSupportTitle": "Hỗ trợ sản phẩm",
+        "productSupportDescription": "Liên hệ đội hỗ trợ của chúng tôi để được giúp đỡ."
+    },
+    "progressModal": {
+        "titleCreating": "Đang tạo Ngân quỹ...",
+        "titleDone": "Đã tạo Ngân quỹ",
+        "titleFailed": "Tạo Ngân quỹ thất bại",
+        "viewTreasury": "Xem Ngân quỹ"
+    },
+    "memberValidation": {
+        "noManagePermission": "Bạn không có quyền quản lý thành viên",
+        "pendingRequest": "Bạn không thể quản lý thành viên khi có yêu cầu đang hoạt động",
+        "rolesAnd": "{first} và {second}",
+        "rolesMany": "{list}, và {last}",
+        "cannotRemoveMember": "Không thể xóa thành viên này. Họ là người duy nhất được gán {roles} {count, plural, other {vai trò}}.",
+        "cannotRemoveMemberGov": "Không thể xóa thành viên này. Họ là người duy nhất được gán {roles} {count, plural, other {vai trò, vốn cần thiết}} để quản lý thành viên đội và cấu hình bỏ phiếu.",
+        "cannotBulkRemove": "Không thể xóa các thành viên này. Việc này sẽ khiến {roles} {count, plural, other {vai trò}} trống.",
+        "cannotBulkRemoveGov": "Không thể xóa các thành viên này. Việc này sẽ khiến {roles} {count, plural, other {vai trò, vốn cần thiết}} trống, vốn cần để quản lý thành viên đội và cấu hình bỏ phiếu.",
+        "cannotRemoveRole": "Bạn không thể xóa vai trò {role} của thành viên này. Họ là người duy nhất được gán vai trò này.",
+        "cannotRemoveRoleGov": "Bạn không thể xóa vai trò {role} của thành viên này. Họ là thành viên {role} duy nhất, và không có vai trò này bạn sẽ không thể quản lý thành viên đội hay cấu hình bỏ phiếu."
+    },
+    "roleSelector": {
+        "setRole": "Đặt vai trò",
+        "allRoles": "Tất cả vai trò",
+        "roles": {
+            "governance": {
+                "title": "Quản trị",
+                "description": "Quản trị có thể tạo và bỏ phiếu cho các cài đặt ngân quỹ liên quan đến đội, bao gồm thành viên, quyền và giao diện ngân quỹ."
+            },
+            "requestor": {
+                "title": "Người yêu cầu",
+                "description": "Người yêu cầu có thể tạo các yêu cầu giao dịch liên quan đến thanh toán, không có quyền bỏ phiếu hoặc phê duyệt."
+            },
+            "financial": {
+                "title": "Tài chính",
+                "description": "Tài chính có thể bỏ phiếu cho các yêu cầu giao dịch liên quan đến thanh toán nhưng không thể tạo chúng."
+            }
+        }
+    },
+    "memberInput": {
+        "creatorYou": "Người tạo (bạn)",
+        "memberAddress": "Địa chỉ thành viên",
+        "addNewMember": "Thêm thành viên mới",
+        "validation": {
+            "rolesRequired": "Cần ít nhất một vai trò",
+            "duplicateAddress": "Địa chỉ đã là một thành viên"
+        }
+    },
+    "recipientInput": {
+        "title": "Đến",
+        "placeholder": "Địa chỉ người nhận"
+    },
+    "accountInput": {
+        "failedValidation": "Không thể xác thực địa chỉ",
+        "invalidNearFormat": "Định dạng tài khoản NEAR không hợp lệ",
+        "invalidChainAddress": "Vui lòng nhập một địa chỉ {chain} hợp lệ.",
+        "validating": "Đang xác thực địa chỉ...",
+        "validAddress": "Địa chỉ hợp lệ",
+        "placeholderWithExample": "Địa chỉ người nhận (ví dụ: {example})",
+        "placeholderNoExample": "Địa chỉ người nhận",
+        "nearExample": "alice.near, 0x..., hoặc hex 64 ký tự",
+        "near": {
+            "required": "Bắt buộc nhập địa chỉ",
+            "length": "Địa chỉ phải có từ 2 đến 64 ký tự",
+            "missingTld": "Tài khoản có tên phải kết thúc bằng .near, .aurora hoặc .tg",
+            "invalidChars": "Địa chỉ chỉ có thể chứa chữ thường, số và dấu phân cách (., -, _)",
+            "accountMissing": "Tài khoản không tồn tại trên blockchain NEAR",
+            "verifyFailed": "Không thể xác minh sự tồn tại của tài khoản"
+        }
+    },
+    "csvUpload": {
+        "uploadFile": "Tải lên tệp",
+        "provideData": "Cung cấp dữ liệu",
+        "chooseFile": "Chọn tệp",
+        "orDragDrop": "hoặc kéo và thả",
+        "maxFileSize": "tối đa 1 tệp lên đến {maxSize} MB, chỉ chấp nhận tệp CSV",
+        "noFilePrompt": "Không có tệp để tải lên?",
+        "downloadTemplate": "Tải xuống mẫu"
+    },
+    "tokenSelect": {
+        "selectToken": "Chọn token",
+        "searchPlaceholder": "Tìm token...",
+        "noTokensFound": "Không tìm thấy token"
+    },
+    "filterOperations": {
+        "is": "Là",
+        "isNot": "Không phải là",
+        "before": "Trước",
+        "after": "Sau",
+        "between": "Giữa",
+        "equal": "Bằng",
+        "moreThan": "Lớn hơn",
+        "lessThan": "Nhỏ hơn",
+        "contains": "Chứa"
+    },
+    "copyButton": {
+        "copied": "Đã sao chép vào bộ nhớ tạm",
+        "failed": "Không thể sao chép"
+    },
+    "recipientForm": {
+        "validation": {
+            "nameRequired": "Bắt buộc nhập tên",
+            "nameMax": "Tên người nhận phải ít hơn {max} ký tự",
+            "addressRequired": "Bắt buộc nhập địa chỉ",
+            "networksRequired": "Hãy chọn ít nhất một mạng"
+        }
+    },
+    "paymentForm": {
+        "validation": {
+            "recipientMin": "Người nhận phải có ít nhất 2 ký tự",
+            "recipientMax": "Người nhận phải ít hơn 128 ký tự",
+            "amountGreaterThanZero": "Số tiền phải lớn hơn 0",
+            "recipientSameAsToken": "Địa chỉ người nhận và token không thể giống nhau",
+            "selectToken": "Vui lòng chọn một token",
+            "recipientMax64": "Người nhận phải ít hơn 64 ký tự",
+            "amountMinLockup": "Số tiền phải lớn hơn hoặc bằng 3.5",
+            "startDateRequired": "Bắt buộc nhập ngày bắt đầu",
+            "endDateRequired": "Bắt buộc nhập ngày kết thúc",
+            "cliffDateRequired": "Bắt buộc nhập ngày Cliff",
+            "startBeforeEnd": "Ngày bắt đầu phải trước ngày kết thúc",
+            "cliffBetween": "Ngày Cliff phải nằm giữa {start} và {end}"
+        }
+    },
+    "exportToasts": {
+        "downloadFailed": "Không thể tải xuống bản xuất",
+        "invalidDateRange": "Khoảng ngày không hợp lệ",
+        "invalidDateRangeDescription": "Vui lòng chọn một khoảng ngày hợp lệ để xuất.",
+        "exportSuccess": "Xuất thành công!",
+        "exportSuccessDescription": "Tệp {type} của bạn đã được tải xuống. Kiểm tra lịch sử xuất để biết chi tiết.",
+        "exportFailed": "Xuất thất bại",
+        "exportFailedFallback": "Không thể xuất dữ liệu. Vui lòng thử lại.",
+        "noDownloadPermission": "Bạn không có quyền tải tệp này.",
+        "noExportPermission": "Bạn không có quyền xuất",
+        "quotaUsed": "Bạn đã dùng hết hạn mức",
+        "exporting": "Đang xuất...",
+        "export": "Xuất",
+        "columnSubmissionTime": "Thời gian gửi",
+        "columnDateRange": "Khoảng ngày",
+        "columnGeneratedBy": "Tạo bởi",
+        "columnStatus": "Trạng thái",
+        "typeAll": "Tất cả loại",
+        "typeSent": "Đã gửi",
+        "typeReceived": "Đã nhận",
+        "typeStakingRewards": "Phần thưởng Staking",
+        "allAssets": "Tất cả tài sản",
+        "upgradeTrial": "Nâng cấp gói của bạn để có thêm và tiếp tục",
+        "upgradePaid": "Nâng cấp gói để có thêm quyền truy cập, hoặc đợi đến khi giới hạn của bạn được đặt lại vào tháng sau.",
+        "selectDateRange": "Chọn khoảng ngày",
+        "noExportsTitle": "Chưa có bản xuất nào",
+        "noExportsDescription": "Các tệp đã xuất trong tháng vừa qua sẽ xuất hiện ở đây sau khi được tạo.",
+        "quotaTitle": "Hạn mức xuất",
+        "unlimited": "Không giới hạn",
+        "creditsPerMonth": "{total} / tháng",
+        "requirementsTitle": "Yêu cầu xuất",
+        "exportFromPeriod": "Bạn có thể xuất dữ liệu từ {period}.",
+        "availableFor48Hours": "Các tệp đã xuất khả dụng để tải trong 48 giờ.",
+        "moreFlexibility": "Cần thêm sự linh hoạt?",
+        "contactUs": "Liên hệ với chúng tôi",
+        "last1Year": "1 năm qua",
+        "last2Years": "2 năm qua",
+        "invalidEmail": "Vui lòng nhập một địa chỉ email hợp lệ"
+    },
+    "proposalKinds": {
+        "Batch Payment Request": "Yêu cầu thanh toán hàng loạt",
+        "Payment Request": "Yêu cầu thanh toán",
+        "Confidential Request": "Yêu cầu bảo mật",
+        "Exchange": "Trao đổi",
+        "Function Call": "Gọi hàm",
+        "Change Policy": "Thay đổi chính sách",
+        "Update General Settings": "Cập nhật cài đặt chung",
+        "Earn NEAR": "Kiếm NEAR",
+        "Unstake NEAR": "Bỏ stake NEAR",
+        "Vesting": "Vesting",
+        "Withdraw Earnings": "Rút thu nhập",
+        "Members": "Thành viên",
+        "Upgrade": "Nâng cấp",
+        "Set Staking Contract": "Đặt hợp đồng Staking",
+        "Bounty": "Tiền thưởng",
+        "Vote": "Bỏ phiếu",
+        "Factory Info Update": "Cập nhật thông tin Factory",
+        "Unsupported": "Không được hỗ trợ"
+    },
+    "paymentFormSection": {
+        "selectRecipient": "Chọn người nhận",
+        "searchByNameOrAddress": "Tìm theo tên hoặc địa chỉ",
+        "restrictedRecipientTitle": "Giao dịch không được phép",
+        "restrictedRecipientMessage": "Địa chỉ này hiện đang bị hạn chế do các kiểm tra bảo mật. Nếu bạn cho rằng địa chỉ này nên được phép, bạn có thể <link>yêu cầu đưa vào danh sách trắng</link>.",
+        "send": "Gửi",
+        "to": "Đến"
+    },
+    "recipientNetworkSelect": {
+        "label": "Mạng người nhận",
+        "placeholder": "Chọn mạng người nhận",
+        "enterAddressFirst": "Hãy nhập địa chỉ người nhận trước",
+        "noCompatibleNetwork": "Không có mạng nào phù hợp với địa chỉ này",
+        "selectPlaceholder": "Chọn mạng",
+        "title": "Chọn mạng",
+        "available": "Khả dụng",
+        "fromAddressBook": "Từ sổ địa chỉ",
+        "otherAvailable": "Khác khả dụng",
+        "incompatible": "Không tương thích",
+        "comingSoon": "Sắp ra mắt",
+        "nearComName": "near.com",
+        "nearComDescription": "Mạng nội bộ cho near.com và trezu"
+    },
+    "addressBookTable": {
+        "emptyTitle": "Chưa có người nhận nào",
+        "emptyDescription": "Thêm người nhận vào sổ địa chỉ này để chi trả nhanh hơn.",
+        "selectAll": "Chọn tất cả người nhận",
+        "selectEntry": "Chọn {name}",
+        "recipient": "Người nhận",
+        "network": "Mạng",
+        "addedBy": "Được thêm bởi",
+        "note": "Ghi chú",
+        "added": "Đã thêm",
+        "remove": "Xóa",
+        "send": "Gửi"
+    },
+    "publicDashboard": {
+        "updatesDaily": "Cập nhật hàng ngày",
+        "noDataTitle": "Chưa có dữ liệu",
+        "noDataDescription": "Thống kê sẽ xuất hiện sau khi ảnh chụp hàng ngày đầu tiên được tính toán.",
+        "assetsSecured": "Tài sản được bảo mật bằng hợp đồng Sputnik DAO",
+        "acrossDaos": "Trên <bold>{count, plural, other {# DAO}}</bold>",
+        "updatedOn": "Cập nhật {date}",
+        "topAssets": "20 tài sản hàng đầu",
+        "noAssetsTitle": "Chưa có tài sản nào",
+        "noAssetsDescription": "Dữ liệu token sẽ xuất hiện sau khi ảnh chụp hàng ngày được tính toán.",
+        "tableToken": "Token",
+        "tableTotalValue": "Tổng giá trị"
+    },
+    "telegramConnectInstructions": {
+        "title": "Kết nối Telegram",
+        "subtitle": "Nhận thông báo về đề xuất và hoạt động trong Telegram của bạn.",
+        "step3": "Nhấn Start và làm theo hướng dẫn.",
+        "success": "Bạn đã sẵn sàng!",
+        "copyBotTooltip": "Sao chép tên bot",
+        "botCopiedToast": "Đã sao chép tên bot",
+        "openInTelegram": "Mở {bot} trong Telegram"
+    },
+    "transactionHashCell": {
+        "copyHash": "Sao chép hash",
+        "hashCopied": "Đã sao chép hash",
+        "openInExplorer": "Mở trong trình khám phá"
+    },
+    "treasurySelector": {
+        "select": "Chọn ngân quỹ",
+        "connectWalletTooltip": "Kết nối ví để xem các ngân quỹ",
+        "manageTreasuries": "Quản lý ngân quỹ",
+        "createTreasury": "Tạo ngân quỹ",
+        "memberOf": "Thành viên của",
+        "guestTreasuries": "Ngân quỹ khách"
+    },
+    "selectModal": {
+        "searchByName": "Tìm theo tên",
+        "noResults": "Không tìm thấy kết quả"
+    },
+    "selectList": {
+        "noResults": "Không tìm thấy kết quả"
+    },
+    "datePicker": {
+        "pickDate": "Chọn một ngày",
+        "timezone": "Múi giờ"
+    },
+    "datePresets": {
+        "today": "Hôm nay",
+        "yesterday": "Hôm qua",
+        "last3Days": "3 ngày qua",
+        "last7Days": "7 ngày qua",
+        "last14Days": "14 ngày qua",
+        "lastMonth": "Tháng trước",
+        "last3Months": "3 tháng qua",
+        "last6Months": "6 tháng qua"
+    },
+    "input": {
+        "openSearch": "Mở tìm kiếm"
+    },
+    "pagination": {
+        "previous": "Trước",
+        "next": "Tiếp"
+    },
+    "confidentialState": {
+        "title": "Bảo mật",
+        "description": "Chỉ thành viên ngân quỹ mới có quyền truy cập."
+    },
+    "exchangeRate": {
+        "rate": "Tỷ giá",
+        "clickToReverse": "Nhấp để đảo ngược tỷ giá"
+    },
+    "exchangeSettings": {
+        "title": "Cài đặt trao đổi",
+        "slippageTolerance": "Dung sai trượt giá",
+        "custom": "Tùy chỉnh",
+        "customPlaceholder": "ví dụ: 2%",
+        "slippageRange": "Trượt giá phải nằm trong khoảng 0.01% và 100%",
+        "enterSlippage": "Vui lòng nhập dung sai trượt giá",
+        "slippageHelp": "Nếu giá thay đổi nhiều hơn tỷ lệ phần trăm này, giao dịch sẽ bị hủy để bảo vệ tiền của bạn.",
+        "save": "Lưu"
+    },
+    "assetsPage": {
+        "title": "Tài sản",
+        "noAssetsTitle": "Chưa có tài sản nào",
+        "noAssetsDescription": "Để bắt đầu, hãy thêm tài sản vào Ngân quỹ của bạn bằng cách nạp tiền."
+    },
+    "newBadge": {
+        "label": "Mới"
+    },
+    "numberBadge": {
+        "pendingRequests": "{count, plural, other {# yêu cầu đang chờ}}"
+    },
+    "balanceWithGraph": {
+        "allTokens": "Tất cả token",
+        "deposit": "Nạp tiền",
+        "send": "Gửi",
+        "exchange": "Trao đổi",
+        "chartNow": "Bây giờ",
+        "totalBalance": "Tổng số dư",
+        "excludedTokens": "Token bị loại trừ:",
+        "noPriceHistory": "Không có lịch sử giá. Chọn một token để xem thay đổi số dư.",
+        "bucketAvailable": "Khả dụng",
+        "bucketLocked": "Đã khóa",
+        "bucketEarning": "Thu nhập",
+        "period": {
+            "1W": "1T",
+            "1M": "1Th",
+            "3M": "3Th",
+            "1Y": "1N"
+        }
+    },
+    "changePolicyExpanded": {
+        "proposalBond": "Bond đề xuất",
+        "proposalPeriod": "Thời gian đề xuất",
+        "bountyBond": "Bond tiền thưởng",
+        "bountyForgivenessPeriod": "Thời gian miễn tiền thưởng",
+        "votesCount": "{count} phiếu",
+        "weightKind": "Loại trọng số",
+        "quorum": "Số đại biểu",
+        "threshold": "Ngưỡng",
+        "defaultThreshold": "Ngưỡng mặc định",
+        "roleThreshold": "Ngưỡng {role}",
+        "member": "Thành viên",
+        "members": "Thành viên",
+        "permissions": "Quyền",
+        "oldPermissions": "Quyền cũ",
+        "newPermissions": "Quyền mới",
+        "category": "Danh mục",
+        "transactionDetails": "Chi tiết giao dịch",
+        "addNewMember": "Thêm thành viên mới",
+        "addNewMembers": "Thêm thành viên mới",
+        "removeMember": "Xóa thành viên",
+        "removeMembers": "Xóa thành viên",
+        "updateMemberPermissions": "Cập nhật quyền thành viên",
+        "updateMembersPermissions": "Cập nhật quyền các thành viên",
+        "memberIndex": "Thành viên {index}",
+        "membersCount": "{count} thành viên",
+        "collapseAll": "Thu gọn tất cả",
+        "expandAll": "Mở rộng tất cả",
+        "loadingHistorical": "Đang tải chính sách lịch sử...",
+        "unableToDiff": "Không thể tính toán khác biệt cho đề xuất này.",
+        "noChangesCurrent": "Không phát hiện thay đổi - chính sách đề xuất giống với chính sách hiện tại.",
+        "noChangesHistorical": "Không phát hiện thay đổi - chính sách đề xuất giống với chính sách lịch sử."
+    },
+    "balanceChart": {
+        "usdValue": "Giá trị USD",
+        "tokenBalance": "Số dư token",
+        "emptyTitle": "Chưa có gì để hiển thị",
+        "emptyDescription": "Thêm tài sản để bắt đầu theo dõi danh mục đầu tư của bạn."
+    },
+    "user": {
+        "saveToAddressBook": "Lưu vào sổ địa chỉ",
+        "walletCopiedToast": "Đã sao chép địa chỉ ví vào bộ nhớ tạm",
+        "copyWalletAddress": "Sao chép địa chỉ ví"
+    },
+    "infoDisplay": {
+        "viewLess": "Xem ít hơn",
+        "viewAllDetails": "Xem tất cả chi tiết"
+    },
+    "amountSummary": {
+        "defaultTitle": "Bạn đang gửi tổng cộng"
+    },
+    "residency": {
+        "vestedToken": "Token đã vesting",
+        "staked": "Đã stake",
+        "fungibleToken": "Token có thể thay thế",
+        "intentsToken": "Token Intents",
+        "nativeToken": "Token gốc"
+    },
+    "exchangeErrors": {
+        "noRoute": "Không tìm thấy giao dịch trao đổi. Hãy thử số tiền nhỏ hơn hoặc token khác.",
+        "amountTooLow": "Số tiền quá thấp để hoán đổi. Hoán đổi liên chuỗi yêu cầu mức tối thiểu cao hơn để chi trả phí mạng.",
+        "insufficientBalance": "Số dư không đủ cho giao dịch hoán đổi này.",
+        "networkError": "Lỗi mạng. Vui lòng kiểm tra kết nối và thử lại.",
+        "fetchFailed": "Không thể lấy báo giá"
+    },
+    "tokenSelectDialog": {
+        "selectToken": "Chọn token",
+        "selectAsset": "Chọn tài sản",
+        "selectNetworkFor": "Chọn mạng cho {asset}",
+        "searchByName": "Tìm theo tên",
+        "noTokensWithBalance": "Không tìm thấy token có số dư",
+        "noTokensFound": "Không tìm thấy token",
+        "yourAssets": "Tài sản của bạn",
+        "otherAssets": "Tài sản khác",
+        "networksWithAssets": "Mạng có tài sản",
+        "supportedNetworks": "Mạng được hỗ trợ",
+        "comingSoon": "Sắp ra mắt"
+    },
+    "intentsQuote": {
+        "initializing": "Dịch vụ báo giá vẫn đang khởi tạo. Vui lòng thử lại.",
+        "noRoute": "Hiện không thể chuẩn bị tuyến thanh toán. Vui lòng thử lại.",
+        "fetchFailed": "Hiện không thể chuẩn bị tuyến thanh toán. Vui lòng thử lại.",
+        "amountTooLow": "Số tiền quá thấp để chi trả phí mạng. Hãy nhập số tiền cao hơn và thử lại.",
+        "amountTooLowWithMin": "Số tiền quá thấp để chi trả phí mạng. Hãy nhập ít nhất {min} {token}.",
+        "networkFeeTooltip": "Phí này được dùng để xử lý giao dịch trên chuỗi đã chọn."
+    },
+    "pageTours": {
+        "paymentsBulk": "Tạo hàng loạt đã có mặt! Tạo nhiều yêu cầu chỉ trong vài bước.",
+        "paymentsPending": "Xem các yêu cầu đang chờ phê duyệt tại đây.",
+        "exchangeSettings": "Tại đây bạn có thể đặt mức thay đổi giá mà bạn sẵn sàng chấp nhận.",
+        "membersPending": "Nhấp để xem các yêu cầu đang chờ phê duyệt.",
+        "guestSaveIntro": "Bạn là khách của ngân quỹ này. Bạn chỉ có thể xem dữ liệu.",
+        "guestSaveAction": "Bạn có thể lưu ngân quỹ khách này vào danh sách ngân quỹ của bạn.",
+        "newFeatureRich": "Mới! 🎉 Lưu các địa chỉ thường dùng để chi trả nhanh hơn và không có lỗi.<br></br> Liên hệ của bạn được giữ riêng tư và chỉ đội của bạn nhìn thấy.",
+        "newFeatureCta": "Hãy thử"
+    },
+    "statusDate": {
+        "expires": "Hết hạn",
+        "created": "Đã tạo",
+        "expired": "Đã hết hạn",
+        "removed": "Đã xóa"
+    },
+    "relativeTime": {
+        "justNow": "Vừa xong",
+        "moments": "khoảnh khắc"
+    },
+    "amount": {
+        "network": "Mạng: {network}"
+    },
+    "activityLabels": {
+        "exchangePending": "Trao đổi đang chờ",
+        "exchangeRequest": "Yêu cầu trao đổi",
+        "exchangeFulfillment": "Hoàn tất trao đổi",
+        "stakingRewards": "Phần thưởng Staking",
+        "proposalAction": "Hành động đề xuất",
+        "deposit": "Nạp {symbol}",
+        "paymentSent": "Đã gửi thanh toán",
+        "transaction": "Giao dịch",
+        "fallbackToken": "Token",
+        "viaIntents": "thông qua NEAR Intents",
+        "from": "từ {account}",
+        "to": "đến {account}",
+        "viewAll": "Xem toàn bộ lịch sử giao dịch của bạn",
+        "sentReceived": "Giao dịch đã gửi và đã nhận ({duration})",
+        "unlimitedHistory": "lịch sử không giới hạn",
+        "oneYear": "1 năm",
+        "yearsCount": "{count} năm",
+        "monthsCount": "{count} tháng",
+        "lastDuration": "{duration} qua"
+    },
+    "nearStore": {
+        "connectAndAcceptTerms": "Vui lòng kết nối ví và chấp nhận các điều khoản để tiếp tục.",
+        "transactionNotApproved": "Giao dịch đã không được phê duyệt trong ví của bạn.",
+        "failedSubmitVote": "Không thể gửi phiếu",
+        "failedSubmitVotes": "Không thể gửi các phiếu",
+        "viewRequest": "Xem yêu cầu",
+        "proposalRemoved": "Đề xuất của bạn đã được xóa",
+        "voteSubmitted": "Phiếu của bạn đã được gửi",
+        "votesSubmitted": "Các phiếu của bạn đã được gửi"
+    },
+    "tokenInput": {
+        "max": "MAX",
+        "insufficientTokens": "Không đủ token. Bạn có thể gửi yêu cầu và nạp thêm trước khi phê duyệt.",
+        "balance": "Số dư: {amount} {symbol}"
+    },
+    "createRequestButton": {
+        "idle": "Tạo yêu cầu",
+        "noPermission": "Bạn không có quyền tạo yêu cầu"
+    },
+    "address": {
+        "copied": "Đã sao chép địa chỉ vào bộ nhớ tạm"
+    },
+    "memberAvatars": {
+        "membersWhoCanVote": "Thành viên có thể bỏ phiếu",
+        "moreMembers": "+{count, plural, other {# thành viên}}"
+    },
+    "accountIdInput": {
+        "minLength": "ID tài khoản phải có ít nhất 2 ký tự",
+        "maxLength": "ID tài khoản phải ít hơn 64 ký tự",
+        "charset": "ID tài khoản chỉ có thể chứa chữ thường, số, dấu chấm, dấu gạch nối và gạch dưới, không có dấu phân cách ở đầu hoặc cuối",
+        "doesNotExist": "ID tài khoản không tồn tại"
+    },
+    "addressBookMutations": {
+        "addedToast": "{count, plural, one {Đã thêm người nhận} other {Đã thêm # người nhận}}",
+        "addedSingleToast": "Đã thêm người nhận",
+        "addFailedToast": "Không thể thêm người nhận",
+        "addSingleFailedToast": "Không thể thêm người nhận",
+        "removedToast": "{count, plural, one {Đã xóa người nhận} other {Đã xóa # người nhận}}",
+        "removeFailedToast": "Không thể xóa người nhận",
+        "exportFailedToast": "Không thể xuất danh sách người nhận"
+    },
+    "treasuryMutations": {
+        "savedToast": "Đã lưu ngân quỹ vào danh sách của bạn",
+        "saveFailedToast": "Không thể lưu ngân quỹ",
+        "hiddenToast": "Đã ẩn ngân quỹ khỏi danh sách",
+        "hideFailedToast": "Không thể ẩn ngân quỹ",
+        "unhiddenToast": "Ngân quỹ lại hiển thị",
+        "unhideFailedToast": "Không thể bỏ ẩn ngân quỹ",
+        "removedToast": "Đã xóa ngân quỹ khỏi danh sách đã lưu",
+        "removeFailedToast": "Không thể xóa ngân quỹ khỏi danh sách đã lưu"
+    },
+    "telegramSettings": {
+        "title": "Telegram",
+        "connectedTo": "Đã kết nối với {chat}",
+        "chatNumber": "Trò chuyện #{id}",
+        "fallbackChat": "một cuộc trò chuyện Telegram",
+        "disconnect": "Ngắt kết nối",
+        "connect": "Kết nối",
+        "connectDescription": "Liên kết ngân quỹ của bạn với một cuộc trò chuyện Telegram để nhận thông báo.",
+        "noTreasuryDescription": "Liên kết các ngân quỹ của bạn với một cuộc trò chuyện Telegram.",
+        "openSettingsHint": "Mở cài đặt từ một ngân quỹ để quản lý tích hợp.",
+        "disconnectedToast": "Đã ngắt kết nối Telegram cho ngân quỹ này",
+        "disconnectFailedToast": "Không thể ngắt kết nối Telegram. Hãy thử lại."
+    },
+    "assetsTable": {
+        "noAssetsFound": "Không tìm thấy tài sản nào.",
+        "assetDetails": "Chi tiết tài sản",
+        "coinPrice": "Giá Coin",
+        "weight": "Trọng số",
+        "balance": "Số dư",
+        "lockedBalance": "Số dư đã khóa",
+        "totalBalance": "Tổng số dư",
+        "source": "Nguồn",
+        "balanceByInvestors": "Số dư theo {count, plural, other {Nhà đầu tư}}",
+        "investors": "{count, plural, other {Nhà đầu tư}}",
+        "poolBreakdown": "Phân tích Pool",
+        "unlockedToken": "Token đã mở khóa",
+        "lockupStakingPool": "Pool staking lockup",
+        "exchange": "Trao đổi",
+        "send": "Gửi",
+        "details": "Chi tiết",
+        "columnToken": "Token",
+        "columnLocked": "Đã khóa",
+        "columnUnlocked": "Đã mở khóa",
+        "columnTotalAllocated": "Tổng đã phân bổ",
+        "columnAvailableToWithdraw": "Có thể rút",
+        "viewAvailable": "Khả dụng",
+        "viewLocked": "Đã khóa",
+        "viewEarning": "Thu nhập",
+        "fullAllocatedBalance": "Toàn bộ số dư đã phân bổ của bạn",
+        "partAllocatedBalance": "Một phần số dư đã phân bổ của bạn",
+        "currentlyEarning": "({amount} {symbol}) hiện đang tạo thu nhập.",
+        "willAppearHere": " Số tiền sẽ xuất hiện ở đây sau khi bạn dừng tạo thu nhập.",
+        "seeInEarningTab": "Xem trong tab Thu nhập",
+        "seeInEarning": "Xem trong Thu nhập"
+    },
+    "earningDetails": {
+        "title": "Chi tiết thu nhập",
+        "totalStaked": "Tổng đã stake",
+        "earningOverview": "Tổng quan thu nhập",
+        "poolBreakdown": "Phân tích Pool ({count, plural, other {# pool}})",
+        "almostReady": "Thu nhập sắp sẵn sàng!",
+        "finalizingFeature": "Chúng tôi đang hoàn tất tính năng này<br></br>để bạn có thể bắt đầu kiếm token sớm.",
+        "comingSoon": "Sắp ra mắt",
+        "goToEarn": "Đi đến Thu nhập",
+        "readyToWithdraw": "Sẵn sàng rút",
+        "unstaking": "Đang bỏ stake",
+        "overview": {
+            "staked": "Đã stake",
+            "stakedInfo": "Token hiện đang được ủy quyền cho validator để kiếm phần thưởng.",
+            "pendingRelease": "Đang chờ phát hành",
+            "pendingReleaseInfo": "Token đã được bỏ stake nhưng vẫn trong giai đoạn unbonding (thường là 2-3 ngày).",
+            "availableForWithdraw": "Có thể rút",
+            "availableForWithdrawInfo": "Token đã bỏ stake hoàn tất giai đoạn unbonding và có thể rút."
+        }
+    },
+    "lockupDetails": {
+        "title": "Chi tiết Lockup",
+        "balance": "Số dư",
+        "reservedForStorage": "Dự trữ cho lưu trữ",
+        "reservedForStorageInfo": "NEAR được tài khoản lockup dự trữ để chi trả chi phí lưu trữ.",
+        "tokenBreakdown": "Phân tích token",
+        "allocatedAmount": "Số tiền đã phân bổ",
+        "earned": "Đã kiếm được",
+        "progress": "Tiến độ",
+        "unlocked": "Đã mở khóa",
+        "locked": "Đã khóa",
+        "schedule": "Lịch trình",
+        "startDate": "Ngày bắt đầu",
+        "endDate": "Ngày kết thúc",
+        "rounds": "Vòng",
+        "releaseInterval": "Khoảng phát hành",
+        "nextUnlockDate": "Ngày mở khóa kế tiếp",
+        "allEarning": "Toàn bộ {amount} {symbol} từ lockup của bạn hiện đang tạo thu nhập.",
+        "partEarning": "Một phần lockup của bạn ({amount} {symbol}) hiện đang tạo thu nhập.",
+        "stopEarningFirst": "Để dùng các token đã mở khóa, hãy dừng kiếm thu nhập trước rồi rút chúng.",
+        "howGrantWorks": "Cách hoạt động của khoản tài trợ",
+        "ftStep1": "Bạn nhận được một khoản tài trợ trong khoảng thời gian cụ thể. Thay vì nhận toàn bộ cùng lúc, tài sản sẽ được mở khóa từng phần theo thời gian.",
+        "ftStep2": "Khi đến ngày phát hành kế tiếp, phần token đó sẽ tự động được mở khóa và chuyển vào số dư ngân quỹ của bạn.",
+        "ftStep3": "Khi chúng xuất hiện trong số dư, bạn có thể sử dụng ngay cho thanh toán, chuyển khoản hoặc các giao dịch khác.",
+        "nearStep1": "Bạn nhận được một khoản tài trợ trong khoảng thời gian cố định với ngày bắt đầu và kết thúc xác định.",
+        "nearStep2": "Khi token được mở khóa, chúng sẽ tự động khả dụng trong số dư ngân quỹ của bạn.",
+        "nearStep3": "Bạn có thể sử dụng các token đã mở khóa ngay lập tức cho thanh toán, chuyển khoản hoặc các giao dịch khác.",
+        "notAvailable": "N/A",
+        "everyMonth": "Mỗi tháng",
+        "everyQuarter": "Mỗi quý",
+        "everyUnit": "Mỗi {unit}",
+        "everyMultiple": "Mỗi {text}",
+        "completed": "Đã hoàn tất",
+        "unit": {
+            "year": "{count, plural, other {# năm}}",
+            "day": "{count, plural, other {# ngày}}",
+            "hour": "{count, plural, other {# giờ}}",
+            "minute": "{count, plural, other {# phút}}",
+            "second": "{count, plural, other {# giây}}"
+        }
+    },
+    "vestingDetails": {
+        "title": "Chi tiết Vesting",
+        "availableToUse": "Có thể sử dụng",
+        "vestingPeriod": "Thời gian Vesting",
+        "vestingPeriodDescription": "Token được mở khóa hàng ngày trong khoảng thời gian này.",
+        "startDate": "Ngày bắt đầu",
+        "endDate": "Ngày kết thúc",
+        "tokenBreakdown": "Phân tích token",
+        "originalVestedAmount": "Số tiền vesting ban đầu",
+        "reservedForStorage": "Dự trữ cho lưu trữ",
+        "reservedForStorageInfo": "Một lượng nhỏ token cần thiết để giữ vesting hoạt động và chi trả chi phí lưu trữ.",
+        "percentVested": "Đã vesting {percent}%",
+        "vestedOf": "{vested} trên {total} {symbol}",
+        "send": "Gửi"
+    },
+    "earningPoolDetails": {
+        "balance": "Số dư",
+        "apy": "APY",
+        "fee": "Phí",
+        "notAvailable": "N/A",
+        "lockupStakingPool": "Pool staking lockup",
+        "lockupAssetsNote": "Tất cả tài sản trong vị thế này đều từ lockup của bạn. Sau khi bạn dừng kiếm thu nhập, một số token vẫn có thể bị khóa và không khả dụng - hãy kiểm tra lịch lockup để biết khi nào chúng được mở khóa."
+    },
+    "onboardingQuestions": {
+        "stepTitle": "Một vài câu hỏi nhanh để bắt đầu.",
+        "other": "Khác",
+        "placeholders": {
+            "describeRole": "Mô tả vai trò của bạn (tùy chọn)",
+            "describeUseCase": "Mô tả trường hợp sử dụng của bạn (tùy chọn)",
+            "networkName": "Nhập tên mạng (tùy chọn)",
+            "currentChallenge": "Nhập thách thức hiện tại của bạn (tùy chọn)",
+            "describeOther": "Mô tả khác (tùy chọn)"
+        },
+        "questions": {
+            "role": "Vai trò nào mô tả bạn tốt nhất?",
+            "useCases": "Bạn dự định dùng Trezu cho mục đích gì?",
+            "teamSize": "Có bao nhiêu người sẽ quản lý ngân quỹ?",
+            "networks": "Bạn sử dụng mạng nào thường xuyên nhất?",
+            "multisigExperience": "Kinh nghiệm của bạn với multisig là gì?",
+            "currentTools": "Bạn hiện đang dùng công cụ gì để quản lý tài chính?",
+            "monthlyVolume": "Khối lượng giao dịch hàng tháng xấp xỉ?",
+            "biggestChallenges": "Thách thức lớn nhất của bạn hiện tại là gì?"
+        },
+        "options": {
+            "role": {
+                "founder": "Người sáng lập",
+                "co-founder": "Đồng sáng lập",
+                "cfo-finance-lead": "CFO / Trưởng phòng Tài chính",
+                "operations-manager": "Quản lý vận hành",
+                "treasury-manager": "Quản lý ngân quỹ",
+                "other": "Khác"
+            },
+            "useCases": {
+                "team-payroll-grants": "Lương đội & tài trợ",
+                "company-assets-management": "Quản lý tài sản công ty",
+                "dao-treasury-management": "Quản lý ngân quỹ DAO",
+                "investment-portfolio": "Danh mục đầu tư",
+                "operational-spending": "Chi tiêu vận hành",
+                "other": "Khác"
+            },
+            "teamSize": {
+                "just-me": "Chỉ tôi",
+                "2-5-people": "2-5 người",
+                "6-15-people": "6-15 người",
+                "15-plus-people": "15+"
+            },
+            "networks": {
+                "near": "NEAR",
+                "bitcoin": "Bitcoin",
+                "ethereum": "Ethereum",
+                "solana": "Solana",
+                "arbitrum": "Arbitrum",
+                "base": "Base",
+                "optimism": "Optimism",
+                "polygon": "Polygon",
+                "gnosis": "Gnosis",
+                "avalanche": "Avalanche",
+                "bnb-chain": "BNB Chain",
+                "other": "Khác"
+            },
+            "multisigExperience": {
+                "never-heard-of-it": "Chưa từng nghe về nó",
+                "heard-about-it": "Đã nghe về nó",
+                "never-used-it": "Chưa từng sử dụng",
+                "used-gnosis-safe-or-similar": "Đã dùng Gnosis Safe hoặc tương tự",
+                "experienced": "Có kinh nghiệm",
+                "looking-for-a-better-option": "Đang tìm một lựa chọn tốt hơn"
+            },
+            "currentTools": {
+                "gnosis-safe": "Gnosis Safe",
+                "fireblocks": "Fireblocks",
+                "tholos": "Tholos",
+                "squads-multisig": "Squads Multisig",
+                "mpc-vault": "MPC Vault",
+                "other": "Khác"
+            },
+            "monthlyVolume": {
+                "under-10k": "Dưới $10K",
+                "10k-100k": "$10K - $100K",
+                "100k-1m": "$100K - $1M",
+                "1m-plus": "$1M+"
+            },
+            "biggestChallenges": {
+                "slow-approvals-and-signing": "Phê duyệt và ký chậm",
+                "lack-of-transparency-in-the-team": "Thiếu minh bạch trong đội",
+                "hard-to-track-spending-and-balances": "Khó theo dõi chi tiêu và số dư",
+                "security-and-access-control": "Bảo mật và kiểm soát truy cập",
+                "no-good-web3-tool-yet": "Chưa có công cụ Web3 tốt",
+                "looking-for-crypto-earnings": "Tôi đang tìm thu nhập từ crypto",
+                "other": "Khác"
+            }
+        }
+    },
+    "onboarding": {
+        "tour": {
+            "addAssets": "Thêm tài sản vào Ngân quỹ của bạn bằng cách nạp tiền.",
+            "makeRequests": "Tạo yêu cầu thanh toán bất cứ khi nào bạn cần gửi tài sản.",
+            "exchangeAssets": "Tại đây bạn có thể trao đổi tài sản của mình.",
+            "addMembers": "Thêm thành viên vào Ngân quỹ của bạn và gán vai trò cho họ.",
+            "newTreasury": "Muốn thiết lập một Ngân quỹ mới? Bạn có thể làm điều đó tại đây chỉ trong vài cú nhấp chuột.",
+            "helpSupport": "Nhận trợ giúp và hỗ trợ bất cứ khi nào bạn cần."
+        },
+        "tourCard": {
+            "close": "Đóng",
+            "stepProgress": "{current} trên {total}",
+            "gotIt": "Đã hiểu",
+            "done": "Xong",
+            "next": "Tiếp"
+        },
+        "progress": {
+            "title": "Làm theo các bước nhanh để khám phá Ngân quỹ",
+            "createTreasuryTitle": "Tạo tài khoản Ngân quỹ",
+            "createTreasuryDescription": "Bạn đã thiết lập tài khoản thành công. Khởi đầu tuyệt vời!",
+            "addAssetsTitle": "Thêm tài sản của bạn",
+            "addAssetsDescription": "Bắt đầu bằng cách thêm tài sản để xem chúng hoạt động.",
+            "deposit": "Nạp tiền",
+            "createPaymentTitle": "Tạo yêu cầu thanh toán",
+            "createPaymentDescription": "Tạo một yêu cầu thanh toán để hoàn tất thiết lập của bạn.",
+            "send": "Gửi"
+        },
+        "welcome": {
+            "heading": "🎉 Chào mừng!",
+            "subheading": "Tham quan nhanh Ngân quỹ",
+            "body": "Xin chào! Trezu của bạn đã sẵn sàng - hãy bắt đầu xây dựng danh mục bằng cách thêm tài sản từ các mạng được hỗ trợ.",
+            "progress": "{current} trên {total}",
+            "next": "Tiếp",
+            "body2": "Xem cách thực hiện nạp tiền, tạo yêu cầu và thiết lập tài khoản mới.",
+            "noThanks": "Không, cảm ơn",
+            "letsGo": "Bắt đầu thôi"
+        },
+        "congrats": {
+            "heading": "🎉 Chúc mừng!",
+            "body": "Bạn đã hoàn tất thiết lập Ngân quỹ. Tận hưởng việc quản lý tài sản dễ dàng.",
+            "letsGo": "Bắt đầu thôi!"
+        },
+        "createBanner": {
+            "close": "Đóng",
+            "title": "Khám phá Trezu",
+            "description": "Tạo một tài khoản để mở khóa quyền truy cập tất cả các tính năng và lợi ích của Trezu.",
+            "cta": "Tạo Ngân quỹ"
+        },
+        "questionnaire": {
+            "continue": "Tiếp tục",
+            "skip": "Bỏ qua"
+        },
+        "createPrompt": {
+            "title": "Bạn gần xong rồi",
+            "description": "Ví của bạn đã được kết nối, nhưng bạn chưa tạo ngân quỹ. Hãy tạo tài khoản để bắt đầu sử dụng Trezu, hoặc {suffix}",
+            "suffixDemo": "xem demo.",
+            "suffixExploring": "tiếp tục khám phá.",
+            "createCta": "Tạo một Ngân quỹ",
+            "viewDemo": "Xem Demo",
+            "keepExploring": "Tiếp tục khám phá"
+        },
+        "infoBox": {
+            "title": "Tận dụng Trezu nhiều hơn",
+            "close": "Đóng",
+            "description": "Khám phá cách người khác sử dụng Ngân quỹ, thử demo và xem tài liệu để tìm hiểu các tính năng.",
+            "demoTitle": "Khám phá Trezu Demo",
+            "demoDescription": "Xem một tài khoản demo trực tiếp đang hoạt động.",
+            "docsTitle": "Tài liệu",
+            "docsDescription": "Tìm hiểu về tất cả tính năng trong tài liệu.",
+            "videoTitle": "Xem demo",
+            "videoDescription": "Xem video ngắn cho thấy cách Trezu hoạt động."
+        }
+    }
+}

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -1,0 +1,2101 @@
+{
+    "common": {
+        "loading": "加载中...",
+        "notAvailable": "不适用",
+        "connecting": "连接中...",
+        "save": "保存",
+        "cancel": "取消",
+        "submit": "提交",
+        "close": "关闭",
+        "back": "返回",
+        "seeDemo": "查看 Trezu 演示",
+        "search": "搜索",
+        "filter": "筛选",
+        "filterActive": "筛选(已启用)",
+        "export": "导出",
+        "exporting": "导出中",
+        "import": "导入",
+        "remove": "移除",
+        "removing": "移除中...",
+        "edit": "编辑",
+        "continue": "继续",
+        "select": "选择",
+        "all": "全部",
+        "none": "无",
+        "retry": "重试",
+        "tryAgain": "请再试一次。",
+        "confirm": "确认",
+        "next": "下一步",
+        "previous": "上一步",
+        "yes": "是",
+        "no": "否",
+        "approve": "批准",
+        "reject": "拒绝",
+        "copy": "复制",
+        "copied": "已复制",
+        "viewAll": "查看全部",
+        "viewDetails": "查看详情",
+        "noResults": "未找到结果",
+        "add": "添加"
+    },
+    "languageSwitcher": {
+        "label": "语言",
+        "select": "选择语言",
+        "english": "English",
+        "spanish": "Español",
+        "ukrainian": "Українська",
+        "hebrew": "עברית",
+        "german": "Deutsch",
+        "french": "Français",
+        "vietnamese": "Tiếng Việt",
+        "chinese": "中文",
+        "turkish": "Türkçe",
+        "indonesian": "Bahasa Indonesia",
+        "portuguese": "Português",
+        "japanese": "日本語",
+        "korean": "한국어"
+    },
+    "header": {
+        "toggleSidebar": "切换侧边栏",
+        "toggleTheme": "切换主题"
+    },
+    "nav": {
+        "dashboard": "仪表板",
+        "requests": "请求",
+        "payments": "付款",
+        "exchange": "兑换",
+        "addressBook": "地址簿",
+        "members": "成员",
+        "settings": "设置",
+        "helpSupport": "帮助与支持",
+        "saveGuestTreasury": "将此访客金库保存到您的金库列表。"
+    },
+    "signIn": {
+        "connect": "连接",
+        "connectWallet": "连接钱包",
+        "wallet": "钱包",
+        "termsOfService": "服务条款",
+        "privacyPolicy": "隐私政策",
+        "disconnect": "断开连接"
+    },
+    "auth": {
+        "noWallet": "请连接您的钱包",
+        "noPermission": "您没有执行此操作的权限",
+        "noVote": "您已对此提案投过票",
+        "noSponsoredTransactions": "已用尽赞助交易额度"
+    },
+    "landing": {
+        "welcome": "欢迎使用 Trezu",
+        "chooseOption": "请选择下方选项以开始使用。",
+        "newUserTitle": "我是 Trezu 新用户",
+        "newUserDescription": "我听说过 Trezu,但还没有金库。",
+        "existingUserTitle": "我已在使用 Trezu",
+        "existingUserDescription": "我已有账户并在管理金库。",
+        "gradientTagline": "用于管理数字资产的跨链多签安全方案",
+        "waitlistTitle": "加入 Trezu 等待名单",
+        "waitlistSubmittedTitle": "您已加入名单 🎉",
+        "waitlistSubmittedDescription": "感谢!一旦可以创建金库,我们会立即通知您。",
+        "waitlistDescription": "我们今天的金库创建额度已用尽。别担心 — 稍后再试,或留下联系方式加入等待名单。有名额时我们会通知您。",
+        "waitlistInputPlaceholder": "电子邮箱或 Telegram(例如 @username)",
+        "waitlistPrivacyNote": "我们仅会用此信息来通知您",
+        "waitlistSubmit": "加入等待名单",
+        "waitlistSubmitFailed": "提交失败。请再试一次。",
+        "welcomeAlt": "欢迎"
+    },
+    "blocked": {
+        "title": "服务在您所在的国家/地区不可用",
+        "description": "由于相关限制,此服务目前在您所在地区不可用。"
+    },
+    "notFound": {
+        "title": "哎呀,此页面已不存在...",
+        "description": "您访问的链接已失效。请返回上一页或回到仪表板。",
+        "backToDashboard": "返回仪表板"
+    },
+    "treasuryInfo": {
+        "logoAlt": "金库标志"
+    },
+    "dateInput": {
+        "placeholder": "yyyy/mm/dd"
+    },
+    "thresholdSlider": {
+        "warningSingleMember": "1/{memberCount} 的阈值意味着任意单个成员均可执行交易。这会降低安全性。",
+        "infoBalanced": "{currentThreshold}/{memberCount} 的阈值在安全性与运营灵活性之间取得了良好平衡。"
+    },
+    "intentsFee": {
+        "amountTooLowForFee": "{prefix}金额过低,无法支付网络手续费({fee} {symbol})。请至少再增加 {addMore} {symbol}。"
+    },
+    "metadata": {
+        "treasuryTitle": "仪表板 | Trezu",
+        "landingTitle": "Trezu | 跨链金库管理",
+        "description": "通过单一仪表板,几分钟内即可管理团队资金,而无需交出您的密钥。",
+        "ogTitle": "Trezu | 一个多签。任意加密货币。完全掌控。"
+    },
+    "pages": {
+        "dashboard": {
+            "title": "仪表板",
+            "description": "金库资产与活动概览",
+            "descriptionLong": "管理金库资产并跟踪活动"
+        },
+        "activity": {
+            "title": "近期交易",
+            "descriptionDetails": "请求详情",
+            "descriptionList": "所有资产的近期交易"
+        },
+        "requests": {
+            "title": "请求",
+            "description": "查看并管理所有待处理的多签请求",
+            "detailDescription": "请求详情",
+            "detailTitle": "请求 #{id}"
+        },
+        "members": {
+            "title": "成员",
+            "description": "管理团队成员与权限"
+        },
+        "settings": {
+            "title": "设置",
+            "description": "调整应用设置"
+        },
+        "addressBook": {
+            "title": "地址簿",
+            "description": "管理已保存的收款人"
+        },
+        "payments": {
+            "title": "付款",
+            "description": "安全地发送与接收资金"
+        },
+        "exchange": {
+            "title": "兑换",
+            "description": "安全高效地兑换您的代币"
+        },
+        "vesting": {
+            "title": "归属",
+            "description": "快速轻松地创建归属计划"
+        },
+        "earn": {
+            "title": "收益",
+            "description": "通过您的资产赚取奖励",
+            "placeholder": "探索收益机会与质押奖励。"
+        },
+        "createTreasury": {
+            "title": "创建金库",
+            "description": "为您的团队创建新的多签金库"
+        },
+        "manageTreasuries": {
+            "title": "管理金库",
+            "description": "控制账户中显示的金库"
+        },
+        "stats": {
+            "title": "统计",
+            "description": "所有 sputnik DAO 金库的实时管理资产数据。"
+        },
+        "telegram": {
+            "title": "连接金库",
+            "description": "将您的金库链接到 Telegram 聊天",
+            "metaTitle": "Trezu — 连接 Telegram",
+            "metaDescription": "将您的 Trezu 金库连接到 Telegram 聊天"
+        },
+        "wallet": {
+            "title": "Trezu 钱包",
+            "description": "通过 Trezu 签署金库提案"
+        }
+    },
+    "depositModal": {
+        "validation": {
+            "selectAsset": "请选择一项资产",
+            "selectNetwork": "请选择一个网络"
+        },
+        "sections": {
+            "supportedNetworks": "支持的网络",
+            "networksWithAssets": "包含资产的网络",
+            "yourAssets": "您的资产",
+            "otherAssets": "其他资产"
+        },
+        "errors": {
+            "addressUnavailable": "无法获取所选资产和网络的存款地址。",
+            "fetchFailed": "获取存款地址失败。请再试一次。"
+        },
+        "title": "存款",
+        "subtitle": "选择资产和网络以查看存款地址",
+        "assetLabel": "资产",
+        "networkLabel": "网络",
+        "selectAsset": "选择资产",
+        "selectNetwork": "选择网络",
+        "otherAssetName": "其他",
+        "otherNetworkInfo": "您可以存入资产列表中未列出的任何代币,但仅限通过 NEAR 网络。",
+        "depositAddressHeading": "存款地址",
+        "depositAddressSubtitle": "请始终仔细核对您的存款地址。",
+        "addressLabel": "地址",
+        "addressCopied": "地址已复制到剪贴板",
+        "memoLabel": "Memo",
+        "memoCopied": "Memo 已复制到剪贴板",
+        "memoWarning": "向此地址转账时,您<bold>必须</bold>包含 Memo。未包含 Memo 的转账可能导致资金永久丢失。",
+        "onlyDeposit": "仅可从 <networkTag>{network}</networkTag> 网络存入 <symbolTag>{symbol}</symbolTag>。建议先进行小额测试交易,确认一切正常后再发送全部金额。",
+        "minimumDeposit": "最低存款金额为 <amountTag>{amount} {symbol}</amountTag>",
+        "searchByName": "按名称搜索"
+    },
+    "assetDetails": {
+        "coinPrice": "币价",
+        "weight": "权重",
+        "source": "来源",
+        "send": "发送",
+        "exchange": "兑换",
+        "comingSoon": "即将推出",
+        "vesting": "归属",
+        "vestedPercent": "已归属 {percent}%",
+        "frozen": "已冻结",
+        "frozenTooltip": "已冻结的代币已锁定,无法使用。它们可能因用于存储、质押或尚未归属而被锁定。",
+        "vested": "已归属"
+    },
+    "dashboard": {
+        "overview": "金库资产与活动概览",
+        "assets": "资产",
+        "balance": "余额",
+        "totalBalance": "总余额",
+        "deposit": "存款",
+        "addAssets": "添加资产",
+        "hidden": "已隐藏",
+        "confidentialHidden": "机密金库的余额已隐藏",
+        "recentActivity": "近期活动",
+        "viewAllTransactions": "查看所有交易"
+    },
+    "activity": {
+        "filters": {
+            "createdDate": "创建日期",
+            "token": "代币",
+            "from": "发送方",
+            "to": "接收方"
+        },
+        "tabs": {
+            "all": "全部",
+            "sent": "已发送",
+            "received": "已接收",
+            "stakingRewards": "质押奖励",
+            "exchange": "兑换"
+        },
+        "searchPlaceholder": "按交易哈希搜索",
+        "searchPlaceholderShort": "交易哈希",
+        "fromPool": "来自 {pool}",
+        "table": {
+            "type": "类型",
+            "transaction": "交易",
+            "from": "发送方",
+            "to": "接收方",
+            "transactionHash": "交易哈希",
+            "hashTooltip": "此交易的唯一标识符(哈希)"
+        },
+        "empty": {
+            "title": "未找到交易",
+            "description": "您的交易在发生后将显示在此处"
+        },
+        "emptyDashboard": {
+            "title": "暂无内容",
+            "description": "您的交易和操作在发生后将显示在此处"
+        },
+        "recentTitle": "近期交易",
+        "details": {
+            "title": "交易详情",
+            "copyAddress": "复制地址",
+            "addressCopied": "地址已复制到剪贴板",
+            "sell": "卖出",
+            "receive": "接收",
+            "pending": "待处理",
+            "type": "类型",
+            "date": "日期",
+            "from": "发送方",
+            "to": "接收方",
+            "method": "方法",
+            "contract": "合约",
+            "transaction": "交易"
+        }
+    },
+    "export": {
+        "types": {
+            "csv": ".CSV",
+            "json": ".JSON",
+            "xlsx": ".XLSX"
+        },
+        "transactionTypes": {
+            "all": "所有类型",
+            "sent": "已发送",
+            "received": "已接收",
+            "stakingRewards": "质押奖励"
+        },
+        "validation": {
+            "invalidEmail": "请输入有效的电子邮箱地址"
+        },
+        "columns": {
+            "submissionTime": "提交时间",
+            "dateRange": "日期范围",
+            "generatedBy": "生成者",
+            "status": "状态"
+        },
+        "status": {
+            "generating": "生成中",
+            "expired": "已过期",
+            "failed": "失败"
+        },
+        "noPermission": "您没有下载此文件的权限。",
+        "download": "下载",
+        "heading": "导出近期交易",
+        "teamOnly": "导出生成与下载仅对团队成员开放。",
+        "creditsUsed": "您的额度已用完",
+        "exportsUsed": "您的导出次数已用完",
+        "upgradePrompt": "升级套餐以获得更多额度并继续使用",
+        "resetPrompt": "升级套餐以获得更多权限,或等待下个月限额重置。",
+        "tabs": {
+            "generate": "生成导出",
+            "history": "历史记录"
+        },
+        "fields": {
+            "documentType": "文档类型",
+            "timeRange": "时间范围",
+            "selectDateRange": "选择日期范围",
+            "asset": "资产",
+            "allAssets": "所有资产",
+            "transactionType": "交易类型"
+        },
+        "buttons": {
+            "noPermissionExport": "您没有导出权限",
+            "quotaExhausted": "您的配额已用完",
+            "exporting": "导出中...",
+            "export": "导出"
+        },
+        "empty": {
+            "title": "暂无导出记录",
+            "description": "上个月的导出文件生成后将显示在此处。"
+        },
+        "requirements": {
+            "heading": "导出要求",
+            "canExportFrom": "您可以从以下时间段导出数据:",
+            "availability": "导出文件可在 48 小时内下载。"
+        },
+        "quota": {
+            "heading": "导出配额",
+            "unlimited": "无限制",
+            "perMonth": "{count} / 月",
+            "flexibilityPrompt": "需要更大的灵活性?",
+            "contactUs": "联系我们"
+        }
+    },
+    "requests": {
+        "filters": {
+            "proposalTypes": {
+                "Payments": "付款",
+                "Exchange": "兑换",
+                "Earn": "收益",
+                "Vesting": "归属",
+                "Function Call": "函数调用",
+                "Change Policy": "修改策略",
+                "Settings": "设置",
+                "Confidential": "机密"
+            },
+            "voteStatus": {
+                "Approved": "已批准",
+                "Rejected": "已拒绝",
+                "No Voted": "未投票"
+            },
+            "requestsType": "请求类型",
+            "createdDate": "创建日期",
+            "recipient": "收款人",
+            "token": "代币",
+            "requester": "请求者",
+            "approver": "批准者",
+            "myVoteStatus": "我的投票状态",
+            "all": "全部",
+            "amount": "金额",
+            "from": "从",
+            "to": "至",
+            "min": "最小",
+            "max": "最大",
+            "invalidDate": "无效日期",
+            "operationIsNot": " 不是",
+            "operationBefore": " 早于",
+            "operationAfter": " 晚于",
+            "operationContains": " 包含",
+            "searchByAddress": "按地址搜索",
+            "loadingMembers": "正在加载成员...",
+            "noMembersFound": "未找到成员。按 Enter 添加“{query}”",
+            "noMembersAvailable": "无可用成员",
+            "reset": "重置",
+            "clear": "清除",
+            "addFilter": "添加筛选"
+        },
+        "tabs": {
+            "all": "全部",
+            "pending": "待处理",
+            "executed": "已执行",
+            "rejected": "已拒绝",
+            "expired": "已过期",
+            "failed": "失败"
+        },
+        "searchPlaceholder": "按名称或 ID 搜索请求",
+        "searchPlaceholderShort": "按名称或 ID 搜索",
+        "errorLoading": "加载提案出错。请再试一次。",
+        "empty": {
+            "title": "创建您的第一个请求",
+            "description": "付款、兑换及其他操作的请求在创建后将显示在此处。",
+            "send": "发送",
+            "exchange": "兑换"
+        },
+        "actions": {
+            "approve": "批准",
+            "reject": "拒绝",
+            "deposit": "存款",
+            "viewRequest": "查看请求"
+        },
+        "table": {
+            "selectAll": "全选",
+            "selectRow": "选择行",
+            "request": "请求",
+            "transaction": "交易",
+            "requester": "请求者",
+            "voting": "投票",
+            "votingTooltip": "第一个数字显示已收到的批准数。第二个数字显示执行所需的批准数。",
+            "status": "状态",
+            "notPending": "提案不处于待处理状态。",
+            "noPermissionVote": "您没有对此请求投票的权限。",
+            "alreadyVoted": "您已对此请求投过票。",
+            "noResults": "未找到符合筛选条件的请求。",
+            "allCaughtUp": "全部处理完毕!",
+            "noPending": "没有待处理的请求。",
+            "send": "发送",
+            "exchange": "兑换",
+            "requestsSelected": "{count, plural, other {已选 # 个请求}}",
+            "bulkApproveDisabled": "由于金库余额不足,此请求无法被批准。"
+        },
+        "pending": {
+            "title": "待处理请求",
+            "viewAll": "查看全部",
+            "emptyTitle": "全部处理完毕!",
+            "emptyDescription": "没有待处理的请求。"
+        }
+    },
+    "proposals": {
+        "status": {
+            "pending": "待处理",
+            "approved": "已批准",
+            "rejected": "已拒绝",
+            "executed": "已执行",
+            "expired": "已过期",
+            "failed": "失败",
+            "removed": "已移除",
+            "inProgress": "进行中"
+        },
+        "statusTooltip": {
+            "pending": "此请求仍待处理,尚未达到执行所需的投票数。",
+            "executed": "在 {required} 名成员中有 {approved} 人批准后已执行。",
+            "rejected": "在 {required} 名成员中有 {rejected} 人投票拒绝后已被拒绝。",
+            "expired": "由于未获得足够的投票而过期。",
+            "failed": "请求未能完成。请在<link>此处</link>查看交易详情。",
+            "failedPlain": "请求未能完成。请在此处查看交易详情。"
+        },
+        "votes": {
+            "approved": "已批准",
+            "rejected": "已拒绝",
+            "pending": "待处理"
+        },
+        "voteModal": {
+            "confirmTitle": "确认您的投票",
+            "removeTitle": "移除请求",
+            "bulkBody": "您即将{action}多个请求。提交后,此决定无法更改。",
+            "singleBody": "您即将{action}此请求。确认后,此操作无法撤销。",
+            "actionApprove": "批准",
+            "actionReject": "拒绝",
+            "actionRemove": "移除",
+            "insufficientBalance": "由于余额不足,请求 <highlight>{ids}</highlight> 无法被批准。您的批准将仅适用于其余请求。",
+            "remove": "移除",
+            "confirm": "确认"
+        },
+        "expanded": {
+            "recipient": "收款人",
+            "amount": "金额",
+            "networkFee": "网络手续费",
+            "notes": "备注",
+            "sent": "已发送",
+            "received": "已接收",
+            "priceDifference": "价差",
+            "priceDifferenceTooltip": "报价汇率与当前市场汇率之间的差额。正值表示汇率优于市场价。",
+            "slippageTolerance": "滑点容忍度",
+            "estimatedTime": "预计时间",
+            "seconds": "{count} 秒",
+            "description": "描述",
+            "methodName": "方法名称",
+            "args": "参数",
+            "deposit": "存款",
+            "gas": "Gas",
+            "totalDeposit": "总存款",
+            "totalGas": "总 Gas",
+            "receiverId": "接收方 ID",
+            "contractId": "合约 ID",
+            "actionsCount": "{count, plural, other {# 个操作}}",
+            "functionCallsCount": "{count, plural, other {# 个函数调用}}",
+            "showLess": "收起",
+            "showMore": "展开",
+            "stakingPool": "质押池",
+            "validator": "验证人",
+            "action": "操作",
+            "stake": "质押",
+            "unstake": "取消质押",
+            "withdraw": "提取",
+            "lockupOwner": "锁仓所有者",
+            "lockupDuration": "锁仓时长",
+            "cliff": "Cliff",
+            "releaseDuration": "释放时长",
+            "vestingSchedule": "归属计划",
+            "cancellable": "可取消",
+            "allowEarn": "允许质押",
+            "yes": "是",
+            "no": "否",
+            "notSet": "未设置",
+            "from": "从",
+            "to": "至",
+            "paymentsCount": "{count, plural, other {# 笔付款}}",
+            "sourceWallet": "来源钱包",
+            "allNear": "全部 NEAR",
+            "startDate": "开始日期",
+            "endDate": "结束日期",
+            "cliffDate": "Cliff 日期",
+            "allowCancellation": "允许取消",
+            "allowStaking": "允许质押",
+            "loadingHistorical": "正在加载历史配置...",
+            "name": "名称",
+            "purpose": "目的",
+            "logo": "标志",
+            "logoAlt": "标志",
+            "primaryColor": "主色",
+            "noChangesCurrent": "与当前状态相比,配置中未检测到任何更改。",
+            "noChangesHistorical": "与历史状态相比,配置中未检测到任何更改。",
+            "method": "方法",
+            "arguments": "参数",
+            "contract": "合约",
+            "actionNumber": "操作 {number}",
+            "actions": "操作",
+            "collapseAll": "全部折叠",
+            "expandAll": "全部展开",
+            "send": "发送",
+            "receive": "接收",
+            "rate": "汇率",
+            "priceSlippageLimit": "价格滑点上限",
+            "slippageTooltip": "这是为此请求设定的滑点上限。如果在执行期间市场汇率变动超过此阈值,请求将自动失败。",
+            "estimatedTimeTooltip": "存款交易确认后,完成兑换所需的预计时间。",
+            "minReceive": "最低接收",
+            "minimumReceived": "最低接收量",
+            "minReceiveTooltip": "这是您将通过此次兑换至少收到的金额,基于为请求设定的滑点上限。",
+            "depositAddress": "存款地址",
+            "depositAddressTooltip": "代币将被发送至此 1Click 存款地址以执行跨链兑换。",
+            "quoteSignature": "报价签名",
+            "quoteSignatureTooltip": "来自 1Click API 的加密签名,用于验证此报价的有效性。",
+            "quoteDeadline": "1-Click 报价截止时间",
+            "quoteDeadlineTooltip": "存款地址失效的时间,届时资金可能丢失。",
+            "status": "状态",
+            "transactionLink": "交易链接",
+            "viewTransaction": "查看交易",
+            "recipientNumber": "收款人 {number}",
+            "oopsTitle": "哎呀!出现了问题",
+            "oopsDescription": "我们找不到可显示的数据。",
+            "totalAmount": "总金额",
+            "recipients": "收款人",
+            "recipientsCount": "{count, plural, other {# 个收款人}}",
+            "unsupportedProposal": "不支持的提案类型",
+            "requestDetails": "请求详情",
+            "linkCopied": "链接已复制到剪贴板",
+            "copyLink": "复制链接",
+            "openRequestPage": "打开请求页面",
+            "deleteRequest": "删除请求",
+            "unknownRecipients": "未知收款人",
+            "loadingConfig": "正在加载配置...",
+            "historicalData": "历史数据...",
+            "generalUpdate": "常规更新",
+            "detailsUnavailable": "详情不可用",
+            "changesCount": "{count, plural, other {# 项更改}}",
+            "policyUpdate": "策略更新",
+            "noChangesDetected": "未检测到任何更改",
+            "loadingPolicy": "正在加载策略...",
+            "roleChanges": "角色更改",
+            "policyParameters": "策略参数",
+            "defaultVotePolicy": "默认投票策略",
+            "policyRoleChanges": "策略与角色更改",
+            "membersAdded": "{count, plural, other {新增 # 名成员}}",
+            "membersRemoved": "{count, plural, other {移除 # 名成员}}",
+            "membersUpdated": "{count, plural, other {更新 # 名成员}}",
+            "rolesModified": "{count, plural, other {修改 # 个角色}}",
+            "parametersChanged": "{count, plural, other {更改 # 个参数}}",
+            "defaultVotePolicyPart": "默认投票策略",
+            "onReceiver": "在 {receiver} 上",
+            "toPrefix": "至:",
+            "validatorPrefix": "验证人:",
+            "validatorSubtitle": "验证人:{address}",
+            "impactTitle": "更改投票时长的影响",
+            "impactBody": "您即将更新投票时长。这将影响以下现有请求。",
+            "activeRequestsBullet": "{count, plural, other {更改后,# 个请求将继续可投票,过期日期会被更新。}}",
+            "expiringRequestsBullet": "{count, plural, other {在新的投票时长下,# 个请求将被标记为“已过期”。}}",
+            "remainActiveHeading": "继续可投票且过期日期已更新的请求",
+            "willExpireHeading": "将被标记为“过期”的请求",
+            "tableRequest": "请求",
+            "tableTransaction": "交易",
+            "tableNewExpiry": "新过期时间",
+            "expireInDays": "{count, plural, other {# 天后过期}}",
+            "today": "今天",
+            "uponApproval": "获批后",
+            "yesContinue": "是,继续",
+            "transactionCreated": "交易已创建",
+            "voting": "投票",
+            "approvalsReceived": "已收到 {received}/{required} 个批准",
+            "expiresAt": "过期时间",
+            "expiredAt": "已过期于",
+            "exchangingTokens": "正在兑换代币",
+            "exchangingTokensBody": "此请求已获团队批准。代币兑换正在进行中,可能需要一些时间。",
+            "requestFailed": "请求失败",
+            "requestFailedBody": "团队已批准此请求,但因汇率波动而失败。请创建新请求并再次尝试。",
+            "votingPeriod24h": "投票期:24 小时",
+            "votingPeriod24hBody": "此兑换请求的投票时长为 24 小时。请在此时间内批准请求,否则该请求将过期。",
+            "reject": "拒绝",
+            "approve": "批准"
+        },
+        "insufficientBalance": {
+            "noAsset": "由于金库中没有所需代币,此请求无法被批准。",
+            "bond": "由于金库的 <token>{symbol}</token> 余额不足,此请求无法被批准。请添加 <token>{amount} {symbol}</token> 以支付提案保证金。",
+            "continue": "由于金库的 <token>{symbol}</token> 余额不足,此请求无法被批准。请添加 <token>{amount} {symbol}</token> 以继续。",
+            "modalTitle": "NEAR 余额不足",
+            "modalBodyVote": "您钱包中的 NEAR 代币不足以投票。投票需要至少 <amount>{required} NEAR</amount> 的余额。请向钱包中添加 NEAR 后再试。",
+            "modalBodyProposal": "您钱包中的 NEAR 代币不足以创建此请求。创建请求需要至少 <amount>{required} NEAR</amount> 的余额。请向钱包中添加 NEAR 后再试。",
+            "gotIt": "知道了"
+        }
+    },
+    "members": {
+        "title": "成员",
+        "description": "管理团队成员与权限",
+        "permissions": "权限",
+        "member": "成员",
+        "activeMembers": "活跃成员",
+        "noActiveMembers": "未找到活跃成员。",
+        "addNewMember": "添加新成员",
+        "membersSelected": "已选择 {count, plural, =0 {无成员} other {# 名成员}}",
+        "remove": "移除",
+        "edit": "编辑",
+        "requestorOnlyTooltip": "您只能为此成员添加 Requestor 角色,因为他们负责从 NEARN 创建付款请求。",
+        "memberModal": {
+            "editRoles": "编辑角色",
+            "addNewMember": "添加新成员",
+            "validatingAddresses": "正在验证地址...",
+            "creatingProposal": "正在创建提案...",
+            "reviewRequest": "审核请求",
+            "noChanges": "未对成员角色进行任何更改"
+        },
+        "previewModal": {
+            "title": "审核您的请求",
+            "youAreEditing": "您正在编辑",
+            "youAreAdding": "您正在添加",
+            "membersCount": "{count, plural, other {# 名成员}}",
+            "newMembersCount": "{count, plural, other {# 名新成员}}",
+            "updatedMembers": "已更新成员",
+            "newMembers": "新成员",
+            "creatingProposal": "正在创建提案...",
+            "confirmSubmit": "确认并提交请求"
+        },
+        "removeDialog": {
+            "title": "移除请求",
+            "nearnBody": "一旦获批,{account} 将从金库中被永久移除,所有相关权限也将被撤销。移除后,此账户将无法再从 NEARN 创建请求。",
+            "genericBody": "一旦获批,此操作将从金库中永久移除 <bold>{accounts}</bold>,并撤销所有已分配的权限。",
+            "creatingProposal": "正在创建提案..."
+        },
+        "validation": {
+            "accountIdRequired": "账户 ID 为必填项",
+            "invalidNearAddress": "无效的 NEAR 地址。",
+            "atLeastOneRole": "必须至少选择一个角色",
+            "atLeastOneMember": "至少需要一名成员",
+            "alreadyAdded": "该成员已在上方添加",
+            "alreadyInTreasury": "该成员已存在于金库中",
+            "cannotRemoveRoleAfter": "您不能从此成员中移除 {role} 角色。在所有更改之后,他们将是唯一被分配此角色的人。",
+            "cannotRemoveRoleAfterGov": "您不能从此成员中移除 {role} 角色。在所有更改之后,他们将是唯一的 {role} 成员,缺少此角色将无法管理团队成员或配置投票。"
+        },
+        "policy": {
+            "addMembers": "更新策略 - 添加新成员",
+            "addMembersSuccess": "新成员请求已成功创建",
+            "editMember": "更新策略 - 编辑成员权限",
+            "editMembers": "更新策略 - 编辑多个成员",
+            "editMemberSuccess": "成员角色更新请求已成功创建",
+            "editMembersSuccess": "批量成员角色更新请求已成功创建",
+            "removeMember": "更新策略 - 移除成员",
+            "removeMembers": "更新策略 - 移除成员",
+            "removeMemberSuccess": "成员移除请求已成功创建"
+        }
+    },
+    "settings": {
+        "tabs": {
+            "general": "常规",
+            "voting": "投票",
+            "preferences": "偏好设置",
+            "integrations": "集成"
+        },
+        "general": {
+            "validation": {
+                "displayNameRequired": "显示名称为必填项",
+                "displayNameMax": "显示名称必须少于 100 个字符"
+            },
+            "proposalDescriptionTitle": "更新配置 - 主题与标志",
+            "proposalSubmitted": "更新配置的请求已提交",
+            "treasuryNotFound": "未找到金库",
+            "treasuryName": "金库名称",
+            "treasuryNameDescription": "您金库的名称。该名称将在应用中显示。",
+            "displayName": "显示名称",
+            "displayNamePlaceholder": "输入显示名称",
+            "accountName": "账户名称",
+            "logo": "标志",
+            "logoDescription": "为您的金库上传标志。建议使用 SVG、PNG 或 JPG 格式(256x256 像素)。",
+            "treasuryLogoAlt": "金库标志",
+            "uploading": "上传中...",
+            "uploadLogo": "上传标志",
+            "removeLogo": "移除标志",
+            "logoUploaded": "标志上传成功",
+            "uploadError": "上传图片时出错,请再试一次。",
+            "invalidLogo": "无效的标志。请上传恰好为 256x256 像素的 PNG、JPG 或 SVG 文件",
+            "invalidImage": "无效的图片文件。请上传有效的图片。",
+            "fileReadError": "读取文件时出错。请再试一次。",
+            "primaryColor": "主色",
+            "primaryColorDescription": "为金库界面元素设置主色。该颜色将在浅色和深色模式中均会使用,因此选择中性色调时请注意对比度。",
+            "selectColorLabel": "选择颜色 {color}"
+        },
+        "voting": {
+            "validation": {
+                "required": "投票时长为必填项",
+                "validNumber": "投票时长必须是有效的数字",
+                "min": "投票时长至少为 1 天",
+                "max": "投票时长必须少于 1000 天",
+                "whole": "投票时长必须为整天数"
+            },
+            "missingData": "缺少必要数据",
+            "thresholdProposalTitle": "更新策略 - 投票阈值",
+            "thresholdProposalSummary": "{account} 请求将投票阈值从 {oldValue} 更改为 {newValue}。",
+            "thresholdSubmitted": "更新投票阈值的请求已提交",
+            "createProposalFailed": "创建提案失败",
+            "durationProposalTitle": "更新策略 - 投票时长",
+            "durationProposalSummary": "{account} 请求将投票时长从 {oldValue} 更改为 {newValue}。",
+            "durationSubmitted": "请求已成功创建",
+            "pendingTitle": "活动中的投票阈值请求",
+            "pendingBody": "为避免冲突,您需要先完成或解决现有的待处理请求,然后再继续。这些请求当前处于活动状态,必须先批准或拒绝。",
+            "viewRequest": "查看请求",
+            "thresholdHeading": "投票阈值",
+            "thresholdDescriptionApprovers": "定义批准付款及团队相关请求所需的投票数。可分别为批准者和治理角色配置阈值。",
+            "thresholdDescriptionGeneric": "定义批准请求所需的投票数。根据各角色的职责分别配置阈值。",
+            "membersWhoCanVote": "可投票的成员",
+            "votesRequired": "批准请求所需的投票数",
+            "durationHeading": "投票时长",
+            "durationDescription": "提案保持开放投票的时长(以天为单位)。如果未在该时段内完成投票,该决定将过期。",
+            "durationApprovers": " 此时长同样适用于治理与批准者角色。",
+            "durationGeneric": " 此时长在所有金库角色中保持一致。",
+            "days": "天"
+        },
+        "preferences": {
+            "timeZone": "时区",
+            "timeZoneDescription": "设置您所在的时区,以便准确显示日期和时间。",
+            "timeFormat": "时间格式",
+            "hour12": "12 小时制(下午 1:00)",
+            "hour24": "24 小时制(13:00)",
+            "autoTimezone": "根据您的位置自动设置时区",
+            "timezone": "时区",
+            "loadingTimezones": "正在加载时区...",
+            "selectTimezone": "选择时区",
+            "searchTimezones": "搜索时区...",
+            "noTimezones": "未找到时区",
+            "save": "保存",
+            "savedToast": "偏好设置保存成功",
+            "saveFailed": "保存偏好设置失败",
+            "loadFailed": "加载时区失败"
+        }
+    },
+    "addressBook": {
+        "emptyTitle": "添加您的第一个收款人",
+        "emptyDescription": "保存常用地址,实现更快、零错误的付款。您的联系人保持私密,仅对您的团队可见。",
+        "import": "导入",
+        "addRecipient": "添加收款人",
+        "recipientsHeading": "收款人",
+        "recipientsSelected": "已选择 {count, plural, =0 {无收款人} other {# 个收款人}}",
+        "sectionHeading": "收款人",
+        "privacyNote": "已保存的地址保持私密,仅对您的团队可见。",
+        "searchPlaceholder": "按名称搜索收款人",
+        "searchPlaceholderShort": "搜索",
+        "review": {
+            "header": "审核详情",
+            "youAreAdding": "您正在添加",
+            "newRecipients": "{count, plural, other {# 个新收款人}}",
+            "onNetworks": "在 {count, plural, other {# 个网络}}上",
+            "recipients": "收款人",
+            "allDuplicates": "所有导入的收款人在您的地址簿中已存在。请返回上传其他列表,或在此审核中移除重复项。",
+            "someDuplicates": "{total} 个收款人中有 {duplicates} 个重复。继续将仅上传新的收款人。",
+            "duplicated": "已重复",
+            "notePlaceholder": "添加备注以便识别此收款人(例如承包商付款、归属分发)。",
+            "skipDuplicates": "跳过重复项,仅导入新收款人。",
+            "allDuplicatesTooltip": "所有导入的收款人均已在您的地址簿中,因此没有新的可导入项。",
+            "duplicateActionTooltip": "启用跳过重复项或移除重复收款人后即可继续。",
+            "adding": "正在添加…",
+            "nothingNew": "没有可导入的新内容",
+            "addRecipientsButton": "{count, plural, other {添加收款人}}"
+        },
+        "removeDialog": {
+            "title": "移除收款人",
+            "bulk": "这将从您的地址簿中移除 <bold>{count, plural, other {# 个收款人}}</bold>。您可以随时再次添加。",
+            "single": "这将从您的地址簿中移除 <bold>{name}</bold>。您可以随时再次添加此收款人。"
+        },
+        "importFlow": {
+            "title": "导入收款人",
+            "description": "将一份收款人地址列表上传到您的地址簿。",
+            "foundSummary": "在 {networkCount, plural, other {# 个网络}}上找到 {count, plural, other {# 个收款人}}",
+            "uploadPrompt": "上传或粘贴收款人数据",
+            "fixErrors": "修复错误以继续",
+            "continueReview": "继续审核"
+        },
+        "form": {
+            "editRecipient": "编辑收款人",
+            "addRecipient": "添加收款人",
+            "import": "导入",
+            "recipientName": "收款人姓名",
+            "namePlaceholder": "Alice",
+            "recipientAddress": "收款人地址",
+            "network": "网络",
+            "networkInfo": "与此地址兼容的网络",
+            "enterAddressFirst": "请先输入收款人地址",
+            "selectNetwork": "选择网络",
+            "selectNetworksTitle": "选择网络",
+            "searchNetworksPlaceholder": "搜索网络…",
+            "done": "完成",
+            "edit": "编辑",
+            "remove": "移除",
+            "incomplete": "未完成",
+            "addAnother": "添加另一位收款人",
+            "fillAllTooltip": "您必须填写所有字段才能添加收款人。",
+            "reviewDetails": "审核详情",
+            "reviewTooltip": "审核前所有收款人信息必须填写完整。",
+            "invalidAddress": "无效地址",
+            "noCompatibleNetworks": "没有与此地址兼容的网络"
+        },
+        "parsing": {
+            "rowPrefix": "第 {row} 行:{message}",
+            "missingName": "缺少收款人姓名。请添加姓名。",
+            "missingAddress": "缺少收款人地址。请添加钱包地址。",
+            "invalidAddressFormat": "地址 “{address}” 不符合任何受支持网络的有效格式。",
+            "unknownNetwork": "未知网络 “{network}”。受支持的网络包括:{available}。",
+            "incompatibleNetwork": "地址 “{address}” 与 {network} 不兼容。兼容的网络:{compatible}。",
+            "noDataFound": "未找到数据。请按以下格式添加收款人:Name, Address, Network, Note",
+            "headerColumnsNotFound": "我们检测到表头行,但未能找到 'Name' 和 'Address' 列。请使用这些列名,或删除表头行。",
+            "failedToParseCsv": "解析 CSV 数据失败"
+        }
+    },
+    "payments": {
+        "validation": {
+            "recipientMin": "收款人至少需 2 个字符",
+            "recipientMax": "收款人必须少于 128 个字符",
+            "amountPositive": "金额必须大于 0",
+            "recipientTokenSame": "收款人地址不能与代币地址相同"
+        },
+        "newPayment": "新建付款",
+        "reviewYourPayment": "审核您的付款",
+        "reviewButton": "审核付款",
+        "reviewButtonDisabled": "请输入金额和地址",
+        "comingSoon": "即将推出",
+        "bulkPayments": "批量付款",
+        "summaryRecipients": "至 {count, plural, other {# 个收款人}}",
+        "networkFee": "网络手续费",
+        "networkFeeInfo": "网络手续费信息",
+        "commentPlaceholder": "添加备注(可选)...",
+        "preparingRoute": "正在准备 1Click 转账路径...",
+        "confirmSubmit": "确认并提交请求",
+        "useDifferentAddress": "使用其他地址",
+        "failed1ClickQuote": "创建 1Click 转账报价失败",
+        "paymentSubmitted": "发送付款的请求已提交"
+    },
+    "bulkPayment": {
+        "comingSoonToast": "批量付款功能即将推出!",
+        "submittingList": "正在提交批量付款列表",
+        "submittingProposal": "正在提交提案",
+        "proposalSubmitted": "批量付款提案已提交",
+        "submitListFailed": "提交付款列表失败",
+        "submitFailed": "提交批量付款失败",
+        "upload": {
+            "pleaseUploadCsv": "请上传 CSV 文件",
+            "fileSizeLimit": "文件大小必须小于 1.5 MB",
+            "headerTitle": "批量付款请求",
+            "headerSubtitle": "通过单个提案向多个收款人付款。",
+            "creditsUsed": "您的额度已用完",
+            "bulkPaymentsUsed": "您的批量付款次数已用完",
+            "upgradeTrial": "升级套餐以获得更多额度并继续使用",
+            "upgradePaid": "升级套餐以获得更多权限,或等待下个月限额重置。",
+            "selectAsset": "选择资产",
+            "disableTokenMessage": "对这些代币的批量付款即将推出。",
+            "providePaymentData": "提供付款数据",
+            "uploadFile": "上传文件",
+            "provideData": "提供数据",
+            "chooseFile": "选择文件",
+            "orDragDrop": "或拖放至此",
+            "maxFileSize": "最多 1 个文件,最大 1.5 MB,仅限 CSV 文件",
+            "noFilePrompt": "没有文件可上传?",
+            "downloadTemplate": "下载模板",
+            "requirements": "批量付款要求",
+            "maxTransactions": "每次导入最多 {max} 笔交易",
+            "singleTokenNetwork": "单一代币和网络",
+            "limitsUsed": "您的额度已用完",
+            "selectAndProvide": "选择资产并提供付款数据",
+            "continueToReview": "继续审核",
+            "selectTokenError": "请选择一个代币",
+            "providePaymentDataError": "请提供付款数据"
+        },
+        "editStep": {
+            "title": "编辑付款",
+            "saveChanges": "保存更改"
+        },
+        "parsing": {
+            "rowPrefix": "第 {row} 行:{message}",
+            "missingRecipientFirstColumn": "缺少收款人地址。请在第一列添加地址。",
+            "invalidNearAddress": "地址 “{address}” 不是有效的 NEAR 账户。",
+            "invalidChainAddress": "地址 “{address}” 不是有效的 {chain} 账户。",
+            "rowNeedsAmountRecipient": "每行需要金额和收款人,以逗号分隔。例如:100, alice.near",
+            "missingRecipientBeforeComma": "缺少收款人地址。请在逗号前添加地址。",
+            "missingAmountAfterComma": "缺少金额。请在逗号后添加数字。例如:{recipient}, 100",
+            "invalidAmountNumber": "金额 “{amountStr}” 不是有效的数字。请仅使用数字和小数点(例如 100 或 100.50)。",
+            "amountGreaterThanZero": "金额必须大于 0。您输入的是 “{amountStr}”。",
+            "amountTooLarge": "金额 “{amountStr}” 过大。请使用更小的数字。",
+            "invalidAmountFallback": "无效金额。请仅使用数字和小数点(例如 100 或 100.50)。",
+            "pleaseRemoveChars": "请移除以下字符:{chars}。仅允许数字、逗号和句点。",
+            "amountCannotBeEmpty": "金额不能为空。",
+            "tokenMismatch": "您输入了 “{provided}”,但上方选择的是 {expected}。请移除代币符号,或在下拉框中选择 {suggested}。",
+            "multipleTokenSymbols": "您在文件中使用了多种代币符号({symbols})。请在文件中仅使用一种代币类型,或移除代币符号并使用上方所选的代币。",
+            "noPaymentDataFound": "未找到付款数据。请按以下格式添加付款:recipient, amount",
+            "exceedsRecipientLimit": "您有 {count} 个收款人,但每批的限制为 {limit}。请移除 {excess, plural, other {# 个收款人}} 或拆分为多批。",
+            "noPaymentDataProvided": "未提供付款数据。请按以下格式输入付款:recipient, amount",
+            "headerColumnsNotFound": "我们检测到表头行,但未能找到 'Recipient' 和 'Amount' 列。请使用这些列名,或删除表头行。",
+            "failedToParseCsv": "解析 CSV 数据失败",
+            "failedToParsePaste": "解析粘贴的数据失败",
+            "failedToValidateAccount": "验证账户失败",
+            "feeEstimationFailed": "无法估算此金额的网络手续费。请确认后再试。",
+            "feeEstimationFailedRow": "第 {row} 行({recipient}):无法估算此金额的网络手续费。请确认后再试。"
+        },
+        "recipients": "收款人",
+        "insufficientTokens": "代币不足。您可以提交请求,并在批准前充值。",
+        "removeRecipient": "移除收款人",
+        "removeRecipientConfirm": "您确定要移除给 <strong>{recipient}</strong> 的付款吗?此操作无法撤销。",
+        "remove": "移除",
+        "edit": "编辑"
+    },
+    "bulkPaymentCredits": {
+        "title": "批量付款",
+        "unlimited": "无限制",
+        "creditsPerPeriod": "{amount} / {period}",
+        "oneTimeTrial": "一次性试用",
+        "month": "月",
+        "moreFlexibility": "需要更大的灵活性?",
+        "contactUs": "联系我们"
+    },
+    "exchange": {
+        "validation": {
+            "amountPositive": "金额必须大于 0"
+        },
+        "requestSubmitted": "兑换请求已提交",
+        "heading": "兑换",
+        "sell": "卖出",
+        "receive": "接收",
+        "slippageTolerance": "滑点容忍度",
+        "disabled": {
+            "differentTokens": "代币必须不同",
+            "enterAmount": "请输入要兑换的金额"
+        },
+        "review": "审核兑换",
+        "poweredBy": "技术支持:",
+        "info": {
+            "priceDifference": "价差",
+            "priceDifferenceTooltip": "报价汇率与当前市场汇率之间的差额。正值表示汇率优于市场价。",
+            "estimatedTime": "预计时间",
+            "estimatedTimeValue": "{seconds} 秒",
+            "estimatedTimeTooltip": "完成兑换的大致时间。",
+            "minimumReceived": "最低接收量",
+            "minimumReceivedTooltip": "这是您将通过此次兑换至少收到的金额,基于为请求设定的滑点上限。",
+            "depositAddress": "存款地址",
+            "depositAddressCopied": "存款地址已复制",
+            "quoteExpires": "报价过期时间",
+            "exchangeFee": "兑换手续费",
+            "exchangeFeeTooltip": "此处产生的 0.70% 手续费用于支付 NEAR Intents 协议的交易处理成本及 Trezu 小部件费用。该金额已自动计入您的报价汇率中。"
+        },
+        "approveWithin24h": "请在 24 小时内批准此请求,否则它将过期。建议尽快确认。",
+        "confirmSubmit": "确认并提交请求",
+        "refreshingIn": "兑换汇率将在 {seconds} 秒后刷新"
+    },
+    "vesting": {
+        "validation": {
+            "amountMin": "金额必须大于或等于 3.5",
+            "startBeforeEnd": "开始日期必须早于结束日期",
+            "cliffBetween": "Cliff 日期必须介于"
+        },
+        "stepTitles": {
+            "details": "详情",
+            "settings": "设置",
+            "review": "审核"
+        },
+        "proposalTitle": "为 {address} 创建归属计划",
+        "scheduleSubmitted": "创建归属计划的请求已提交",
+        "heading": "新建归属计划",
+        "amount": "金额",
+        "startDate": "开始日期",
+        "endDate": "结束日期",
+        "noteOptional": "备注(可选)",
+        "continue": "继续",
+        "advancedSettings": "高级设置",
+        "allowCancellation": "允许取消",
+        "allowCancellationDescription": "允许 NEAR Foundation 随时取消锁仓。不可取消的锁仓与 Cliff 日期不兼容。",
+        "cliffDate": "Cliff 日期",
+        "allowEarn": "允许赚取收益",
+        "allowEarnDescription": "允许锁仓所有者将锁仓中的全部代币用于质押(即使在 Cliff 日期之前)。",
+        "commentPlaceholder": "为此归属计划添加备注(可选)...",
+        "reviewRequest": "审核请求",
+        "reviewHeading": "审核您的归属计划",
+        "confirmSubmit": "确认并提交请求",
+        "review": {
+            "recipient": "收款人",
+            "startDate": "开始日期",
+            "endDate": "结束日期",
+            "cliffDate": "Cliff 日期",
+            "cancelable": "可取消",
+            "allowEarn": "允许赚取收益",
+            "na": "不适用"
+        }
+    },
+    "earn": {
+        "placeholder": "探索收益机会与质押奖励。"
+    },
+    "createTreasury": {
+        "validation": {
+            "nameMin": "金库名称至少需 2 个字符",
+            "nameMax": "金库名称必须少于 64 个字符",
+            "accountMin": "账户名称至少需 2 个字符",
+            "accountMax": "账户名称必须少于 64 个字符",
+            "accountChars": "账户名称只能包含拉丁字母、数字和连字符",
+            "accountTaken": "此账户名称已被占用"
+        },
+        "votingNote": "您需要更多成员才能修改投票设置。请添加另一名成员以配置投票。",
+        "minimumVoteNote": "至少需要一个批准投票。",
+        "heading": "创建金库",
+        "addMembers": "添加成员",
+        "addMembersInfo": "您现在可以添加或更新成员,稍后随时可以再次编辑。",
+        "treasuryName": "金库名称",
+        "treasuryNamePlaceholder": "我的金库",
+        "accountName": "账户名称",
+        "accountNameInfo": "这是您账户的唯一名称。它将用于您的金库 URL,并显示在交易中以标识付款人。请为您的账户选择一个简短易识别的名称。",
+        "accountPlaceholder": "my-treasury",
+        "continue": "继续",
+        "votingThreshold": "投票阈值",
+        "thresholdDescription": "设置批准请求所需的投票数:",
+        "financial": "财务",
+        "financialDescription": "批准付款与兑换请求。",
+        "governance": "治理",
+        "governanceDescription": "批准设置、成员及投票配置。",
+        "confidential": "机密",
+        "public": "公开",
+        "anyone": "任何人",
+        "teamOnly": "仅限团队",
+        "soon": "即将推出",
+        "publicDescription": "所有余额、活动和交易在区块链上对任何人都可见。此选项最适合透明的组织和公共 DAO。",
+        "balanceTransactions": "余额、交易",
+        "membersVoting": "成员、投票",
+        "allFeatures": "所有功能可用",
+        "confidentialDescription": "所有余额、活动和转账在区块链上保持私密。仅您的团队可以查看这些信息。最适合需要财务隐私的私人公司、家族办公室或团队。",
+        "recentTransactionsExport": "近期交易导出",
+        "bulkPayment": "批量付款",
+        "treasuryType": "金库类型",
+        "treasuryTypeWarning": "每个金库只能选择一次,后续无法更改。",
+        "select": "选择",
+        "visibleOnChain": "链上可见",
+        "featuresAvailable": "可用功能",
+        "mostFeaturesSupported": "支持大多数功能",
+        "reviewTreasury": "审核金库",
+        "membersLabel": "成员",
+        "financialThreshold": "财务阈值",
+        "governanceThreshold": "治理阈值",
+        "noDeploymentFee": "🎉 无部署费用",
+        "noDeploymentFeeDescription": "为支持新项目,TREZU 承担所有一次性部署及网络存储费用。",
+        "createButton": "创建金库",
+        "connectWalletCreate": "连接钱包以创建金库",
+        "unexpectedError": "发生意外错误",
+        "creationFailed": "创建金库失败。请再试一次。",
+        "stepTitles": {
+            "aboutYou": "关于您",
+            "details": "详情",
+            "members": "成员",
+            "treasuryType": "金库类型",
+            "review": "审核"
+        },
+        "steps": {
+            "creatingNear": "正在 NEAR 上创建您的金库",
+            "registeringKey": "正在注册公钥",
+            "settingUpConfidential": "正在设置机密交易",
+            "configuringMembers": "正在配置金库成员",
+            "finalizingSetup": "正在完成设置"
+        }
+    },
+    "manageTreasuries": {
+        "warningOne": "至少需保留一个金库可见",
+        "warningOnePeriod": "至少需保留一个金库可见。",
+        "activeHeading": "活跃金库",
+        "activeDescription": "当前在您账户列表中可见的金库。",
+        "activeEmpty": "无活跃金库。",
+        "hiddenHeading": "已隐藏金库",
+        "hiddenDescription": "已从您的账户列表中隐藏的金库。",
+        "removeGuestTitle": "移除访客金库",
+        "removeDialog": "您即将移除 <bold>{name}</bold>。一旦确认,此操作无法撤销。",
+        "tooltips": {
+            "removeFromList": "从您的列表中移除",
+            "viewTreasury": "查看金库",
+            "hideFromList": "从您的列表中隐藏",
+            "showInList": "显示在您的列表中"
+        }
+    },
+    "wallet": {
+        "proposal": {
+            "transfer": "来自外部 dApp 的提案:向 {receiverId} 转账 NEAR",
+            "functionCall": "来自外部 dApp 的提案:在 {receiverId} 上调用 {methods}",
+            "unsupportedAction": "不支持的操作类型 “{type}”。仅 Transfer 和 FunctionCall 操作可转换为 Trezu 提案。"
+        },
+        "loading": "加载中...",
+        "connectPrompt": "请连接您的 NEAR 钱包以继续。然后您将选择要代表其操作的金库。",
+        "connectWallet": "连接钱包",
+        "cancel": "取消",
+        "connectedAs": "已以 <strong>{account}</strong> 身份连接",
+        "loadingTreasuries": "正在加载金库...",
+        "selectSignIn": "选择要登录的金库:",
+        "selectSignTx": "选择要为其创建提案的金库:",
+        "notMember": "您不是任何金库的成员。",
+        "actingAs": "代表",
+        "signedBy": "由 {account} 签署",
+        "createsNProposals": "这将为以下内容创建 {count, plural, other {# 个 Trezu 提案}}:",
+        "proposalDescriptionLabel": "提案描述(可选)",
+        "proposalDescriptionPlaceholder": "描述此提案...",
+        "createProposal": "创建提案",
+        "creatingProposal": "正在创建提案...",
+        "confirmInWallet": "请在您的钱包中确认",
+        "proposalSubmitted": "提案已提交",
+        "shareProposal": "您的提案已创建。请将下方链接分享给金库成员进行投票。",
+        "proposalLink": "{daoId} — 提案 #{id}",
+        "checking": "检查中...",
+        "proposalApprovedProceed": "提案已获批准。请继续",
+        "signedInSuccess": "登录成功",
+        "proposalCreatedSuccess": "提案创建成功",
+        "closeWindow": "您可以关闭此窗口。",
+        "errorGeneric": "发生错误",
+        "tryAgain": "再试一次",
+        "errors": {
+            "parseTx": "解析交易请求失败。请再试一次。",
+            "fetchTreasuries": "获取您的金库失败。请再试一次。",
+            "connectFailed": "连接钱包失败",
+            "createProposalFailed": "创建提案失败",
+            "stillPending": "提案仍在等待批准。请等待金库成员投票。",
+            "wasStatus": "提案 #{id} 的状态为 {status}",
+            "awaitIndex": "提案已获批准,但执行交易尚未被索引。请稍后再试。",
+            "checkStatusFailed": "检查提案状态失败",
+            "userCancelled": "用户已取消",
+            "proposalWasStatus": "提案状态为 {status}"
+        }
+    },
+    "telegram": {
+        "tagPill": "Telegram",
+        "invalidLinkTitle": "链接无效",
+        "invalidLinkDescription": "此 Telegram 连接链接缺少令牌。请在 Telegram 中重新点击 Connect Treasury 以生成新的链接。",
+        "successTitle": "连接成功",
+        "successDescription": "金库已链接到此 Telegram 聊天。",
+        "successToast": "金库连接成功",
+        "goToApp": "前往应用",
+        "linkExpiredTitle": "链接已过期",
+        "linkExpiredDescription": "此链接已过期或已被使用。在 Telegram 中输入下方命令以重新启动连接流程。",
+        "commandCopied": "命令已复制",
+        "copy": "复制",
+        "unableToLoadTitle": "无法加载聊天",
+        "unableToLoadDescription": "目前无法加载聊天详情。请从 Telegram 重试。",
+        "signInTitle": "登录以继续",
+        "signInDescription": "请先连接您的 NEAR 钱包,然后选择要链接到此 Telegram 聊天的金库。",
+        "connectWallet": "连接钱包",
+        "selectTreasuriesTitle": "选择金库",
+        "selectTreasuriesDescription": "选择要连接到此 Telegram 聊天的金库。",
+        "telegramChat": "Telegram 聊天",
+        "chatIdFallback": "聊天 #{id}",
+        "failedToConnect": "连接金库失败。请再试一次。",
+        "relinking": "{count, plural, other {# 个所选金库当前已链接到其他 Telegram 聊天。连接将重新链接它们,并将其聊天 ID 更改为此聊天。}}",
+        "alreadyConnected": "已连接到此聊天",
+        "connectedToAnother": "已连接到其他聊天",
+        "notMember": "您不是任何金库的策略成员。",
+        "connecting": "连接中…",
+        "connect": "连接"
+    },
+    "systemStatus": {
+        "underMaintenance": "维护中",
+        "maintenanceMessage": "我们正在进行维护。某些功能可能暂时不可用。请稍后再试。"
+    },
+    "creditsQuota": {
+        "available": "{count} 可用",
+        "used": "已用 {count}",
+        "resetOn": "限额将于 {date} 重置"
+    },
+    "approvalInfo": {
+        "infoText": "批准付款相关请求所需的投票数。可在“投票”设置中编辑。",
+        "thresholdPill": "阈值 {required} / {total}",
+        "alertBody": "此付款执行前需要 <bold>{required}</bold> 名金库成员的批准。"
+    },
+    "guestBadge": {
+        "title": "访客",
+        "tooltip": "您是此金库的访客。您只能查看数据。"
+    },
+    "exportButton": {
+        "confidentialTooltip": "导出功能在机密模式下尚不可用。此功能即将推出!"
+    },
+    "sponsoredActions": {
+        "titleExhausted": "赞助操作已用完",
+        "titleAlmost": "您的团队即将用完赞助操作",
+        "closeNotice": "关闭提示",
+        "teamUsage": "团队用量:每月 {total} 次操作",
+        "available": "{count} 可用",
+        "used": "已用 {count}",
+        "exhaustedBody": "您的团队已达到本月赞助操作上限。您可以在 {date} 之后继续,或与我们联系",
+        "almostBody": "TREZU 当前为所有团队操作(如创建请求和投票)赞助存储费用。您的团队即将达到月度赞助上限。",
+        "contactUs": "联系我们",
+        "nextMonthlyReset": "下次月度重置时间",
+        "sidebarBody": "您的团队已达到本月赞助操作上限。您可以在 {date} 之后继续,或 ⬇️"
+    },
+    "acceptTerms": {
+        "title": "接受条款以继续",
+        "privacyTitle": "您在 Trezu 的隐私",
+        "privacyBody": "Trezu 是一个非托管界面。我们在确保平台安全和功能正常的同时,优先保护您的隐私。",
+        "minimalTitle": "最少数据",
+        "minimalBody": "我们仅收集有限的信息,例如公开钱包地址、IP 地址和使用分析,以运营和改进本界面。",
+        "noCustodyTitle": "非托管",
+        "noCustodyBody": "我们绝不会访问您的私钥、助记词或数字资产。",
+        "publicTitle": "公开记录",
+        "publicBody": "请记住,所有区块链交易本身都是公开的,且不受我们控制。",
+        "responsibilityTitle": "您的责任",
+        "responsibilityBody": "您需自行负责监控钱包活动并保护您的凭证。",
+        "futureTitle": "未来更新",
+        "futureBody": "如果您选择接收未来的通知(如电子邮件或 Telegram),我们将仅使用这些数据来通知您。",
+        "agreement": "我已阅读并同意<terms>服务条款</terms>和<privacy>隐私政策</privacy>",
+        "accepting": "正在接受...",
+        "continue": "继续"
+    },
+    "confidentialBanner": {
+        "label": "机密",
+        "description": "余额、活动和转账仅对您的团队可见 — 公共区块链上不可见。"
+    },
+    "supportCenter": {
+        "title": "支持中心",
+        "resources": "资源",
+        "support": "支持",
+        "websiteTitle": "Trezu 网站",
+        "websiteDescription": "了解更多关于 Trezu 的信息并阅读我们的博客。",
+        "demo": "Trezu 演示",
+        "demoTitle": "探索公开版本",
+        "demoDescription": "查看一个实时的公开账户。",
+        "confidentialDemoTitle": "探索机密版本",
+        "confidentialDemoDescription": "探索一个实时的机密账户。",
+        "videoTitle": "观看演示",
+        "videoDescription": "观看一段简短视频,了解 Trezu 的工作方式。",
+        "xTitle": "在 X 上关注我们",
+        "xDescription": "及时获取我们的最新发布与见解。",
+        "statsTitle": "统计",
+        "statsDescription": "查看所有 sputnik DAO 的总管理资产。",
+        "docsTitle": "文档",
+        "docsDescription": "在文档中了解所有功能。",
+        "productSupportTitle": "产品支持",
+        "productSupportDescription": "联系我们的支持团队寻求帮助。"
+    },
+    "progressModal": {
+        "titleCreating": "正在创建金库...",
+        "titleDone": "金库已创建",
+        "titleFailed": "金库创建失败",
+        "viewTreasury": "查看金库"
+    },
+    "memberValidation": {
+        "noManagePermission": "您没有管理成员的权限",
+        "pendingRequest": "存在活动请求时,您无法管理成员",
+        "rolesAnd": "{first} 和 {second}",
+        "rolesMany": "{list} 以及 {last}",
+        "cannotRemoveMember": "无法移除此成员。他们是唯一被分配 {roles} {count, plural, other {角色}}的成员。",
+        "cannotRemoveMemberGov": "无法移除此成员。他们是唯一被分配 {roles} {count, plural, other {角色,而该角色}}的成员,该角色用于管理团队成员和配置投票。",
+        "cannotBulkRemove": "无法移除这些成员。这将使 {roles} {count, plural, other {角色}}变空。",
+        "cannotBulkRemoveGov": "无法移除这些成员。这将使 {roles} {count, plural, other {角色,而该角色}}变空,该角色用于管理团队成员和配置投票。",
+        "cannotRemoveRole": "您不能从此成员中移除 {role} 角色。他们是唯一被分配此角色的人。",
+        "cannotRemoveRoleGov": "您不能从此成员中移除 {role} 角色。他们是唯一的 {role} 成员,缺少此角色将无法管理团队成员或配置投票。"
+    },
+    "roleSelector": {
+        "setRole": "设置角色",
+        "allRoles": "所有角色",
+        "roles": {
+            "governance": {
+                "title": "治理",
+                "description": "治理可以创建并投票决定团队相关的金库设置,包括成员、权限和金库外观。"
+            },
+            "requestor": {
+                "title": "请求者",
+                "description": "请求者可以创建付款相关的交易请求,但没有投票或批准权限。"
+            },
+            "financial": {
+                "title": "财务",
+                "description": "财务可以对付款相关的交易请求投票,但不能创建请求。"
+            }
+        }
+    },
+    "memberInput": {
+        "creatorYou": "创建者(您)",
+        "memberAddress": "成员地址",
+        "addNewMember": "添加新成员",
+        "validation": {
+            "rolesRequired": "至少需要一个角色",
+            "duplicateAddress": "地址已是成员"
+        }
+    },
+    "recipientInput": {
+        "title": "至",
+        "placeholder": "收款人地址"
+    },
+    "accountInput": {
+        "failedValidation": "验证地址失败",
+        "invalidNearFormat": "无效的 NEAR 账户格式",
+        "invalidChainAddress": "请输入有效的 {chain} 地址。",
+        "validating": "正在验证地址...",
+        "validAddress": "有效地址",
+        "placeholderWithExample": "收款人地址(例如:{example})",
+        "placeholderNoExample": "收款人地址",
+        "nearExample": "alice.near、0x...,或 64 字符十六进制",
+        "near": {
+            "required": "地址为必填项",
+            "length": "地址长度必须在 2 到 64 个字符之间",
+            "missingTld": "命名账户必须以 .near、.aurora 或 .tg 结尾",
+            "invalidChars": "地址只能包含小写字母、数字和分隔符(.、-、_)",
+            "accountMissing": "账户在 NEAR 区块链上不存在",
+            "verifyFailed": "验证账户存在性失败"
+        }
+    },
+    "csvUpload": {
+        "uploadFile": "上传文件",
+        "provideData": "提供数据",
+        "chooseFile": "选择文件",
+        "orDragDrop": "或拖放至此",
+        "maxFileSize": "最多 1 个文件,最大 {maxSize} MB,仅限 CSV 文件",
+        "noFilePrompt": "没有文件可上传?",
+        "downloadTemplate": "下载模板"
+    },
+    "tokenSelect": {
+        "selectToken": "选择代币",
+        "searchPlaceholder": "搜索代币...",
+        "noTokensFound": "未找到代币"
+    },
+    "filterOperations": {
+        "is": "是",
+        "isNot": "不是",
+        "before": "早于",
+        "after": "晚于",
+        "between": "介于",
+        "equal": "等于",
+        "moreThan": "大于",
+        "lessThan": "小于",
+        "contains": "包含"
+    },
+    "copyButton": {
+        "copied": "已复制到剪贴板",
+        "failed": "复制失败"
+    },
+    "recipientForm": {
+        "validation": {
+            "nameRequired": "姓名为必填项",
+            "nameMax": "收款人必须少于 {max} 个字符",
+            "addressRequired": "地址为必填项",
+            "networksRequired": "请至少选择一个网络"
+        }
+    },
+    "paymentForm": {
+        "validation": {
+            "recipientMin": "收款人至少需 2 个字符",
+            "recipientMax": "收款人必须少于 128 个字符",
+            "amountGreaterThanZero": "金额必须大于 0",
+            "recipientSameAsToken": "收款人地址不能与代币地址相同",
+            "selectToken": "请选择一个代币",
+            "recipientMax64": "收款人必须少于 64 个字符",
+            "amountMinLockup": "金额必须大于或等于 3.5",
+            "startDateRequired": "开始日期为必填项",
+            "endDateRequired": "结束日期为必填项",
+            "cliffDateRequired": "Cliff 日期为必填项",
+            "startBeforeEnd": "开始日期必须早于结束日期",
+            "cliffBetween": "Cliff 日期必须介于 {start} 和 {end} 之间"
+        }
+    },
+    "exportToasts": {
+        "downloadFailed": "下载导出文件失败",
+        "invalidDateRange": "无效的日期范围",
+        "invalidDateRangeDescription": "请为导出选择有效的日期范围。",
+        "exportSuccess": "导出成功!",
+        "exportSuccessDescription": "您的 {type} 文件已下载。请查看导出历史以了解详情。",
+        "exportFailed": "导出失败",
+        "exportFailedFallback": "导出数据失败。请再试一次。",
+        "noDownloadPermission": "您没有下载此文件的权限。",
+        "noExportPermission": "您没有导出权限",
+        "quotaUsed": "您的配额已用完",
+        "exporting": "导出中...",
+        "export": "导出",
+        "columnSubmissionTime": "提交时间",
+        "columnDateRange": "日期范围",
+        "columnGeneratedBy": "生成者",
+        "columnStatus": "状态",
+        "typeAll": "所有类型",
+        "typeSent": "已发送",
+        "typeReceived": "已接收",
+        "typeStakingRewards": "质押奖励",
+        "allAssets": "所有资产",
+        "upgradeTrial": "升级套餐以获得更多额度并继续使用",
+        "upgradePaid": "升级套餐以获得更多权限,或等待下个月限额重置。",
+        "selectDateRange": "选择日期范围",
+        "noExportsTitle": "暂无导出记录",
+        "noExportsDescription": "上个月的导出文件生成后将显示在此处。",
+        "quotaTitle": "导出配额",
+        "unlimited": "无限制",
+        "creditsPerMonth": "{total} / 月",
+        "requirementsTitle": "导出要求",
+        "exportFromPeriod": "您可以从 {period} 导出数据。",
+        "availableFor48Hours": "导出文件可在 48 小时内下载。",
+        "moreFlexibility": "需要更大的灵活性?",
+        "contactUs": "联系我们",
+        "last1Year": "过去 1 年",
+        "last2Years": "过去 2 年",
+        "invalidEmail": "请输入有效的电子邮箱地址"
+    },
+    "proposalKinds": {
+        "Batch Payment Request": "批量付款请求",
+        "Payment Request": "付款请求",
+        "Confidential Request": "机密请求",
+        "Exchange": "兑换",
+        "Function Call": "函数调用",
+        "Change Policy": "修改策略",
+        "Update General Settings": "更新常规设置",
+        "Earn NEAR": "赚取 NEAR",
+        "Unstake NEAR": "取消质押 NEAR",
+        "Vesting": "归属",
+        "Withdraw Earnings": "提取收益",
+        "Members": "成员",
+        "Upgrade": "升级",
+        "Set Staking Contract": "设置质押合约",
+        "Bounty": "悬赏",
+        "Vote": "投票",
+        "Factory Info Update": "工厂信息更新",
+        "Unsupported": "不支持"
+    },
+    "paymentFormSection": {
+        "selectRecipient": "选择收款人",
+        "searchByNameOrAddress": "按名称或地址搜索",
+        "restrictedRecipientTitle": "不允许此交易",
+        "restrictedRecipientMessage": "由于安全检查,该地址当前受到限制。如果您认为该地址应被允许,可<link>申请将其加入白名单</link>。",
+        "send": "发送",
+        "to": "至"
+    },
+    "recipientNetworkSelect": {
+        "label": "收款人网络",
+        "placeholder": "选择收款人网络",
+        "enterAddressFirst": "请先输入收款人地址",
+        "noCompatibleNetwork": "没有与此地址匹配的网络",
+        "selectPlaceholder": "选择网络",
+        "title": "选择网络",
+        "available": "可用",
+        "fromAddressBook": "来自地址簿",
+        "otherAvailable": "其他可用",
+        "incompatible": "不兼容",
+        "comingSoon": "即将推出",
+        "nearComName": "near.com",
+        "nearComDescription": "near.com 与 trezu 的内部网络"
+    },
+    "addressBookTable": {
+        "emptyTitle": "暂无收款人",
+        "emptyDescription": "向此地址簿添加收款人以加快付款速度。",
+        "selectAll": "选择所有收款人",
+        "selectEntry": "选择 {name}",
+        "recipient": "收款人",
+        "network": "网络",
+        "addedBy": "添加者",
+        "note": "备注",
+        "added": "已添加",
+        "remove": "移除",
+        "send": "发送"
+    },
+    "publicDashboard": {
+        "updatesDaily": "每日更新",
+        "noDataTitle": "暂无数据",
+        "noDataDescription": "在计算首次每日快照后将显示统计数据。",
+        "assetsSecured": "由 Sputnik DAO 合约保护的资产",
+        "acrossDaos": "跨 <bold>{count, plural, other {# 个 DAO}}</bold>",
+        "updatedOn": "更新于 {date}",
+        "topAssets": "前 20 大资产",
+        "noAssetsTitle": "暂无资产",
+        "noAssetsDescription": "在计算每日快照后将显示代币数据。",
+        "tableToken": "代币",
+        "tableTotalValue": "总价值"
+    },
+    "telegramConnectInstructions": {
+        "title": "连接 Telegram",
+        "subtitle": "在您的 Telegram 中接收提案与活动通知。",
+        "step3": "按下 Start 并按照说明操作。",
+        "success": "全部就绪!",
+        "copyBotTooltip": "复制机器人账号",
+        "botCopiedToast": "机器人账号已复制",
+        "openInTelegram": "在 Telegram 中打开 {bot}"
+    },
+    "transactionHashCell": {
+        "copyHash": "复制哈希",
+        "hashCopied": "哈希已复制",
+        "openInExplorer": "在区块浏览器中打开"
+    },
+    "treasurySelector": {
+        "select": "选择金库",
+        "connectWalletTooltip": "连接钱包以查看金库",
+        "manageTreasuries": "管理金库",
+        "createTreasury": "创建金库",
+        "memberOf": "所属",
+        "guestTreasuries": "访客金库"
+    },
+    "selectModal": {
+        "searchByName": "按名称搜索",
+        "noResults": "未找到结果"
+    },
+    "selectList": {
+        "noResults": "未找到结果"
+    },
+    "datePicker": {
+        "pickDate": "选择日期",
+        "timezone": "时区"
+    },
+    "datePresets": {
+        "today": "今天",
+        "yesterday": "昨天",
+        "last3Days": "过去 3 天",
+        "last7Days": "过去 7 天",
+        "last14Days": "过去 14 天",
+        "lastMonth": "上个月",
+        "last3Months": "过去 3 个月",
+        "last6Months": "过去 6 个月"
+    },
+    "input": {
+        "openSearch": "打开搜索"
+    },
+    "pagination": {
+        "previous": "上一页",
+        "next": "下一页"
+    },
+    "confidentialState": {
+        "title": "机密",
+        "description": "仅金库成员可访问。"
+    },
+    "exchangeRate": {
+        "rate": "汇率",
+        "clickToReverse": "点击反转汇率"
+    },
+    "exchangeSettings": {
+        "title": "兑换设置",
+        "slippageTolerance": "滑点容忍度",
+        "custom": "自定义",
+        "customPlaceholder": "例如:2%",
+        "slippageRange": "滑点必须介于 0.01% 和 100% 之间",
+        "enterSlippage": "请输入滑点容忍度",
+        "slippageHelp": "如果价格变动超过此百分比,交易将被取消以保护您的资金。",
+        "save": "保存"
+    },
+    "assetsPage": {
+        "title": "资产",
+        "noAssetsTitle": "暂无资产",
+        "noAssetsDescription": "请通过存款向您的金库添加资产以开始使用。"
+    },
+    "newBadge": {
+        "label": "新"
+    },
+    "numberBadge": {
+        "pendingRequests": "{count, plural, other {# 个待处理请求}}"
+    },
+    "balanceWithGraph": {
+        "allTokens": "所有代币",
+        "deposit": "存款",
+        "send": "发送",
+        "exchange": "兑换",
+        "chartNow": "现在",
+        "totalBalance": "总余额",
+        "excludedTokens": "已排除代币:",
+        "noPriceHistory": "无价格历史。请选择代币以查看其余额变化。",
+        "bucketAvailable": "可用",
+        "bucketLocked": "已锁定",
+        "bucketEarning": "收益中",
+        "period": {
+            "1W": "1周",
+            "1M": "1月",
+            "3M": "3月",
+            "1Y": "1年"
+        }
+    },
+    "changePolicyExpanded": {
+        "proposalBond": "提案保证金",
+        "proposalPeriod": "提案期限",
+        "bountyBond": "悬赏保证金",
+        "bountyForgivenessPeriod": "悬赏宽限期",
+        "votesCount": "{count} 票",
+        "weightKind": "权重类型",
+        "quorum": "法定人数",
+        "threshold": "阈值",
+        "defaultThreshold": "默认阈值",
+        "roleThreshold": "{role} 阈值",
+        "member": "成员",
+        "members": "成员",
+        "permissions": "权限",
+        "oldPermissions": "旧权限",
+        "newPermissions": "新权限",
+        "category": "类别",
+        "transactionDetails": "交易详情",
+        "addNewMember": "添加新成员",
+        "addNewMembers": "添加新成员",
+        "removeMember": "移除成员",
+        "removeMembers": "移除成员",
+        "updateMemberPermissions": "更新成员权限",
+        "updateMembersPermissions": "更新成员权限",
+        "memberIndex": "成员 {index}",
+        "membersCount": "{count} 名成员",
+        "collapseAll": "全部折叠",
+        "expandAll": "全部展开",
+        "loadingHistorical": "正在加载历史策略...",
+        "unableToDiff": "无法计算此提案的差异。",
+        "noChangesCurrent": "未检测到任何更改 — 提议的策略与当前策略一致。",
+        "noChangesHistorical": "未检测到任何更改 — 提议的策略与历史策略一致。"
+    },
+    "balanceChart": {
+        "usdValue": "美元价值",
+        "tokenBalance": "代币余额",
+        "emptyTitle": "暂无内容",
+        "emptyDescription": "添加资产以开始跟踪您的投资组合。"
+    },
+    "user": {
+        "saveToAddressBook": "保存到地址簿",
+        "walletCopiedToast": "钱包地址已复制到剪贴板",
+        "copyWalletAddress": "复制钱包地址"
+    },
+    "infoDisplay": {
+        "viewLess": "收起",
+        "viewAllDetails": "查看所有详情"
+    },
+    "amountSummary": {
+        "defaultTitle": "您正在发送的总金额为"
+    },
+    "residency": {
+        "vestedToken": "归属代币",
+        "staked": "已质押",
+        "fungibleToken": "同质化代币",
+        "intentsToken": "Intents 代币",
+        "nativeToken": "原生代币"
+    },
+    "exchangeErrors": {
+        "noRoute": "未找到兑换路径。请尝试更小的金额或不同的代币。",
+        "amountTooLow": "兑换金额过低。跨链兑换需要更高的最低金额以支付网络手续费。",
+        "insufficientBalance": "此次兑换余额不足。",
+        "networkError": "网络错误。请检查您的连接并再试一次。",
+        "fetchFailed": "获取报价失败"
+    },
+    "tokenSelectDialog": {
+        "selectToken": "选择代币",
+        "selectAsset": "选择资产",
+        "selectNetworkFor": "为 {asset} 选择网络",
+        "searchByName": "按名称搜索",
+        "noTokensWithBalance": "未找到有余额的代币",
+        "noTokensFound": "未找到代币",
+        "yourAssets": "您的资产",
+        "otherAssets": "其他资产",
+        "networksWithAssets": "包含资产的网络",
+        "supportedNetworks": "支持的网络",
+        "comingSoon": "即将推出"
+    },
+    "intentsQuote": {
+        "initializing": "报价服务仍在初始化中。请再试一次。",
+        "noRoute": "目前无法准备付款路径。请重试。",
+        "fetchFailed": "目前无法准备付款路径。请重试。",
+        "amountTooLow": "金额过低,无法支付网络手续费。请输入更高金额后再试。",
+        "amountTooLowWithMin": "金额过低,无法支付网络手续费。请输入至少 {min} {token}。",
+        "networkFeeTooltip": "此手续费用于在所选链上处理交易。"
+    },
+    "pageTours": {
+        "paymentsBulk": "批量创建功能已上线!只需几步即可创建多个请求。",
+        "paymentsPending": "在此查看等待批准的请求。",
+        "exchangeSettings": "在此设置您愿意接受的价格变动幅度。",
+        "membersPending": "点击查看等待批准的活动请求。",
+        "guestSaveIntro": "您是此金库的访客。您只能查看数据。",
+        "guestSaveAction": "您可以将此访客金库保存到您的金库列表。",
+        "newFeatureRich": "新功能!🎉 保存常用地址,实现更快、零错误的付款。<br></br> 您的联系人保持私密,仅对您的团队可见。",
+        "newFeatureCta": "试用一下"
+    },
+    "statusDate": {
+        "expires": "过期",
+        "created": "已创建",
+        "expired": "已过期",
+        "removed": "已移除"
+    },
+    "relativeTime": {
+        "justNow": "刚刚",
+        "moments": "片刻"
+    },
+    "amount": {
+        "network": "网络:{network}"
+    },
+    "activityLabels": {
+        "exchangePending": "兑换待处理",
+        "exchangeRequest": "兑换请求",
+        "exchangeFulfillment": "兑换完成",
+        "stakingRewards": "质押奖励",
+        "proposalAction": "提案操作",
+        "deposit": "存入 {symbol}",
+        "paymentSent": "付款已发送",
+        "transaction": "交易",
+        "fallbackToken": "代币",
+        "viaIntents": "通过 NEAR Intents",
+        "from": "来自 {account}",
+        "to": "至 {account}",
+        "viewAll": "查看您的所有交易历史",
+        "sentReceived": "已发送和已接收的交易({duration})",
+        "unlimitedHistory": "无限历史记录",
+        "oneYear": "1 年",
+        "yearsCount": "{count} 年",
+        "monthsCount": "{count} 个月",
+        "lastDuration": "过去 {duration}"
+    },
+    "nearStore": {
+        "connectAndAcceptTerms": "请连接钱包并接受条款以继续。",
+        "transactionNotApproved": "交易未在您的钱包中获批。",
+        "failedSubmitVote": "提交投票失败",
+        "failedSubmitVotes": "提交投票失败",
+        "viewRequest": "查看请求",
+        "proposalRemoved": "您的提案已被移除",
+        "voteSubmitted": "您的投票已提交",
+        "votesSubmitted": "您的投票已提交"
+    },
+    "tokenInput": {
+        "max": "MAX",
+        "insufficientTokens": "代币不足。您可以提交请求,并在批准前充值。",
+        "balance": "余额:{amount} {symbol}"
+    },
+    "createRequestButton": {
+        "idle": "创建请求",
+        "noPermission": "您没有创建请求的权限"
+    },
+    "address": {
+        "copied": "地址已复制到剪贴板"
+    },
+    "memberAvatars": {
+        "membersWhoCanVote": "可投票的成员",
+        "moreMembers": "+{count, plural, other {# 名成员}}"
+    },
+    "accountIdInput": {
+        "minLength": "账户 ID 至少需 2 个字符",
+        "maxLength": "账户 ID 必须少于 64 个字符",
+        "charset": "账户 ID 只能包含小写字母、数字、句点、连字符和下划线,且不能以分隔符开头或结尾",
+        "doesNotExist": "账户 ID 不存在"
+    },
+    "addressBookMutations": {
+        "addedToast": "{count, plural, other {已添加 # 个收款人}}",
+        "addedSingleToast": "已添加收款人",
+        "addFailedToast": "添加收款人失败",
+        "addSingleFailedToast": "添加收款人失败",
+        "removedToast": "{count, plural, other {已移除 # 个收款人}}",
+        "removeFailedToast": "移除收款人失败",
+        "exportFailedToast": "导出收款人失败"
+    },
+    "treasuryMutations": {
+        "savedToast": "金库已保存到您的列表",
+        "saveFailedToast": "保存金库失败",
+        "hiddenToast": "金库已从列表中隐藏",
+        "hideFailedToast": "隐藏金库失败",
+        "unhiddenToast": "金库再次可见",
+        "unhideFailedToast": "取消隐藏金库失败",
+        "removedToast": "金库已从已保存列表中移除",
+        "removeFailedToast": "从已保存列表中移除金库失败"
+    },
+    "telegramSettings": {
+        "title": "Telegram",
+        "connectedTo": "已连接到 {chat}",
+        "chatNumber": "聊天 #{id}",
+        "fallbackChat": "一个 Telegram 聊天",
+        "disconnect": "断开连接",
+        "connect": "连接",
+        "connectDescription": "将您的金库链接到 Telegram 聊天以接收通知。",
+        "noTreasuryDescription": "将您的金库链接到 Telegram 聊天。",
+        "openSettingsHint": "从某个金库打开设置以管理集成。",
+        "disconnectedToast": "已为此金库断开 Telegram 连接",
+        "disconnectFailedToast": "无法断开 Telegram 连接。请再试一次。"
+    },
+    "assetsTable": {
+        "noAssetsFound": "未找到资产。",
+        "assetDetails": "资产详情",
+        "coinPrice": "币价",
+        "weight": "权重",
+        "balance": "余额",
+        "lockedBalance": "已锁定余额",
+        "totalBalance": "总余额",
+        "source": "来源",
+        "balanceByInvestors": "按 {count, plural, other {投资者}}划分的余额",
+        "investors": "{count, plural, other {投资者}}",
+        "poolBreakdown": "矿池明细",
+        "unlockedToken": "已解锁代币",
+        "lockupStakingPool": "锁仓质押池",
+        "exchange": "兑换",
+        "send": "发送",
+        "details": "详情",
+        "columnToken": "代币",
+        "columnLocked": "已锁定",
+        "columnUnlocked": "已解锁",
+        "columnTotalAllocated": "总分配量",
+        "columnAvailableToWithdraw": "可提取",
+        "viewAvailable": "可用",
+        "viewLocked": "已锁定",
+        "viewEarning": "收益中",
+        "fullAllocatedBalance": "您的全部已分配余额",
+        "partAllocatedBalance": "您已分配余额的一部分",
+        "currentlyEarning": "({amount} {symbol}) 当前正在产生收益。",
+        "willAppearHere": " 在您停止产生收益后,它将显示在此处。",
+        "seeInEarningTab": "在“收益”标签页中查看",
+        "seeInEarning": "在“收益”中查看"
+    },
+    "earningDetails": {
+        "title": "收益详情",
+        "totalStaked": "总质押量",
+        "earningOverview": "收益概览",
+        "poolBreakdown": "矿池明细({count, plural, other {# 个矿池}})",
+        "almostReady": "收益功能即将就绪!",
+        "finalizingFeature": "我们正在完善此功能,<br></br>您很快就能开始通过代币赚取收益。",
+        "comingSoon": "即将推出",
+        "goToEarn": "前往收益",
+        "readyToWithdraw": "可以提取",
+        "unstaking": "正在取消质押",
+        "overview": {
+            "staked": "已质押",
+            "stakedInfo": "当前委托给验证人以赚取奖励的代币。",
+            "pendingRelease": "待释放",
+            "pendingReleaseInfo": "已取消质押但仍处于解绑期(通常为 2-3 天)的代币。",
+            "availableForWithdraw": "可提取",
+            "availableForWithdrawInfo": "已完成解绑期、可以提取的已取消质押代币。"
+        }
+    },
+    "lockupDetails": {
+        "title": "锁仓详情",
+        "balance": "余额",
+        "reservedForStorage": "存储预留",
+        "reservedForStorageInfo": "锁仓账户为支付存储费用而预留的 NEAR。",
+        "tokenBreakdown": "代币明细",
+        "allocatedAmount": "已分配数量",
+        "earned": "已赚取",
+        "progress": "进度",
+        "unlocked": "已解锁",
+        "locked": "已锁定",
+        "schedule": "计划",
+        "startDate": "开始日期",
+        "endDate": "结束日期",
+        "rounds": "轮次",
+        "releaseInterval": "释放间隔",
+        "nextUnlockDate": "下次解锁日期",
+        "allEarning": "您锁仓中的全部 {amount} {symbol} 当前正在产生收益。",
+        "partEarning": "您锁仓的一部分({amount} {symbol})当前正在产生收益。",
+        "stopEarningFirst": "要使用已解锁的代币,请先停止产生收益并提取它们。",
+        "howGrantWorks": "您的授予如何运作",
+        "ftStep1": "您将获得一份特定时段的授予。资产不会一次性全部到账,而是在一段时间内分批可用。",
+        "ftStep2": "下一个释放日期到达时,该部分代币将自动解锁并转入您的金库余额。",
+        "ftStep3": "代币出现在您的余额中后,您即可立即将其用于付款、转账或其他交易。",
+        "nearStep1": "您将获得一份具有明确开始和结束日期的限时授予。",
+        "nearStep2": "代币解锁后,会自动出现在您的金库余额中。",
+        "nearStep3": "您可以立即将已解锁的代币用于付款、转账或其他交易。",
+        "notAvailable": "不适用",
+        "everyMonth": "每月",
+        "everyQuarter": "每季度",
+        "everyUnit": "每{unit}",
+        "everyMultiple": "每{text}",
+        "completed": "已完成",
+        "unit": {
+            "year": "{count, plural, other {# 年}}",
+            "day": "{count, plural, other {# 天}}",
+            "hour": "{count, plural, other {# 小时}}",
+            "minute": "{count, plural, other {# 分钟}}",
+            "second": "{count, plural, other {# 秒}}"
+        }
+    },
+    "vestingDetails": {
+        "title": "归属详情",
+        "availableToUse": "可使用",
+        "vestingPeriod": "归属期",
+        "vestingPeriodDescription": "代币在此期间每日解锁。",
+        "startDate": "开始日期",
+        "endDate": "结束日期",
+        "tokenBreakdown": "代币明细",
+        "originalVestedAmount": "原始归属数量",
+        "reservedForStorage": "存储预留",
+        "reservedForStorageInfo": "为保持归属生效并支付存储费用所需的少量代币。",
+        "percentVested": "已归属 {percent}%",
+        "vestedOf": "已归属 {vested} / {total} {symbol}",
+        "send": "发送"
+    },
+    "earningPoolDetails": {
+        "balance": "余额",
+        "apy": "年化收益率",
+        "fee": "手续费",
+        "notAvailable": "不适用",
+        "lockupStakingPool": "锁仓质押池",
+        "lockupAssetsNote": "此持仓中的所有资产均来自您的锁仓。停止产生收益后,某些代币可能仍处于锁定状态而无法使用 — 请查看您的锁仓计划以了解解锁时间。"
+    },
+    "onboardingQuestions": {
+        "stepTitle": "几个简单的问题以开始。",
+        "other": "其他",
+        "placeholders": {
+            "describeRole": "描述您的角色(可选)",
+            "describeUseCase": "描述您的使用场景(可选)",
+            "networkName": "输入网络名称(可选)",
+            "currentChallenge": "输入您当前面临的挑战(可选)",
+            "describeOther": "描述其他(可选)"
+        },
+        "questions": {
+            "role": "以下哪项最能描述您的角色?",
+            "useCases": "您打算将 Trezu 用于什么?",
+            "teamSize": "将由多少人来管理金库?",
+            "networks": "您最常使用哪些网络?",
+            "multisigExperience": "您对多签的使用经验如何?",
+            "currentTools": "您目前使用哪些工具来管理财务?",
+            "monthlyVolume": "大致的月交易量是多少?",
+            "biggestChallenges": "您目前面临的最大挑战是什么?"
+        },
+        "options": {
+            "role": {
+                "founder": "创始人",
+                "co-founder": "联合创始人",
+                "cfo-finance-lead": "CFO / 财务负责人",
+                "operations-manager": "运营经理",
+                "treasury-manager": "金库经理",
+                "other": "其他"
+            },
+            "useCases": {
+                "team-payroll-grants": "团队薪酬与赠款",
+                "company-assets-management": "公司资产管理",
+                "dao-treasury-management": "DAO 金库管理",
+                "investment-portfolio": "投资组合",
+                "operational-spending": "运营支出",
+                "other": "其他"
+            },
+            "teamSize": {
+                "just-me": "只有我",
+                "2-5-people": "2-5 人",
+                "6-15-people": "6-15 人",
+                "15-plus-people": "15 人以上"
+            },
+            "networks": {
+                "near": "NEAR",
+                "bitcoin": "Bitcoin",
+                "ethereum": "Ethereum",
+                "solana": "Solana",
+                "arbitrum": "Arbitrum",
+                "base": "Base",
+                "optimism": "Optimism",
+                "polygon": "Polygon",
+                "gnosis": "Gnosis",
+                "avalanche": "Avalanche",
+                "bnb-chain": "BNB Chain",
+                "other": "其他"
+            },
+            "multisigExperience": {
+                "never-heard-of-it": "从未听说过",
+                "heard-about-it": "听说过",
+                "never-used-it": "从未使用过",
+                "used-gnosis-safe-or-similar": "使用过 Gnosis Safe 或类似工具",
+                "experienced": "经验丰富",
+                "looking-for-a-better-option": "正在寻找更好的选择"
+            },
+            "currentTools": {
+                "gnosis-safe": "Gnosis Safe",
+                "fireblocks": "Fireblocks",
+                "tholos": "Tholos",
+                "squads-multisig": "Squads Multisig",
+                "mpc-vault": "MPC Vault",
+                "other": "其他"
+            },
+            "monthlyVolume": {
+                "under-10k": "低于 $10K",
+                "10k-100k": "$10K - $100K",
+                "100k-1m": "$100K - $1M",
+                "1m-plus": "$1M 以上"
+            },
+            "biggestChallenges": {
+                "slow-approvals-and-signing": "审批与签名速度慢",
+                "lack-of-transparency-in-the-team": "团队中缺乏透明度",
+                "hard-to-track-spending-and-balances": "难以跟踪支出与余额",
+                "security-and-access-control": "安全与访问控制",
+                "no-good-web3-tool-yet": "尚无好用的 Web3 工具",
+                "looking-for-crypto-earnings": "我正在寻找加密货币收益",
+                "other": "其他"
+            }
+        }
+    },
+    "onboarding": {
+        "tour": {
+            "addAssets": "通过存款向您的金库添加资产。",
+            "makeRequests": "在需要发送资产时随时创建付款请求。",
+            "exchangeAssets": "在此兑换您的资产。",
+            "addMembers": "向您的金库添加成员并分配角色。",
+            "newTreasury": "想创建新金库?在此只需几次点击即可完成。",
+            "helpSupport": "随时获取帮助与支持。"
+        },
+        "tourCard": {
+            "close": "关闭",
+            "stepProgress": "{current} / {total}",
+            "gotIt": "知道了",
+            "done": "完成",
+            "next": "下一步"
+        },
+        "progress": {
+            "title": "按照以下快捷步骤探索金库",
+            "createTreasuryTitle": "创建金库账户",
+            "createTreasuryDescription": "您已成功设置账户。开端不错!",
+            "addAssetsTitle": "添加您的资产",
+            "addAssetsDescription": "首先添加资产以查看其运行情况。",
+            "deposit": "存款",
+            "createPaymentTitle": "创建付款请求",
+            "createPaymentDescription": "创建付款请求以完成您的设置。",
+            "send": "发送"
+        },
+        "welcome": {
+            "heading": "🎉 欢迎!",
+            "subheading": "快速浏览金库",
+            "body": "您好!您的 Trezu 已就绪 — 通过从受支持的网络添加资产开始构建您的投资组合。",
+            "progress": "{current} / {total}",
+            "next": "下一步",
+            "body2": "了解如何存款、创建请求以及设置新账户。",
+            "noThanks": "不,谢谢",
+            "letsGo": "开始吧"
+        },
+        "congrats": {
+            "heading": "🎉 恭喜!",
+            "body": "您已完成金库设置。享受轻松的资产管理。",
+            "letsGo": "开始吧!"
+        },
+        "createBanner": {
+            "close": "关闭",
+            "title": "探索 Trezu",
+            "description": "创建账户以解锁 Trezu 所有功能与权益的访问权限。",
+            "cta": "创建金库"
+        },
+        "questionnaire": {
+            "continue": "继续",
+            "skip": "跳过"
+        },
+        "createPrompt": {
+            "title": "您即将就绪",
+            "description": "您的钱包已连接,但您尚未创建金库。请创建账户以开始使用 Trezu,或{suffix}",
+            "suffixDemo": "查看演示。",
+            "suffixExploring": "继续探索。",
+            "createCta": "创建金库",
+            "viewDemo": "查看演示",
+            "keepExploring": "继续探索"
+        },
+        "infoBox": {
+            "title": "更好地利用 Trezu",
+            "close": "关闭",
+            "description": "了解他人如何使用金库,试用演示,并查看文档以了解各项功能。",
+            "demoTitle": "探索 Trezu 演示",
+            "demoDescription": "查看一个实时的演示账户。",
+            "docsTitle": "文档",
+            "docsDescription": "在文档中了解所有功能。",
+            "videoTitle": "观看演示",
+            "videoDescription": "观看一段简短视频,了解 Trezu 的工作方式。"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds nine new UI locales alongside the existing English / Spanish / Ukrainian / Hebrew, expanding the language picker from 4 to 13 options:

| Code | Language |
|------|----------|
| \`de\` | Deutsch |
| \`fr\` | Français |
| \`vi\` | Tiếng Việt |
| \`zh\` | 中文 (Simplified) |
| \`tr\` | Türkçe |
| \`id\` | Bahasa Indonesia |
| \`pt\` | Português (Brazilian) |
| \`ja\` | 日本語 |
| \`ko\` | 한국어 |

For Portuguese / Japanese / Korean the translation pass also leaned on the human-reviewed Ukrainian and Spanish files for nuanced UX phrasing.

**Changes:**

- \`i18n/config\`: \`locales\` array extended; \`localeNames\` populated with native-script names.
- \`components/ui/datepicker\`: register 9 new \`date-fns\` locales (\`de\`, \`fr\`, \`vi\`, \`zh-CN\`, \`tr\`, \`id\`, \`pt\`, \`ja\`, \`ko\`) in \`DATE_FNS_LOCALES\` so \`DayPicker\` weekdays, month header, \`MonthYearPicker\` grid, and the popover trigger format all localize.
- \`components/language-switcher\`: new entries in \`labelKeyByLocale\`.
- \`messages/{de,fr,vi,zh,tr,id,pt,ja,ko}.json\`: full translations, perfect **1659-key parity** with \`en\` / \`es\` / \`uk\` / \`he\`.
  - ICU placeholders + rich-text tags (\`<bold>\`, \`<link>\`, \`<symbolTag>\`, \`<networkTag>\`, \`<amountTag>\`, \`<token>\`, \`<amount>\`, \`<br></br>\`, \`<terms>\`, \`<privacy>\`) preserved verbatim.
  - Plural categories adjusted per language rules — \`one\`/\`other\` for de/fr/pt; \`other\`-only collapse for vi/zh/ja/ko/id; tr uses identical singular form for both shapes.
  - Date placeholders, period codes (1W/1M/3M/1Y), and currency formats localized per region.
  - Proper nouns (Trezu, NEAR, Bitcoin, Ethereum, Telegram, Gnosis Safe, Fireblocks, Tholos, Squads Multisig, MPC Vault) kept Latin; CSV column header tokens kept English in parsing error messages.
- \`languageSwitcher.{german,french,vietnamese,chinese,turkish,indonesian,portuguese,japanese,korean}\` keys added across all 13 locale files.

Verified via headless browser: dashboard sidebar buttons render correctly in all 9 new locales. Build green.

## Test plan

- [ ] Open the language switcher — confirm 13 locale options visible with native-script labels
- [ ] Pick each new locale, sanity-check dashboard, requests, payments, members, settings, address-book — strings render in target language
- [ ] Open any DatePicker (Created Date filter, vesting form, export) — weekday/month names follow active locale
- [ ] Switch to a CJK locale (zh / ja / ko) — confirm period buttons (1周, 1ヶ月, 1주) render
- [ ] Plural-heavy strings (members selected, recipients count) format correctly per locale
- [ ] Reload after switching — cookie persists, locale sticks across nav
- [ ] Verify existing en/es/uk/he still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)