### PR TITLE
fix: apply short expiry only to non-wrap-near exchange flows

### DIFF
--- a/nt-be/src/handlers/proposals/scraper.rs
+++ b/nt-be/src/handlers/proposals/scraper.rs
@@ -349,6 +349,41 @@ fn get_current_time_nanos() -> U64 {
     U64::from(nanos as u64)
 }
 
+fn is_short_expiry_exchange(proposal: &Proposal) -> bool {
+    // First, gate short-expiry logic to exchange proposals only.
+    if AssetExchangeInfo::from_proposal(proposal).is_none() {
+        return false;
+    }
+
+    let Some(function_call) = proposal.kind.get("FunctionCall") else {
+        return false;
+    };
+
+    let receiver_id = function_call
+        .get("receiver_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let actions = function_call
+        .get("actions")
+        .and_then(|a| a.as_array())
+        .map(|a| a.as_slice())
+        .unwrap_or(&[]);
+
+    // Pure wrap/unwrap (single near_deposit/near_withdraw on wrap.near)
+    // follows normal proposal period, not short expiry.
+    if receiver_id == "wrap.near" && actions.len() == 1 {
+        let method_name = actions[0]
+            .get("method_name")
+            .and_then(|m| m.as_str())
+            .unwrap_or("");
+        if method_name == "near_deposit" || method_name == "near_withdraw" {
+            return false;
+        }
+    }
+
+    true
+}
+
 pub fn get_status_display(
     status: &ProposalStatus,
     submission_time: u64,
@@ -360,13 +395,11 @@ pub fn get_status_display(
         ProposalStatus::InProgress => {
             let current_time = get_current_time_nanos().0;
 
-            // For exchange proposals, use 24-hour expiration instead of policy period
+            // Exchange proposals use short expiration, except pure wrap/unwrap.
             let expiration_period = if let Some(p) = proposal {
-                if extract_from_description(&p.description, "proposalaction")
-                    == Some("asset-exchange".to_string())
-                {
-                    // 24 hours in nanoseconds
-                    24 * 60 * 60 * 1_000_000_000
+                if is_short_expiry_exchange(p) {
+                    // 1 hour in nanoseconds
+                    60 * 60 * 1_000_000_000
                 } else {
                     period
                 }
@@ -995,9 +1028,6 @@ impl ProposalType for AssetExchangeInfo {
                             .unwrap_or(""),
                     )
                     .to_string();
-                if proposal.id == 457 {
-                    println!("token_in_address: {:?}", token_in_address);
-                }
 
                 // Extract amount_in from args or description
                 let amount_in = json_args
@@ -1008,9 +1038,6 @@ impl ProposalType for AssetExchangeInfo {
                             .map(|s| s.parse::<u128>().unwrap_or(0))
                     })
                     .unwrap_or(0);
-                if proposal.id == 457 {
-                    println!("amount_in: {:?}", amount_in);
-                }
 
                 // Extract token_out from description
                 // Try both old format ("tokenOut") and new 1Click format ("Token Out Address")
@@ -1025,23 +1052,12 @@ impl ProposalType for AssetExchangeInfo {
                 let amount_out = extract_from_description(&proposal.description, "amountOut")
                     .or_else(|| extract_from_description(&proposal.description, "Amount Out"))
                     .unwrap_or_else(|| "0".to_string());
-                if proposal.id == 457 {
-                    println!("json_args: {:?}", json_args);
-                }
 
                 // Extract deposit_address from args
                 let deposit_address = json_args
                     .get("receiver_id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
-                if proposal.id == 457 {
-                    println!("proposal id: {}", proposal.id);
-                    println!("token_in_address: {:?}", token_in_address);
-                    println!("amount_in: {:?}", amount_in);
-                    println!("token_out_symbol: {:?}", token_out_symbol);
-                    println!("amount_out: {:?}", amount_out);
-                    println!("deposit_address: {:?}", deposit_address);
-                }
 
                 return Some(AssetExchangeInfo {
                     token_in_address,

--- a/nt-be/src/handlers/proposals/scraper.rs
+++ b/nt-be/src/handlers/proposals/scraper.rs
@@ -384,6 +384,15 @@ fn is_short_expiry_exchange(proposal: &Proposal) -> bool {
     true
 }
 
+fn get_effective_expiration_period_ns(proposal: &Proposal, period: u64) -> u64 {
+    if !is_short_expiry_exchange(proposal) {
+        return period;
+    }
+
+    // Exchange custom deadline is 24h, capped by proposal period.
+    std::cmp::min(period, 24 * 60 * 60 * 1_000_000_000)
+}
+
 pub fn get_status_display(
     status: &ProposalStatus,
     submission_time: u64,
@@ -395,14 +404,9 @@ pub fn get_status_display(
         ProposalStatus::InProgress => {
             let current_time = get_current_time_nanos().0;
 
-            // Exchange proposals use short expiration, except pure wrap/unwrap.
+            // Exchange proposals use custom 24h expiration, capped by proposal period.
             let expiration_period = if let Some(p) = proposal {
-                if is_short_expiry_exchange(p) {
-                    // 1 hour in nanoseconds
-                    60 * 60 * 1_000_000_000
-                } else {
-                    period
-                }
+                get_effective_expiration_period_ns(p, period)
             } else {
                 period
             };

--- a/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft } from "lucide-react";
-import { redirect, useRouter } from "next/navigation";
+import { redirect } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { trackEvent } from "@/lib/analytics";
 import { use, useEffect, useMemo, useState } from "react";
@@ -45,7 +44,6 @@ export default function RequestPage({ params }: RequestPageProps) {
     const t = useTranslations("pages.requests");
     const { id } = use(params);
     const { treasuryId } = useTreasury();
-    const router = useRouter();
     const queryClient = useQueryClient();
     const cachedSubmissionTime = useMemo(() => {
         const cachedQueries = queryClient.getQueriesData({

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -8,6 +8,7 @@ import { getApproversAndThreshold } from "@/lib/config-utils";
 import { useNear } from "@/stores/near-store";
 import { useTreasury } from "@/hooks/use-treasury";
 import {
+    EXCHANGE_EXPIRY_MS,
     getProposalStatus,
     UIProposalStatus,
     getProposalUIKind,
@@ -353,7 +354,9 @@ export function ProposalSidebar({
         ),
     );
     const statusDateInfo = getProposalStatusDateInfo(proposal, policy);
-    const shortExpiryExchange = isShortExpiryExchangeProposal(proposal);
+    const shortExpiryExchange =
+        isShortExpiryExchangeProposal(proposal) &&
+        nanosToMs(policy.proposal_period) > EXCHANGE_EXPIRY_MS;
 
     let timestamp;
     switch (status) {

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -11,7 +11,8 @@ import {
     getProposalStatus,
     UIProposalStatus,
     getProposalUIKind,
-    EXCHANGE_EXPIRY_MS,
+    getProposalStatusDateInfo,
+    isShortExpiryExchangeProposal,
 } from "@/features/proposals/utils/proposal-utils";
 import { useProposalInsufficientBalance } from "@/features/proposals/hooks/use-proposal-insufficient-balance";
 import { UserVote } from "../../user-vote";
@@ -351,21 +352,14 @@ export function ProposalSidebar({
                 .toFixed(0),
         ),
     );
-
-    // For exchange proposals, calculate 24-hour expiration
-    const exchange24HourExpiry = isExchangeProposal
-        ? new Date(nanosToMs(proposal.submission_time) + EXCHANGE_EXPIRY_MS)
-        : null;
+    const statusDateInfo = getProposalStatusDateInfo(proposal, policy);
+    const shortExpiryExchange = isShortExpiryExchangeProposal(proposal);
 
     let timestamp;
     switch (status) {
         case "Expired":
         case "Pending":
-            // Use 24-hour expiry for exchange proposals, otherwise use policy period
-            timestamp =
-                isExchangeProposal && exchange24HourExpiry
-                    ? exchange24HourExpiry
-                    : expiresAt;
+            timestamp = statusDateInfo.date;
             break;
 
         default:
@@ -525,8 +519,8 @@ export function ProposalSidebar({
                 </>
             )}
 
-            {/* Exchange Proposal 24-Hour Warning */}
-            {isPending && isExchangeProposal && exchange24HourExpiry && (
+            {/* Exchange Proposal Short-Expiry Warning */}
+            {isPending && shortExpiryExchange && (
                 <InfoAlert
                     className="inline-flex"
                     message={

--- a/nt-fe/features/proposals/components/voting-duration-impact-modal.tsx
+++ b/nt-fe/features/proposals/components/voting-duration-impact-modal.tsx
@@ -80,12 +80,14 @@ export function VotingDurationImpactModal({
                 // voting-duration policy changes.
                 const oldExpiryDate = new Date(
                     isShortExpiryExchange
-                        ? submissionTimeMs + EXCHANGE_EXPIRY_MS
+                        ? submissionTimeMs +
+                              Math.min(currentDurationMs, EXCHANGE_EXPIRY_MS)
                         : submissionTimeMs + currentDurationMs,
                 );
                 const newExpiryDate = new Date(
                     isShortExpiryExchange
-                        ? submissionTimeMs + EXCHANGE_EXPIRY_MS
+                        ? submissionTimeMs +
+                              Math.min(newDurationMs, EXCHANGE_EXPIRY_MS)
                         : submissionTimeMs + newDurationMs,
                 );
 

--- a/nt-fe/features/proposals/components/voting-duration-impact-modal.tsx
+++ b/nt-fe/features/proposals/components/voting-duration-impact-modal.tsx
@@ -20,6 +20,7 @@ import { TransactionCell } from "@/features/proposals/components/transaction-cel
 import {
     EXCHANGE_EXPIRY_MS,
     getProposalUIKind,
+    isShortExpiryExchangeProposal,
 } from "@/features/proposals/utils/proposal-utils";
 import { useProposalKindLabel } from "@/features/proposals/hooks/use-proposal-kind-label";
 import { FormattedDate } from "@/components/formatted-date";
@@ -72,18 +73,18 @@ export function VotingDurationImpactModal({
         return activeProposals
             .map((proposal): ProposalImpact => {
                 const submissionTimeMs = nanosToMs(proposal.submission_time);
-                const proposalType = getProposalUIKind(proposal);
-                const isExchangeProposal = proposalType === "Exchange";
+                const isShortExpiryExchange =
+                    isShortExpiryExchangeProposal(proposal);
 
-                // Exchange requests always expire in 24h and are unaffected by
+                // Short-expiry exchanges are unaffected by
                 // voting-duration policy changes.
                 const oldExpiryDate = new Date(
-                    isExchangeProposal
+                    isShortExpiryExchange
                         ? submissionTimeMs + EXCHANGE_EXPIRY_MS
                         : submissionTimeMs + currentDurationMs,
                 );
                 const newExpiryDate = new Date(
-                    isExchangeProposal
+                    isShortExpiryExchange
                         ? submissionTimeMs + EXCHANGE_EXPIRY_MS
                         : submissionTimeMs + newDurationMs,
                 );

--- a/nt-fe/features/proposals/utils/proposal-utils.ts
+++ b/nt-fe/features/proposals/utils/proposal-utils.ts
@@ -10,15 +10,13 @@ import {
     SwapRequestData,
     VestingData,
 } from "../types/index";
-import { decodeArgs, decodeProposalDescription } from "@/lib/utils";
+import { decodeArgs, decodeProposalDescription, nanosToMs } from "@/lib/utils";
 import { extractProposalData } from "./proposal-extractors";
 
-// Short-expiry exchange proposal constants.
+// Exchange custom deadline (capped by proposal_period).
 // Pure wrap/unwrap (single wrap.near near_deposit/near_withdraw) uses normal proposal period.
-export const EXCHANGE_EXPIRY_HOURS = 1;
-export const EXCHANGE_EXPIRY_NS =
-    EXCHANGE_EXPIRY_HOURS * 60 * 60 * 1_000_000_000; // 1 hour in nanoseconds
-export const EXCHANGE_EXPIRY_MS = EXCHANGE_EXPIRY_HOURS * 60 * 60 * 1000; // 1 hour in milliseconds
+export const EXCHANGE_EXPIRY_HOURS = 24;
+export const EXCHANGE_EXPIRY_MS = EXCHANGE_EXPIRY_HOURS * 60 * 60 * 1000; // 24 hours in milliseconds
 
 const BULK_PAYMENT_CONTRACT_ID =
     process.env.NEXT_PUBLIC_BULK_PAYMENT_CONTRACT_ID || "bulkpayment.near";
@@ -317,12 +315,20 @@ export function isShortExpiryExchangeProposal(proposal: Proposal): boolean {
     return isExchangeProposal && !isNormalPeriodWrapProposal(proposal);
 }
 
+function getEffectiveExpiryPeriodMs(
+    proposal: Proposal,
+    policy: Policy,
+): number {
+    const proposalPeriodMs = nanosToMs(policy.proposal_period);
+    if (!isShortExpiryExchangeProposal(proposal)) return proposalPeriodMs;
+    return Math.min(proposalPeriodMs, EXCHANGE_EXPIRY_MS);
+}
+
 export function getProposalStatus(
     proposal: Proposal,
     policy: Policy,
 ): UIProposalStatus {
-    const proposalPeriod = parseInt(policy.proposal_period);
-    const submissionTime = parseInt(proposal.submission_time);
+    const submissionTimeMs = nanosToMs(proposal.submission_time);
 
     switch (proposal.status) {
         case "Approved":
@@ -332,18 +338,11 @@ export function getProposalStatus(
         case "Failed":
             return "Failed";
         case "InProgress":
-            // Exchange proposals use short expiry, except pure wrap/unwrap.
-            if (isShortExpiryExchangeProposal(proposal)) {
-                if (
-                    (submissionTime + EXCHANGE_EXPIRY_NS) / 1_000_000 <
-                    Date.now()
-                ) {
-                    return "Expired";
-                }
-            }
-
-            // Check if proposal has expired based on policy period
-            if ((submissionTime + proposalPeriod) / 1_000_000 < Date.now()) {
+            if (
+                submissionTimeMs +
+                    getEffectiveExpiryPeriodMs(proposal, policy) <
+                Date.now()
+            ) {
                 return "Expired";
             }
 
@@ -366,23 +365,19 @@ export function getProposalStatusDateInfo(
     proposal: Proposal,
     policy: Policy,
 ): { date: Date; isFuture: boolean; labelKey: StatusDateLabelKey | null } {
-    const submissionTime = parseInt(proposal.submission_time);
+    const submissionTimeMs = nanosToMs(proposal.submission_time);
     const uiStatus = getProposalStatus(proposal, policy);
 
     if (uiStatus === "Pending") {
-        // Expiry = submission_time + proposal_period (nanoseconds → ms)
-        const proposalPeriod = parseInt(policy.proposal_period);
-        // Exchange proposals use short expiry, except pure wrap/unwrap.
-        const expiryNs = isShortExpiryExchangeProposal(proposal)
-            ? submissionTime + EXCHANGE_EXPIRY_NS
-            : submissionTime + proposalPeriod;
-        const expiryDate = new Date(expiryNs / 1_000_000);
+        const expiryDate = new Date(
+            submissionTimeMs + getEffectiveExpiryPeriodMs(proposal, policy),
+        );
         return { date: expiryDate, isFuture: true, labelKey: "expires" };
     }
 
     // For all resolved statuses, use submission_time as a fallback since
     // the API doesn't provide a separate execution timestamp.
-    const submissionDate = new Date(submissionTime / 1_000_000);
+    const submissionDate = new Date(submissionTimeMs);
 
     switch (uiStatus) {
         case "Executed":
@@ -404,13 +399,9 @@ export function getProposalStatusDateInfo(
                 labelKey: "created",
             };
         case "Expired": {
-            // Exchange proposals expire after short period, except pure wrap/unwrap.
-            const expiredDate = isShortExpiryExchangeProposal(proposal)
-                ? new Date(submissionTime / 1_000_000 + EXCHANGE_EXPIRY_MS)
-                : new Date(
-                      (submissionTime + parseInt(policy.proposal_period)) /
-                          1_000_000,
-                  );
+            const expiredDate = new Date(
+                submissionTimeMs + getEffectiveExpiryPeriodMs(proposal, policy),
+            );
             return {
                 date: expiredDate,
                 isFuture: false,

--- a/nt-fe/features/proposals/utils/proposal-utils.ts
+++ b/nt-fe/features/proposals/utils/proposal-utils.ts
@@ -13,11 +13,12 @@ import {
 import { decodeArgs, decodeProposalDescription } from "@/lib/utils";
 import { extractProposalData } from "./proposal-extractors";
 
-// Exchange proposal expiration constants
-export const EXCHANGE_EXPIRY_HOURS = 24;
+// Short-expiry exchange proposal constants.
+// Pure wrap/unwrap (single wrap.near near_deposit/near_withdraw) uses normal proposal period.
+export const EXCHANGE_EXPIRY_HOURS = 1;
 export const EXCHANGE_EXPIRY_NS =
-    EXCHANGE_EXPIRY_HOURS * 60 * 60 * 1_000_000_000; // 24 hours in nanoseconds
-export const EXCHANGE_EXPIRY_MS = EXCHANGE_EXPIRY_HOURS * 60 * 60 * 1000; // 24 hours in milliseconds
+    EXCHANGE_EXPIRY_HOURS * 60 * 60 * 1_000_000_000; // 1 hour in nanoseconds
+export const EXCHANGE_EXPIRY_MS = EXCHANGE_EXPIRY_HOURS * 60 * 60 * 1000; // 1 hour in milliseconds
 
 const BULK_PAYMENT_CONTRACT_ID =
     process.env.NEXT_PUBLIC_BULK_PAYMENT_CONTRACT_ID || "bulkpayment.near";
@@ -297,6 +298,25 @@ export type UIProposalStatus =
     | "Removed"
     | "Moved";
 
+function isNormalPeriodWrapProposal(proposal: Proposal): boolean {
+    if (!("FunctionCall" in proposal.kind)) return false;
+
+    const functionCall = proposal.kind.FunctionCall;
+    const actions = functionCall.actions ?? [];
+
+    if (functionCall.receiver_id !== "wrap.near" || actions.length !== 1) {
+        return false;
+    }
+
+    const methodName = actions[0]?.method_name;
+    return methodName === "near_deposit" || methodName === "near_withdraw";
+}
+
+export function isShortExpiryExchangeProposal(proposal: Proposal): boolean {
+    const isExchangeProposal = getProposalUIKind(proposal) === "Exchange";
+    return isExchangeProposal && !isNormalPeriodWrapProposal(proposal);
+}
+
 export function getProposalStatus(
     proposal: Proposal,
     policy: Policy,
@@ -312,9 +332,8 @@ export function getProposalStatus(
         case "Failed":
             return "Failed";
         case "InProgress":
-            // For exchange proposals, check if 24 hours have passed
-            const proposalType = getProposalUIKind(proposal);
-            if (proposalType === "Exchange") {
+            // Exchange proposals use short expiry, except pure wrap/unwrap.
+            if (isShortExpiryExchangeProposal(proposal)) {
                 if (
                     (submissionTime + EXCHANGE_EXPIRY_NS) / 1_000_000 <
                     Date.now()
@@ -353,12 +372,10 @@ export function getProposalStatusDateInfo(
     if (uiStatus === "Pending") {
         // Expiry = submission_time + proposal_period (nanoseconds → ms)
         const proposalPeriod = parseInt(policy.proposal_period);
-        // For exchange proposals, use the shorter 24h expiry
-        const proposalType = getProposalUIKind(proposal);
-        const expiryNs =
-            proposalType === "Exchange"
-                ? submissionTime + EXCHANGE_EXPIRY_NS
-                : submissionTime + proposalPeriod;
+        // Exchange proposals use short expiry, except pure wrap/unwrap.
+        const expiryNs = isShortExpiryExchangeProposal(proposal)
+            ? submissionTime + EXCHANGE_EXPIRY_NS
+            : submissionTime + proposalPeriod;
         const expiryDate = new Date(expiryNs / 1_000_000);
         return { date: expiryDate, isFuture: true, labelKey: "expires" };
     }
@@ -387,15 +404,13 @@ export function getProposalStatusDateInfo(
                 labelKey: "created",
             };
         case "Expired": {
-            // Exchange proposals expire after 24h, others after proposal_period
-            const proposalType = getProposalUIKind(proposal);
-            const expiredDate =
-                proposalType === "Exchange"
-                    ? new Date(submissionTime / 1_000_000 + EXCHANGE_EXPIRY_MS)
-                    : new Date(
-                          (submissionTime + parseInt(policy.proposal_period)) /
-                              1_000_000,
-                      );
+            // Exchange proposals expire after short period, except pure wrap/unwrap.
+            const expiredDate = isShortExpiryExchangeProposal(proposal)
+                ? new Date(submissionTime / 1_000_000 + EXCHANGE_EXPIRY_MS)
+                : new Date(
+                      (submissionTime + parseInt(policy.proposal_period)) /
+                          1_000_000,
+                  );
             return {
                 date: expiredDate,
                 isFuture: false,


### PR DESCRIPTION
Short expiry now applies only to true exchange execution flows. Single-action `wrap.near` `near_deposit`/`near_withdraw` requests follow the standard proposal period, preventing them from being marked expired early and still appearing under Pending due to backend/frontend mismatch.

Fixes issue reported by Olha: expired exchange shown in [Pending](https://trezu.app/yurtur-empty-treasury.sputnik-dao.near/requests/16)
<img width="1280" height="589" alt="image" src="https://github.com/user-attachments/assets/dbac1871-5926-42f4-9417-b1197a6e30c5" />
