### PR TITLE
feat: add rule-based network sections for guest confidential flows

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -23,6 +23,7 @@ import { type BridgeNetwork, useBridgeTokens } from "@/hooks/use-bridge-tokens";
 import { useTreasury } from "@/hooks/use-treasury";
 import Big from "@/lib/big";
 import { fetchDepositAddress } from "@/lib/bridge-api";
+import { buildSectionedOptions } from "@/lib/section-rules";
 import { formatBalance, formatSmartAmount } from "@/lib/utils";
 import { useThemeStore } from "@/stores/theme-store";
 import { SelectModal } from "./select-modal";
@@ -109,7 +110,7 @@ export function DepositModal({
             }),
         [t],
     );
-    const { treasuryId, isConfidential } = useTreasury();
+    const { treasuryId, isConfidential, isGuestTreasury } = useTreasury();
     const { theme } = useThemeStore();
     const {
         data: { tokens: treasuryAssets } = { tokens: STABLE_EMPTY_ARRAY },
@@ -193,6 +194,20 @@ export function DepositModal({
     }, [selectedAsset, selectedNetwork, bridgeAssets]);
 
     const networkSections = useMemo(() => {
+        if (isConfidential && isGuestTreasury) {
+            return buildSectionedOptions(filteredNetworks, [
+                {
+                    title: t("sections.available"),
+                    filter: (network) => network.id === NEAR_DIRECT_NETWORK_ID,
+                },
+                {
+                    title: t("sections.forMembersOnly"),
+                    filter: () => true,
+                    disabled: true,
+                },
+            ]);
+        }
+
         const withAssets = filteredNetworks
             .filter((network) => {
                 const balance = selectedNetworkBalances.get(network.id);
@@ -235,7 +250,13 @@ export function DepositModal({
                 options: supportedNetworks,
             },
         ];
-    }, [filteredNetworks, selectedNetworkBalances, t]);
+    }, [
+        filteredNetworks,
+        selectedNetworkBalances,
+        isConfidential,
+        isGuestTreasury,
+        t,
+    ]);
 
     useEffect(() => {
         if (!isOpen || !bridgeAssets.length) return;

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/select-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/select-modal.tsx
@@ -145,8 +145,10 @@ export function SelectModal({
                 variant="ghost"
                 disabled={item.disabled}
                 className={cn(
-                    "w-full flex items-center gap-1 py-3 rounded-lg h-auto justify-start pl-1!",
-                    selectedId === item.id && "bg-muted",
+                    "w-full flex items-center gap-1 py-2.5 rounded-lg h-auto justify-start pl-1.5! mx-1 my-0.5",
+                    selectedId === item.id
+                        ? "bg-muted hover:bg-muted focus-visible:bg-muted"
+                        : "hover:bg-transparent focus-visible:bg-transparent",
                     item.disabled &&
                         "opacity-60 cursor-not-allowed pointer-events-none",
                 )}

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
@@ -26,7 +26,12 @@ import { NetworkList } from "@/components/network-list";
 import { Button } from "@/components/button";
 import { UserWithData } from "@/components/user";
 import { FormField } from "@/components/ui/form";
-import { RecipientNetworkSelect } from "./recipient-network-select";
+import { type SectionRule } from "@/lib/section-rules";
+import {
+    NEAR_COM_NETWORK_ID,
+    RecipientNetworkSelect,
+    type RecipientNetworkRuleOption,
+} from "./recipient-network-select";
 import { cn } from "@/lib/utils";
 
 interface PaymentFormSectionProps<
@@ -86,6 +91,7 @@ export function PaymentFormSection<
     hideRecipientNetwork = false,
 }: PaymentFormSectionProps<TFieldValues, TTokenPath>) {
     const t = useTranslations("paymentFormSection");
+    const tRecipientNetwork = useTranslations("recipientNetworkSelect");
     const { setValue, setError, clearErrors } = useFormContext<TFieldValues>();
     const [isRecipientValid, setIsRecipientValid] = useState(false);
     const [isValidatingRecipient, setIsValidatingRecipient] = useState(false);
@@ -126,7 +132,60 @@ export function PaymentFormSection<
         [recipientName, setValue],
     );
 
-    const { isConfidential } = useTreasury();
+    const { isConfidential, isGuestTreasury } = useTreasury();
+
+    const networkSectionRules = useMemo<
+        SectionRule<RecipientNetworkRuleOption>[]
+    >(() => {
+        if (isConfidential && isGuestTreasury) {
+            return [
+                {
+                    title: tRecipientNetwork("available"),
+                    filter: (option) => option.id === NEAR_COM_NETWORK_ID,
+                },
+                {
+                    title: tRecipientNetwork("forMembersOnly"),
+                    filter: () => true,
+                    disabled: true,
+                },
+            ];
+        }
+
+        const contactSet = new Set(selectedContact?.networks ?? []);
+        if (contactSet.size > 0) {
+            return [
+                {
+                    title: tRecipientNetwork("fromAddressBook"),
+                    filter: (option) =>
+                        option.isCompatible &&
+                        contactSet.has(option.networkName),
+                },
+                {
+                    title: tRecipientNetwork("otherAvailable"),
+                    filter: (option) =>
+                        option.isCompatible &&
+                        !contactSet.has(option.networkName),
+                },
+                {
+                    title: tRecipientNetwork("incompatible"),
+                    filter: (option) => !option.isCompatible,
+                    disabled: true,
+                },
+            ];
+        }
+
+        return [
+            {
+                title: tRecipientNetwork("available"),
+                filter: (option) => option.isCompatible,
+            },
+            {
+                title: tRecipientNetwork("incompatible"),
+                filter: (option) => !option.isCompatible,
+                disabled: true,
+            },
+        ];
+    }, [isConfidential, isGuestTreasury, selectedContact, tRecipientNetwork]);
 
     // For bulk (hideRecipientNetwork=true) we still validate against token's
     // chain. When the network selector is shown, the recipient input runs in
@@ -363,7 +422,7 @@ export function PaymentFormSection<
                         <RecipientNetworkSelect
                             value={(field.value as string | undefined) ?? ""}
                             recipient={recipient}
-                            contactNetworks={selectedContact?.networks}
+                            sectionRules={networkSectionRules}
                             onChange={(id) => {
                                 field.onChange(id);
                             }}
@@ -379,7 +438,6 @@ export function PaymentFormSection<
                                     );
                                 }
                             }}
-                            isConfidential={isConfidential}
                             token={token}
                         />
                     )}

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
@@ -18,7 +18,6 @@ import AccountInput from "@/components/account-input";
 import { CreateRequestButton } from "@/components/create-request-button";
 import { InfoAlert } from "@/components/info-alert";
 import { getBlockchainType } from "@/lib/blockchain-utils";
-import { useTreasury } from "@/hooks/use-treasury";
 import { useAddressBook, AddressBookEntry } from "@/features/address-book";
 import { SelectModal } from "@/app/(treasury)/[treasuryId]/dashboard/components/select-modal";
 import { useChains, ChainInfo } from "@/features/address-book/chains";
@@ -28,7 +27,6 @@ import { UserWithData } from "@/components/user";
 import { FormField } from "@/components/ui/form";
 import { type SectionRule } from "@/lib/section-rules";
 import {
-    NEAR_COM_NETWORK_ID,
     RecipientNetworkSelect,
     type RecipientNetworkRuleOption,
 } from "./recipient-network-select";
@@ -121,6 +119,10 @@ export function PaymentFormSection<
     const token = watched[0];
     const recipient = (watched[1] ?? "") as string;
     const selectedNetworkName = (watched[2] ?? "") as string;
+    const amountValue = useWatch({
+        control,
+        name: amountName,
+    }) as unknown as string | number | undefined;
     const setRecipientValue = useCallback(
         (value: PathValue<TFieldValues, Path<TFieldValues>>) => {
             setValue(recipientName, value, {
@@ -132,25 +134,9 @@ export function PaymentFormSection<
         [recipientName, setValue],
     );
 
-    const { isConfidential, isGuestTreasury } = useTreasury();
-
     const networkSectionRules = useMemo<
         SectionRule<RecipientNetworkRuleOption>[]
     >(() => {
-        if (isConfidential && isGuestTreasury) {
-            return [
-                {
-                    title: tRecipientNetwork("available"),
-                    filter: (option) => option.id === NEAR_COM_NETWORK_ID,
-                },
-                {
-                    title: tRecipientNetwork("forMembersOnly"),
-                    filter: () => true,
-                    disabled: true,
-                },
-            ];
-        }
-
         const contactSet = new Set(selectedContact?.networks ?? []);
         if (contactSet.size > 0) {
             return [
@@ -185,7 +171,7 @@ export function PaymentFormSection<
                 disabled: true,
             },
         ];
-    }, [isConfidential, isGuestTreasury, selectedContact, tRecipientNetwork]);
+    }, [selectedContact, tRecipientNetwork]);
 
     // For bulk (hideRecipientNetwork=true) we still validate against token's
     // chain. When the network selector is shown, the recipient input runs in
@@ -198,6 +184,11 @@ export function PaymentFormSection<
     }, [hideRecipientNetwork, selectedNetworkName]);
 
     const hasSelectedNetwork = !!selectedNetworkName;
+    const hasValidAmount = useMemo(() => {
+        if (amountValue === null || amountValue === undefined) return false;
+        const parsed = Number(amountValue);
+        return Number.isFinite(parsed) && parsed > 0;
+    }, [amountValue]);
 
     // Sync fee coverage error into the amount field.
     useEffect(() => {
@@ -291,6 +282,7 @@ export function PaymentFormSection<
     );
 
     const isSaveDisabled =
+        !hasValidAmount ||
         !recipient ||
         (hideRecipientNetwork && !isRecipientValid) ||
         (!hideRecipientNetwork && !hasSelectedNetwork) ||

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -13,6 +13,7 @@ import { useBridgeTokens } from "@/hooks/use-bridge-tokens";
 import { isValidAddress } from "@/lib/address-validation";
 import { getBlockchainType } from "@/lib/blockchain-utils";
 import { isValidNearAddressFormat } from "@/lib/near-validation";
+import { buildSectionedOptions, type SectionRule } from "@/lib/section-rules";
 import { cn } from "@/lib/utils";
 import { useThemeStore } from "@/stores/theme-store";
 
@@ -30,7 +31,6 @@ export interface RecipientNetworkOption {
 interface RecipientNetworkSelectProps {
     value: string;
     onChange: (networkId: string) => void;
-    isConfidential: boolean;
     token: Token | null;
     /**
      * Recipient address entered by the user. Drives compatibility split in
@@ -38,26 +38,17 @@ interface RecipientNetworkSelectProps {
      * in a separate "Incompatible" section and disabled.
      */
     recipient: string;
-    /**
-     * Chain keys attached to the selected address-book contact. When present
-     * and non-empty, compatible options are split into "Available" (keys
-     * matching the contact) and "Other Available" (remaining compatible).
-     */
-    contactNetworks?: string[];
+    sectionRules: SectionRule<RecipientNetworkRuleOption>[];
     /**
      * Fires when the user picks a network. Carries the raw network name so
      * callers can derive blockchain type (for downstream address validation).
      */
     onNetworkChange?: (option: RecipientNetworkOption) => void;
-    /**
-     * Returns the list of coming-soon networks. Receives the available
-     * networks so the consumer can filter its own pool against them.
-     * Reserved for future bulk-payment use.
-     */
-    comingSoonFilter?: (
-        available: RecipientNetworkOption[],
-    ) => RecipientNetworkOption[];
 }
+
+export type RecipientNetworkRuleOption = RecipientNetworkOption & {
+    isCompatible: boolean;
+};
 
 function isAddressCompatibleWithNetwork(
     address: string,
@@ -118,9 +109,8 @@ export function RecipientNetworkSelect({
     onChange,
     token,
     recipient,
-    contactNetworks,
+    sectionRules,
     onNetworkChange,
-    comingSoonFilter,
 }: RecipientNetworkSelectProps) {
     const t = useTranslations("recipientNetworkSelect");
     const { theme } = useThemeStore();
@@ -169,116 +159,45 @@ export function RecipientNetworkSelect({
         [nearComOption, tokenNetworkOptions],
     );
 
-    const comingSoonOptions = useMemo(
-        () => comingSoonFilter?.(availableOptions) ?? [],
-        [availableOptions, comingSoonFilter],
-    );
-
     const selectedOption = useMemo(() => {
         if (!value) return null;
         if (value === NEAR_COM_NETWORK_ID) return nearComOption;
         return availableOptions.find((o) => o.id === value) ?? null;
     }, [availableOptions, nearComOption, value]);
 
-    const { compatibleOptions, incompatibleOptions } = useMemo(() => {
-        const compatible: RecipientNetworkOption[] = [];
-        const incompatible: RecipientNetworkOption[] = [];
-        for (const o of availableOptions) {
-            if (isAddressCompatibleWithNetwork(recipient, o.networkName)) {
-                compatible.push(o);
-            } else {
-                incompatible.push(o);
-            }
-        }
-        return {
-            compatibleOptions: compatible,
-            incompatibleOptions: incompatible,
-        };
+    const enrichedOptions = useMemo(() => {
+        return availableOptions.map((option) => ({
+            ...option,
+            isCompatible: isAddressCompatibleWithNetwork(
+                recipient,
+                option.networkName,
+            ),
+        }));
     }, [availableOptions, recipient]);
 
+    const compatibleOptions = useMemo(
+        () => enrichedOptions.filter((option) => option.isCompatible),
+        [enrichedOptions],
+    );
+
     const sections = useMemo(() => {
-        const out: {
-            title: string;
-            options: {
-                id: string;
-                name: string;
-                icon: string;
-                disabled?: boolean;
-                _option: RecipientNetworkOption;
-                _disabled?: boolean;
-            }[];
-        }[] = [];
-
-        const compatible = compatibleOptions;
-        const incompatible = incompatibleOptions;
-
-        const hasContactSplit = !!contactNetworks && contactNetworks.length > 0;
-        const contactSet = new Set(contactNetworks ?? []);
-        const inContact = (o: RecipientNetworkOption) =>
-            contactSet.has(o.networkName);
-
-        const mapOption = (o: RecipientNetworkOption) => ({
-            id: o.id,
-            name: o.name,
-            icon: "",
-            _option: o,
-        });
-
-        if (hasContactSplit) {
-            const primary = compatible.filter(inContact);
-            const other = compatible.filter((o) => !inContact(o));
-            if (primary.length > 0) {
-                out.push({
-                    title: t("fromAddressBook"),
-                    options: primary.map(mapOption),
-                });
-            }
-            if (other.length > 0) {
-                out.push({
-                    title: t("otherAvailable"),
-                    options: other.map(mapOption),
-                });
-            }
-        } else if (compatible.length > 0) {
-            out.push({
-                title: t("available"),
-                options: compatible.map(mapOption),
-            });
-        }
-        if (incompatible.length > 0) {
-            out.push({
-                title: t("incompatible"),
-                options: incompatible.map((o) => ({
-                    id: o.id,
-                    name: o.name,
-                    icon: "",
-                    disabled: true,
-                    _option: o,
-                    _disabled: true,
-                })),
-            });
-        }
-        if (comingSoonOptions.length > 0) {
-            out.push({
-                title: t("comingSoon"),
-                options: comingSoonOptions.map((o) => ({
-                    id: o.id,
-                    name: o.name,
-                    icon: "",
-                    disabled: true,
-                    _option: o,
-                    _disabled: true,
-                })),
-            });
-        }
-        return out;
-    }, [
-        compatibleOptions,
-        incompatibleOptions,
-        comingSoonOptions,
-        contactNetworks,
-        t,
-    ]);
+        return buildSectionedOptions(enrichedOptions, sectionRules).map(
+            (section) => ({
+                title: section.title,
+                options: section.options.map((option) => {
+                    const { isCompatible: _ignored, ...rawOption } = option;
+                    return {
+                        id: option.id,
+                        name: option.name,
+                        icon: "",
+                        disabled: option.disabled,
+                        _option: rawOption,
+                        _disabled: option.disabled,
+                    };
+                }),
+            }),
+        );
+    }, [enrichedOptions, sectionRules]);
 
     const hasCompatibleNetwork = compatibleOptions.length > 0;
     const isDisabled = !recipient || !hasCompatibleNetwork;

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -241,7 +241,7 @@ export function RecipientNetworkSelect({
                     variant="ghost"
                     onClick={() => setOpen(true)}
                     disabled={isDisabled}
-                    className="w-full h-12 justify-between px-0! hover:bg-transparent disabled:opacity-100"
+                    className="w-full h-12 justify-between px-0! hover:bg-transparent dark:hover:bg-transparent focus-visible:bg-transparent dark:focus-visible:bg-transparent disabled:opacity-100"
                 >
                     {selectedOption && !isDisabled ? (
                         <NetworkRow option={selectedOption} />

--- a/nt-fe/lib/section-rules.ts
+++ b/nt-fe/lib/section-rules.ts
@@ -1,0 +1,46 @@
+export interface SectionRule<T> {
+    title: string;
+    filter: (option: T) => boolean;
+    disabled?: boolean;
+}
+
+export interface Section<T> {
+    title: string;
+    options: (T & { disabled?: boolean })[];
+}
+
+export function buildSectionedOptions<T extends { id: string }>(
+    options: T[],
+    rules: SectionRule<T>[],
+): Section<T>[] {
+    const remaining = [...options];
+    const sections: Section<T>[] = [];
+
+    for (const rule of rules) {
+        const matched: T[] = [];
+        const unmatched: T[] = [];
+
+        for (const option of remaining) {
+            if (rule.filter(option)) {
+                matched.push(option);
+            } else {
+                unmatched.push(option);
+            }
+        }
+
+        remaining.splice(0, remaining.length, ...unmatched);
+
+        if (matched.length === 0) {
+            continue;
+        }
+
+        sections.push({
+            title: rule.title,
+            options: matched.map((option) =>
+                rule.disabled ? { ...option, disabled: true } : option,
+            ),
+        });
+    }
+
+    return sections;
+}

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "Unterstützte Netzwerke",
             "networksWithAssets": "Netzwerke mit Vermögenswerten",
             "yourAssets": "Ihre Vermögenswerte",
-            "otherAssets": "Andere Vermögenswerte"
+            "otherAssets": "Andere Vermögenswerte",
+            "available": "Verfügbar",
+            "forMembersOnly": "Nur für Mitglieder"
         },
         "errors": {
             "addressUnavailable": "Einzahlungsadresse für den ausgewählten Vermögenswert und das Netzwerk konnte nicht abgerufen werden.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "Andere verfügbar",
         "incompatible": "Inkompatibel",
         "comingSoon": "Demnächst verfügbar",
+        "forMembersOnly": "Nur für Mitglieder",
         "nearComName": "near.com",
         "nearComDescription": "Internes Netzwerk für near.com und Trezu"
     },

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "Supported Networks",
             "networksWithAssets": "Networks with Assets",
             "yourAssets": "Your Assets",
-            "otherAssets": "Other Assets"
+            "otherAssets": "Other Assets",
+            "available": "Available",
+            "forMembersOnly": "For Members Only"
         },
         "errors": {
             "addressUnavailable": "Could not retrieve deposit address for the selected asset and network.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "Other Available",
         "incompatible": "Incompatible",
         "comingSoon": "Coming Soon",
+        "forMembersOnly": "For Members Only",
         "nearComName": "near.com",
         "nearComDescription": "Internal Network for near.com and trezu"
     },

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "Redes compatibles",
             "networksWithAssets": "Redes con activos",
             "yourAssets": "Tus activos",
-            "otherAssets": "Otros activos"
+            "otherAssets": "Otros activos",
+            "available": "Disponible",
+            "forMembersOnly": "Solo para miembros"
         },
         "errors": {
             "addressUnavailable": "No se pudo obtener la dirección de depósito para el activo y la red seleccionados.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "Otras disponibles",
         "incompatible": "Incompatible",
         "comingSoon": "Próximamente",
+        "forMembersOnly": "Solo para miembros",
         "nearComName": "near.com",
         "nearComDescription": "Red interna para near.com y trezu"
     },

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "Réseaux pris en charge",
             "networksWithAssets": "Réseaux avec actifs",
             "yourAssets": "Vos actifs",
-            "otherAssets": "Autres actifs"
+            "otherAssets": "Autres actifs",
+            "available": "Disponible",
+            "forMembersOnly": "Réservé aux membres"
         },
         "errors": {
             "addressUnavailable": "Impossible de récupérer l'adresse de dépôt pour l'actif et le réseau sélectionnés.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "Autres disponibles",
         "incompatible": "Incompatible",
         "comingSoon": "Bientôt disponible",
+        "forMembersOnly": "Réservé aux membres",
         "nearComName": "near.com",
         "nearComDescription": "Réseau interne pour near.com et trezu"
     },

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "רשתות נתמכות",
             "networksWithAssets": "רשתות עם נכסים",
             "yourAssets": "הנכסים שלך",
-            "otherAssets": "נכסים אחרים"
+            "otherAssets": "נכסים אחרים",
+            "available": "זמין",
+            "forMembersOnly": "לחברים בלבד"
         },
         "errors": {
             "addressUnavailable": "לא ניתן היה לאחזר כתובת הפקדה עבור הנכס והרשת שנבחרו.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "זמינים אחרים",
         "incompatible": "לא תואם",
         "comingSoon": "בקרוב",
+        "forMembersOnly": "לחברים בלבד",
         "nearComName": "near.com",
         "nearComDescription": "רשת פנימית עבור near.com ו-Trezu"
     },

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "Jaringan yang Didukung",
             "networksWithAssets": "Jaringan dengan Aset",
             "yourAssets": "Aset Anda",
-            "otherAssets": "Aset Lainnya"
+            "otherAssets": "Aset Lainnya",
+            "available": "Tersedia",
+            "forMembersOnly": "Hanya untuk anggota"
         },
         "errors": {
             "addressUnavailable": "Tidak dapat mengambil alamat deposit untuk aset dan jaringan yang dipilih.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "Tersedia Lainnya",
         "incompatible": "Tidak Kompatibel",
         "comingSoon": "Segera Hadir",
+        "forMembersOnly": "Hanya untuk anggota",
         "nearComName": "near.com",
         "nearComDescription": "Jaringan Internal untuk near.com dan trezu"
     },

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "対応ネットワーク",
             "networksWithAssets": "資産のあるネットワーク",
             "yourAssets": "あなたの資産",
-            "otherAssets": "その他の資産"
+            "otherAssets": "その他の資産",
+            "available": "利用可能",
+            "forMembersOnly": "メンバー限定"
         },
         "errors": {
             "addressUnavailable": "選択した資産とネットワークの入金アドレスを取得できませんでした。",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "その他の利用可能",
         "incompatible": "非互換",
         "comingSoon": "近日公開",
+        "forMembersOnly": "メンバー限定",
         "nearComName": "near.com",
         "nearComDescription": "near.comとtrezuの内部ネットワーク"
     },

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "지원 네트워크",
             "networksWithAssets": "자산이 있는 네트워크",
             "yourAssets": "내 자산",
-            "otherAssets": "기타 자산"
+            "otherAssets": "기타 자산",
+            "available": "사용 가능",
+            "forMembersOnly": "회원 전용"
         },
         "errors": {
             "addressUnavailable": "선택한 자산과 네트워크에 대한 입금 주소를 가져올 수 없습니다.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "기타 사용 가능",
         "incompatible": "호환되지 않음",
         "comingSoon": "곧 제공",
+        "forMembersOnly": "회원 전용",
         "nearComName": "near.com",
         "nearComDescription": "near.com 및 trezu용 내부 네트워크"
     },

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "Redes suportadas",
             "networksWithAssets": "Redes com ativos",
             "yourAssets": "Seus ativos",
-            "otherAssets": "Outros ativos"
+            "otherAssets": "Outros ativos",
+            "available": "Disponível",
+            "forMembersOnly": "Apenas para membros"
         },
         "errors": {
             "addressUnavailable": "Não foi possível obter o endereço de depósito para o ativo e a rede selecionados.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "Outras disponíveis",
         "incompatible": "Incompatível",
         "comingSoon": "Em breve",
+        "forMembersOnly": "Apenas para membros",
         "nearComName": "near.com",
         "nearComDescription": "Rede interna para near.com e trezu"
     },

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "Desteklenen Ağlar",
             "networksWithAssets": "Varlıkları Olan Ağlar",
             "yourAssets": "Varlıklarınız",
-            "otherAssets": "Diğer Varlıklar"
+            "otherAssets": "Diğer Varlıklar",
+            "available": "Mevcut",
+            "forMembersOnly": "Yalnızca Üyelere Özel"
         },
         "errors": {
             "addressUnavailable": "Seçili varlık ve ağ için para yatırma adresi alınamadı.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "Diğer Kullanılabilir",
         "incompatible": "Uyumsuz",
         "comingSoon": "Yakında",
+        "forMembersOnly": "Yalnızca Üyelere Özel",
         "nearComName": "near.com",
         "nearComDescription": "near.com ve trezu için Dahili Ağ"
     },

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "Підтримувані мережі",
             "networksWithAssets": "Мережі з активами",
             "yourAssets": "Ваші активи",
-            "otherAssets": "Інші активи"
+            "otherAssets": "Інші активи",
+            "available": "Доступно",
+            "forMembersOnly": "Лише для учасників"
         },
         "errors": {
             "addressUnavailable": "Не вдалось отримати адресу депозиту для обраного активу та мережі.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "Інші доступні",
         "incompatible": "Несумісні",
         "comingSoon": "Скоро",
+        "forMembersOnly": "Лише для учасників",
         "nearComName": "near.com",
         "nearComDescription": "Внутрішня мережа для near.com і trezu"
     },

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "Mạng được hỗ trợ",
             "networksWithAssets": "Mạng có tài sản",
             "yourAssets": "Tài sản của bạn",
-            "otherAssets": "Tài sản khác"
+            "otherAssets": "Tài sản khác",
+            "available": "Có sẵn",
+            "forMembersOnly": "Chỉ dành cho thành viên"
         },
         "errors": {
             "addressUnavailable": "Không thể lấy địa chỉ nạp tiền cho tài sản và mạng đã chọn.",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "Khác khả dụng",
         "incompatible": "Không tương thích",
         "comingSoon": "Sắp ra mắt",
+        "forMembersOnly": "Chỉ dành cho thành viên",
         "nearComName": "near.com",
         "nearComDescription": "Mạng nội bộ cho near.com và trezu"
     },

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -232,7 +232,9 @@
             "supportedNetworks": "支持的网络",
             "networksWithAssets": "包含资产的网络",
             "yourAssets": "您的资产",
-            "otherAssets": "其他资产"
+            "otherAssets": "其他资产",
+            "available": "可用",
+            "forMembersOnly": "仅限成员"
         },
         "errors": {
             "addressUnavailable": "无法获取所选资产和网络的存款地址。",
@@ -1552,6 +1554,7 @@
         "otherAvailable": "其他可用",
         "incompatible": "不兼容",
         "comingSoon": "即将推出",
+        "forMembersOnly": "仅限成员",
         "nearComName": "near.com",
         "nearComDescription": "near.com 与 trezu 的内部网络"
     },


### PR DESCRIPTION
- Added a shared `section-rules` helper to build dropdown sections from simple rules (`title`, `filter`, `disabled`).
- Updated recipient network selection to use caller-provided rules instead of hardcoded section logic.
- Added guest confidential behavior:
  - `Available` shows only `near.com`
  - `For Members Only` shows other networks as disabled
- Applied the same guest section pattern in deposit network selection.
- Improved dropdown row styling in dark mode