### PR TITLE
feat(nt-fe): gate non-en/es/uk locales behind extraLocales feature flag

### DIFF
--- a/nt-fe/app/(init)/layout.tsx
+++ b/nt-fe/app/(init)/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
-import { getLocaleDirection, isLocale } from "@/i18n/config";
+import { getLocaleDirection } from "@/i18n/config";
 import "../globals.css";
 import { GleapWidget } from "@/components/gleap-widget";
 import { GoogleAnalytics } from "@/components/google-analytics";
@@ -51,7 +51,7 @@ export default async function RootLayout({
 }>) {
     const locale = await getLocale();
     const messages = await getMessages();
-    const dir = isLocale(locale) ? getLocaleDirection(locale) : "ltr";
+    const dir = getLocaleDirection(locale);
 
     return (
         <html

--- a/nt-fe/app/(treasury)/layout.tsx
+++ b/nt-fe/app/(treasury)/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
-import { getLocaleDirection, isLocale } from "@/i18n/config";
+import { getLocaleDirection } from "@/i18n/config";
 import "../globals.css";
 import { AuthProvider } from "@/components/auth-provider";
 import { GleapWidget } from "@/components/gleap-widget";
@@ -55,7 +55,7 @@ export default async function RootLayout({
 }>) {
     const locale = await getLocale();
     const messages = await getMessages();
-    const dir = isLocale(locale) ? getLocaleDirection(locale) : "ltr";
+    const dir = getLocaleDirection(locale);
 
     return (
         <html

--- a/nt-fe/app/blocked/layout.tsx
+++ b/nt-fe/app/blocked/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
-import { getLocaleDirection, isLocale } from "@/i18n/config";
+import { getLocaleDirection } from "@/i18n/config";
 import "../globals.css";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -20,7 +20,7 @@ export default async function BlockedLayout({
 }>) {
     const locale = await getLocale();
     const messages = await getMessages();
-    const dir = isLocale(locale) ? getLocaleDirection(locale) : "ltr";
+    const dir = getLocaleDirection(locale);
 
     return (
         <html lang={locale} dir={dir}>

--- a/nt-fe/app/telegram/layout.tsx
+++ b/nt-fe/app/telegram/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
-import { getLocaleDirection, isLocale } from "@/i18n/config";
+import { getLocaleDirection } from "@/i18n/config";
 import "../globals.css";
 import { AuthProvider } from "@/components/auth-provider";
 import { NearInitializer } from "@/components/near-initializer";
@@ -34,7 +34,7 @@ export default async function TelegramLayout({
 }>) {
     const locale = await getLocale();
     const messages = await getMessages();
-    const dir = isLocale(locale) ? getLocaleDirection(locale) : "ltr";
+    const dir = getLocaleDirection(locale);
 
     return (
         <html

--- a/nt-fe/app/wallet/layout.tsx
+++ b/nt-fe/app/wallet/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
-import { getLocaleDirection, isLocale } from "@/i18n/config";
+import { getLocaleDirection } from "@/i18n/config";
 import "../globals.css";
 import { QueryProvider } from "@/components/query-provider";
 
@@ -31,7 +31,7 @@ export default async function WalletLayout({
 }>) {
     const locale = await getLocale();
     const messages = await getMessages();
-    const dir = isLocale(locale) ? getLocaleDirection(locale) : "ltr";
+    const dir = getLocaleDirection(locale);
 
     return (
         <html

--- a/nt-fe/components/language-switcher.tsx
+++ b/nt-fe/components/language-switcher.tsx
@@ -11,7 +11,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LOCALE_COOKIE, type Locale, locales } from "@/i18n/config";
+import { enabledLocales, LOCALE_COOKIE, type Locale } from "@/i18n/config";
 import { cn } from "@/lib/utils";
 
 const labelKeyByLocale: Record<Locale, string> = {
@@ -93,7 +93,7 @@ export function LanguageSwitcher({
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align={align} className="min-w-[160px]">
-                {locales.map((code) => (
+                {enabledLocales.map((code) => (
                     <DropdownMenuItem
                         key={code}
                         onSelect={() => handleSelect(code)}

--- a/nt-fe/constants/features.ts
+++ b/nt-fe/constants/features.ts
@@ -15,7 +15,10 @@ const staging =
 export const features = staging
     ? {
           integrations: true,
+          extraLocales: true,
       }
     : {
           integrations: false,
+          // In production only en/es/uk are exposed in the language switcher.
+          extraLocales: false,
       };

--- a/nt-fe/i18n/config.ts
+++ b/nt-fe/i18n/config.ts
@@ -31,7 +31,9 @@ export const enabledLocales: readonly Locale[] = features.extraLocales
     ? locales
     : corePublicLocales;
 
-export function isEnabledLocale(value: string | undefined | null): value is Locale {
+export function isEnabledLocale(
+    value: string | undefined | null,
+): value is Locale {
     return !!value && enabledLocales.includes(value as Locale);
 }
 
@@ -56,15 +58,16 @@ export const localeNames: Record<Locale, string> = {
 /** Right-to-left locales. */
 export const rtlLocales: readonly Locale[] = ["he"];
 
-export function getLocaleDirection(locale: Locale): "ltr" | "rtl" {
+export function getLocaleDirection(
+    locale: Locale | string | undefined | null,
+): "ltr" | "rtl" {
+    if (!isEnabledLocale(locale)) {
+        return "ltr";
+    }
     return rtlLocales.includes(locale) ? "rtl" : "ltr";
 }
 
 export const LOCALE_COOKIE = "NEXT_LOCALE";
-
-export function isLocale(value: string | undefined | null): value is Locale {
-    return !!value && (locales as readonly string[]).includes(value);
-}
 
 export function pickLocaleFromAcceptLanguage(header: string | null): Locale {
     if (!header) return defaultLocale;

--- a/nt-fe/i18n/config.ts
+++ b/nt-fe/i18n/config.ts
@@ -1,3 +1,5 @@
+import { features } from "@/constants/features";
+
 export const locales = [
     "en",
     "es",
@@ -14,6 +16,24 @@ export const locales = [
     "ko",
 ] as const;
 export type Locale = (typeof locales)[number];
+
+/** Locales always exposed to end users in production. */
+const corePublicLocales: readonly Locale[] = ["en", "es", "uk"];
+
+/**
+ * Locales that are visible to end users at runtime.
+ *
+ * In production this is gated to en/es/uk via features.extraLocales;
+ * staging and development show every locale we ship messages for so QA
+ * and translators can preview them.
+ */
+export const enabledLocales: readonly Locale[] = features.extraLocales
+    ? locales
+    : corePublicLocales;
+
+export function isEnabledLocale(value: string | undefined | null): value is Locale {
+    return !!value && enabledLocales.includes(value as Locale);
+}
 
 export const defaultLocale: Locale = "en";
 
@@ -65,7 +85,7 @@ export function pickLocaleFromAcceptLanguage(header: string | null): Locale {
 
     for (const { tag } of parts) {
         const base = tag.split("-")[0];
-        if (isLocale(base)) return base;
+        if (isEnabledLocale(base)) return base;
     }
     return defaultLocale;
 }

--- a/nt-fe/i18n/request.ts
+++ b/nt-fe/i18n/request.ts
@@ -2,7 +2,7 @@ import { cookies, headers } from "next/headers";
 import { getRequestConfig } from "next-intl/server";
 import {
     defaultLocale,
-    isLocale,
+    isEnabledLocale,
     LOCALE_COOKIE,
     pickLocaleFromAcceptLanguage,
 } from "./config";
@@ -11,7 +11,9 @@ export default getRequestConfig(async () => {
     const cookieStore = await cookies();
     const cookieLocale = cookieStore.get(LOCALE_COOKIE)?.value;
 
-    let locale = isLocale(cookieLocale) ? cookieLocale : undefined;
+    // Reject cookies pinning a locale that's gated off in this environment so
+    // production users can't end up stuck on a feature-flagged language.
+    let locale = isEnabledLocale(cookieLocale) ? cookieLocale : undefined;
 
     if (!locale) {
         const hdrs = await headers();

--- a/nt-fe/i18n/request.ts
+++ b/nt-fe/i18n/request.ts
@@ -11,8 +11,6 @@ export default getRequestConfig(async () => {
     const cookieStore = await cookies();
     const cookieLocale = cookieStore.get(LOCALE_COOKIE)?.value;
 
-    // Reject cookies pinning a locale that's gated off in this environment so
-    // production users can't end up stuck on a feature-flagged language.
     let locale = isEnabledLocale(cookieLocale) ? cookieLocale : undefined;
 
     if (!locale) {

--- a/nt-fe/proxy.ts
+++ b/nt-fe/proxy.ts
@@ -6,7 +6,7 @@ import {
 } from "@/constants/sanctioned-countries";
 import {
     LOCALE_COOKIE,
-    isLocale,
+    isEnabledLocale,
     pickLocaleFromAcceptLanguage,
 } from "@/i18n/config";
 
@@ -87,7 +87,7 @@ export function proxy(request: NextRequest) {
 
     const response = NextResponse.next();
     const existingLocale = request.cookies.get(LOCALE_COOKIE)?.value;
-    if (!isLocale(existingLocale)) {
+    if (!isEnabledLocale(existingLocale)) {
         const detected = pickLocaleFromAcceptLanguage(
             request.headers.get("accept-language"),
         );


### PR DESCRIPTION
## Summary

Hides 10 of the 13 shipped locales (\`he\`, \`de\`, \`fr\`, \`vi\`, \`zh\`, \`tr\`, \`id\`, \`pt\`, \`ja\`, \`ko\`) on production. Only \`en\` / \`es\` / \`uk\` are exposed to end users in the language switcher. Staging + development continue to show every locale so QA and translators can keep reviewing them.

Reuses the existing feature-gate mechanism in \`constants/features.ts\` — same shape as the \`integrations\` flag.

## Changes

- **\`constants/features.ts\`** — new \`extraLocales\` flag, \`true\` when \`NEXT_PUBLIC_STAGING=true\` or \`NODE_ENV=development\`, \`false\` in prod.
- **\`i18n/config.ts\`**:
  - \`enabledLocales\` — runtime list to surface in UI; trio in prod, full list in staging/dev.
  - \`isEnabledLocale()\` — type guard against the gated set.
- **\`components/language-switcher.tsx\`** — iterates \`enabledLocales\` instead of \`locales\`.
- **\`i18n/request.ts\`** — \`NEXT_LOCALE\` cookie now validated against \`isEnabledLocale\`, so a stale cookie pinning a gated locale (e.g. user picked Hebrew on staging, then visits production) is rejected and we fall back to Accept-Language / \`defaultLocale\`. \`pickLocaleFromAcceptLanguage\` also gated.

All 13 message files remain shipped; only the runtime surface area changes. Promoting a locale later means flipping a single flag entry — no translation work lost.

## Verified locally

- \`npx next dev\` → switcher lists all 13 (English … 한국어).
- \`NODE_ENV=production npx next start\` → switcher lists 3 (English / Español / Українська).
- \`bun run check:i18n\` still passes (1668 keys × 13 locales, no dead keys).

## Test plan

- [ ] Deploy to staging → confirm all 13 locales selectable
- [ ] Production preview → confirm only 3 selectable
- [ ] Set a \`NEXT_LOCALE=he\` cookie manually in production → page falls back to en (cookie ignored, replaced on next switcher use)
- [ ] Browser sending \`Accept-Language: ja\` lands on production → falls back to defaultLocale (\`en\`) since \`ja\` is gated

🤖 Generated with [Claude Code](https://claude.com/claude-code)