### PR TITLE
fix: align backend proposal auth with DAO Everyone policy

### DIFF
--- a/e2e-tests/bulk-payment/dao-bulk-payment-flow.js
+++ b/e2e-tests/bulk-payment/dao-bulk-payment-flow.js
@@ -761,8 +761,8 @@ const nonMemberSubmitResponse = await apiRequest('/api/bulk-payment/submit-list'
 }, true);
 assert.equal(nonMemberSubmitResponse.success, false, 'Non-member submit must fail');
 assert.ok(
-  nonMemberSubmitResponse.error.includes('Not a DAO policy member'),
-  `Error should mention DAO membership requirement: ${nonMemberSubmitResponse.error}`
+  nonMemberSubmitResponse.error.includes("not allowed to perform 'AddProposal'"),
+  `Error should mention AddProposal policy requirement: ${nonMemberSubmitResponse.error}`
 );
 console.log(`✅ Non-member submit rejected as expected: ${nonMemberSubmitResponse.error}`);
 

--- a/nt-be/src/auth/middleware.rs
+++ b/nt-be/src/auth/middleware.rs
@@ -1,8 +1,10 @@
 use crate::AppState;
 use crate::auth::{AuthError, jwt::hash_token, verify_jwt};
+use crate::handlers::treasury::policy::fetch_treasury_policy_cached;
 use axum::http::StatusCode;
 use axum::{extract::FromRequestParts, http::request::Parts};
 use axum_extra::extract::CookieJar;
+use serde_json::Value;
 use std::sync::Arc;
 
 /// The name of the auth cookie
@@ -37,6 +39,117 @@ impl AuthUser {
         .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
 
         member.map(|_| ()).ok_or(AuthError::NotDaoMember)
+    }
+
+    fn role_has_action_permission(role: &Value, action_name: &str) -> bool {
+        role.get("permissions")
+            .and_then(Value::as_array)
+            .map(|permissions| {
+                permissions.iter().any(|permission| {
+                    permission
+                        .as_str()
+                        .and_then(|permission| permission.split(':').nth(1))
+                        .map(|action| action == action_name || action == "*")
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false)
+    }
+
+    fn role_applies_to_account(role: &Value, account_id: &str) -> bool {
+        let Some(kind) = role.get("kind") else {
+            return false;
+        };
+
+        if kind.as_str() == Some("Everyone") {
+            return true;
+        }
+
+        kind.get("Group")
+            .and_then(Value::as_array)
+            .map(|group| {
+                group
+                    .iter()
+                    .any(|member| member.as_str() == Some(account_id))
+            })
+            .unwrap_or(false)
+    }
+
+    fn policy_allows_action_for_account(
+        policy: &Value,
+        account_id: &str,
+        action_name: &str,
+    ) -> bool {
+        policy
+            .get("roles")
+            .and_then(Value::as_array)
+            .map(|roles| {
+                roles.iter().any(|role| {
+                    Self::role_has_action_permission(role, action_name)
+                        && Self::role_applies_to_account(role, account_id)
+                })
+            })
+            .unwrap_or(false)
+    }
+
+    pub async fn fetch_dao_policy(
+        &self,
+        state: &Arc<AppState>,
+        dao_id: &str,
+    ) -> Result<Value, (StatusCode, String)> {
+        let dao_account_id = dao_id.parse().map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Invalid treasury account '{}': {}", dao_id, e),
+            )
+        })?;
+
+        let policy = fetch_treasury_policy_cached(state, &dao_account_id, None).await?;
+
+        Ok(policy)
+    }
+
+    pub fn verify_can_perform_action_with_policy(
+        &self,
+        policy: &Value,
+        dao_id: &str,
+        action_name: &str,
+    ) -> Result<(), (StatusCode, String)> {
+        if Self::policy_allows_action_for_account(policy, &self.account_id, action_name) {
+            Ok(())
+        } else {
+            Err((
+                StatusCode::FORBIDDEN,
+                format!(
+                    "Account '{}' is not allowed to perform '{}' for treasury '{}'",
+                    self.account_id, action_name, dao_id
+                ),
+            ))
+        }
+    }
+
+    /// Verify this user can perform a policy action according to on-chain roles.
+    ///
+    /// This honors `Everyone` roles and wildcard permissions (e.g. `*:*`).
+    pub async fn verify_can_perform_action(
+        &self,
+        state: &Arc<AppState>,
+        dao_id: &str,
+        action_name: &str,
+    ) -> Result<(), (StatusCode, String)> {
+        let policy = self.fetch_dao_policy(state, dao_id).await?;
+
+        self.verify_can_perform_action_with_policy(&policy, dao_id, action_name)
+    }
+
+    /// Verify this user can submit proposals according to on-chain policy.
+    pub async fn verify_can_add_proposal(
+        &self,
+        state: &Arc<AppState>,
+        dao_id: &str,
+    ) -> Result<(), (StatusCode, String)> {
+        self.verify_can_perform_action(state, dao_id, "AddProposal")
+            .await
     }
 
     pub async fn verify_member_if_confidential(

--- a/nt-be/src/handlers/bulkpayment/submit.rs
+++ b/nt-be/src/handlers/bulkpayment/submit.rs
@@ -149,20 +149,17 @@ pub async fn submit_list(
         ));
     }
 
-    // Step 2: Ensure the caller is a DAO policy member
-    if let Err(e) = auth_user
-        .verify_dao_member(&state.db_pool, &request.dao_contract_id)
+    // Step 2: Ensure the caller can submit proposals by DAO policy
+    if let Err((status, msg)) = auth_user
+        .verify_can_add_proposal(&state, &request.dao_contract_id)
         .await
     {
         return Err((
-            StatusCode::FORBIDDEN,
+            status,
             Json(SubmitListResponse {
                 success: false,
                 list_id: None,
-                error: Some(format!(
-                    "Only DAO policy members can submit bulk payment lists: {}",
-                    e
-                )),
+                error: Some(msg),
             }),
         ));
     }

--- a/nt-be/src/handlers/intents/confidential/generate_intent.rs
+++ b/nt-be/src/handlers/intents/confidential/generate_intent.rs
@@ -42,10 +42,7 @@ pub async fn generate_intent(
         .signer_id
         .strip_prefix("near:")
         .unwrap_or(&request.signer_id);
-    auth_user
-        .verify_dao_member(&state.db_pool, dao_id)
-        .await
-        .map_err(|e| (StatusCode::FORBIDDEN, format!("Not a DAO member: {}", e)))?;
+    auth_user.verify_can_add_proposal(&state, dao_id).await?;
 
     // Extract deposit_address from quote_metadata.quote.depositAddress
     let deposit_address = request

--- a/nt-be/src/handlers/relay/submit.rs
+++ b/nt-be/src/handlers/relay/submit.rs
@@ -64,6 +64,78 @@ fn error_response(status: StatusCode, msg: String) -> (StatusCode, Json<RelayRes
     )
 }
 
+async fn verify_relay_access(
+    state: &Arc<AppState>,
+    auth_user: &AuthUser,
+    request: &RelayRequest,
+    signed_delegate_action: &SignedDelegateAction,
+) -> Result<(), (StatusCode, Json<RelayResponse>)> {
+    // Vote relays follow on-chain vote permissions (including Everyone roles),
+    if request.proposal_type.as_deref() == Some("vote") {
+        let mut requested_vote_actions = HashSet::new();
+        for action in &signed_delegate_action.delegate_action.actions {
+            if let Action::FunctionCall(function_call) = action.deref()
+                && function_call.method_name == "act_proposal"
+            {
+                let args = serde_json::from_slice::<Value>(&function_call.args).map_err(|e| {
+                    error_response(
+                        StatusCode::BAD_REQUEST,
+                        format!("Invalid act_proposal args: {}", e),
+                    )
+                })?;
+
+                let vote_action = args.get("action").and_then(Value::as_str).ok_or_else(|| {
+                    error_response(
+                        StatusCode::BAD_REQUEST,
+                        "Missing vote action in act_proposal args".to_string(),
+                    )
+                })?;
+
+                match vote_action {
+                    "VoteApprove" | "VoteReject" | "VoteRemove" => {
+                        requested_vote_actions.insert(vote_action.to_string());
+                    }
+                    _ => {
+                        return Err(error_response(
+                            StatusCode::BAD_REQUEST,
+                            format!("Unsupported vote action '{}'", vote_action),
+                        ));
+                    }
+                }
+            }
+        }
+
+        if requested_vote_actions.is_empty() {
+            return Err(error_response(
+                StatusCode::BAD_REQUEST,
+                "No vote actions found in delegate action".to_string(),
+            ));
+        }
+
+        let policy = auth_user
+            .fetch_dao_policy(state, request.treasury_id.as_str())
+            .await
+            .map_err(|(status, msg)| error_response(status, msg))?;
+
+        for vote_action in requested_vote_actions {
+            auth_user
+                .verify_can_perform_action_with_policy(
+                    &policy,
+                    request.treasury_id.as_str(),
+                    &vote_action,
+                )
+                .map_err(|(status, msg)| error_response(status, msg))?;
+        }
+
+        return Ok(());
+    }
+
+    auth_user
+        .verify_can_add_proposal(state, request.treasury_id.as_str())
+        .await
+        .map_err(|(status, msg)| error_response(status, msg))
+}
+
 const MAX_STORAGE_BYTES: u128 = 4000;
 const MAX_SPONSORING: NearToken = NearToken::from_millinear(1200);
 // We need to multiply the buffer by 25 because this is the bulk payment limit for single transaction
@@ -268,16 +340,6 @@ pub async fn relay_delegate_action(
     auth_user: AuthUser,
     Json(request): Json<RelayRequest>,
 ) -> Result<Json<RelayResponse>, (StatusCode, Json<RelayResponse>)> {
-    auth_user
-        .verify_dao_member(&state.db_pool, request.treasury_id.as_str())
-        .await
-        .map_err(|e| {
-            error_response(
-                StatusCode::FORBIDDEN,
-                format!("Not a DAO policy member: {}", e),
-            )
-        })?;
-
     // Step 1: Decode and deserialize SignedDelegateAction
     let signed_delegate_action =
         SignedDelegateAction::try_from_slice(&request.signed_delegate_action.0).map_err(|e| {
@@ -286,6 +348,8 @@ pub async fn relay_delegate_action(
                 format!("Invalid delegate action: {}", e),
             )
         })?;
+
+    verify_relay_access(&state, &auth_user, &request, &signed_delegate_action).await?;
 
     // Step 2: Verify sender_id matches authenticated user
     let sender_id = signed_delegate_action.delegate_action.sender_id.to_string();

--- a/nt-be/src/handlers/treasury/policy.rs
+++ b/nt-be/src/handlers/treasury/policy.rs
@@ -18,14 +18,14 @@ pub struct GetTreasuryPolicyQuery {
     pub at_before: Option<U64>,
 }
 
-pub async fn get_treasury_policy(
-    State(state): State<Arc<AppState>>,
-    Query(params): Query<GetTreasuryPolicyQuery>,
-) -> Result<axum::Json<serde_json::Value>, (StatusCode, String)> {
-    let treasury_id = params.treasury_id.clone();
-    let at_before = params.at_before.map(|at| at.0).unwrap_or(0);
+pub async fn fetch_treasury_policy_cached(
+    state: &Arc<AppState>,
+    treasury_id: &AccountId,
+    at_before: Option<u64>,
+) -> Result<serde_json::Value, (StatusCode, String)> {
+    let at_before = at_before.unwrap_or(0);
     let cache_key = CacheKey::new("treasury-policy")
-        .with(&treasury_id)
+        .with(treasury_id)
         .with(at_before)
         .build();
 
@@ -35,7 +35,7 @@ pub async fn get_treasury_policy(
         &state.network
     };
     let state_clone = state.clone();
-    let result = state
+    state
         .cache
         .cached_contract_call(CacheTier::ShortTerm, cache_key, async move {
             let at = if at_before > 0 {
@@ -58,7 +58,16 @@ pub async fn get_treasury_policy(
                 .await
                 .map(|r| r.data)
         })
-        .await?;
+        .await
+}
+
+pub async fn get_treasury_policy(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<GetTreasuryPolicyQuery>,
+) -> Result<axum::Json<serde_json::Value>, (StatusCode, String)> {
+    let result =
+        fetch_treasury_policy_cached(&state, &params.treasury_id, params.at_before.map(|at| at.0))
+            .await?;
 
     Ok(axum::Json(result))
 }


### PR DESCRIPTION
Resolves #589 
Tested locally on `testing-astradao.sputnik-dao.near`, where `AddProposal` permission is enabled for everyone.