### PR TITLE
fix: align confidential payment request details with public intents metadata

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -68,6 +68,7 @@ import {
     formatTokenDisplayAmount,
 } from "@/lib/utils";
 import {
+    computeQuoteNetworkFee,
     isIntentsCrossChainToken,
     isIntentsToken,
     isNearChainFtToken,
@@ -228,7 +229,6 @@ function Step1({
 }
 
 interface Step2Props extends StepProps {
-    showFeeBreakdown: boolean;
     liveQuote?: IntentsQuoteResponse | null;
     isLoadingLiveQuote?: boolean;
     isFetchingLiveQuote?: boolean;
@@ -237,7 +237,6 @@ interface Step2Props extends StepProps {
 
 function Step2({
     handleBack,
-    showFeeBreakdown,
     liveQuote,
     isLoadingLiveQuote,
     isFetchingLiveQuote,
@@ -289,14 +288,24 @@ function Step2({
 
         if (liveQuote?.quote) {
             const divisor = Big(10).pow(token.decimals);
-            const quotedTotal = Big(liveQuote.quote.minAmountIn || "0").div(
-                divisor,
+            const quotedTotal = Big(
+                liveQuote.quote.amountInFormatted ||
+                    Big(liveQuote.quote.minAmountIn || "0")
+                        .div(divisor)
+                        .toString(),
             );
             const quotedRecipient = Big(
-                liveQuote.quote.minAmountOut || "0",
-            ).div(divisor);
-            const quotedFee = quotedTotal.minus(quotedRecipient);
-            const feeValue = quotedFee.gt(0) ? quotedFee : Big(0);
+                liveQuote.quote.amountOutFormatted ||
+                    Big(liveQuote.quote.minAmountOut || "0")
+                        .div(divisor)
+                        .toString(),
+            );
+            const feeValue = Big(
+                (computeQuoteNetworkFee(liveQuote.quote) || "0").replaceAll(
+                    ",",
+                    "",
+                ),
+            );
 
             return {
                 totalAmountWithFees: quotedTotal,
@@ -382,7 +391,7 @@ function Step2({
                                 </div>
                             </div>
                         </div>
-                        {showFeeBreakdown && displayNetworkFee.gt(0) && (
+                        {isViaIntents && displayNetworkFee.gt(0) && (
                             <div className="flex items-center justify-between gap-2 text-sm my-3">
                                 <div className="flex items-center gap-1 text-muted-foreground">
                                     <p>{tPay("networkFee")}</p>
@@ -565,13 +574,14 @@ function buildIntentTransferDescription(
     quote: Awaited<ReturnType<typeof getIntentsQuote>>,
 ): string {
     const notes = [data.memo?.trim()].filter(Boolean).join(" ");
+    const networkFee = computeQuoteNetworkFee(quote?.quote);
 
     return encodeToMarkdown({
         proposal_action: "payment-transfer",
         notes,
         recipient: data.address,
         destinationNetwork: data.destinationNetwork || undefined,
-        destinationNetworkName: data.destinationNetworkName || undefined,
+        networkFee,
         depositAddress: quote?.quote.depositAddress,
         signature: quote?.signature,
     });
@@ -1072,7 +1082,6 @@ export default function PaymentsPage() {
             {
                 component: Step2,
                 props: {
-                    showFeeBreakdown: isViaIntents,
                     liveQuote: liveQuote ?? quoteRef.current,
                     isLoadingLiveQuote,
                     isFetchingLiveQuote,

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -309,6 +309,7 @@ export function ProposalSidebar({
     const proposalType = getProposalUIKind(proposal);
     const isExchangeProposal = proposalType === "Exchange";
     const isPaymentProposal = proposalType === "Payment Request";
+    const isConfidentialRequest = proposalType === "Confidential Request";
     const isFailed = status === "Failed";
     const isExecuted = status === "Executed";
 
@@ -323,14 +324,23 @@ export function ProposalSidebar({
         }
     }
 
-    // Extract deposit address for exchange proposals and intents payment proposals
+    // Extract intents details for exchange/payment/confidential requests.
+    // Confidential metadata is backend-enriched and nested under mapped.data.
     let depositAddress: string | undefined;
-    if (isExchangeProposal || isPaymentProposal) {
+    let isConfidentialPayment = false;
+    if (isExchangeProposal || isPaymentProposal || isConfidentialRequest) {
         try {
-            const { data } = extractProposalData(proposal);
-            depositAddress = (data as any).depositAddress;
+            const { data } = extractProposalData(proposal, treasuryId);
+            if (isConfidentialRequest) {
+                const mapped = (data as any)?.mapped;
+                isConfidentialPayment = mapped?.type === "payment";
+                depositAddress = mapped?.data?.depositAddress;
+            } else {
+                depositAddress = (data as any)?.depositAddress;
+            }
         } catch (e) {}
     }
+    const isPaymentLikeProposal = isPaymentProposal || isConfidentialPayment;
 
     // Whether this proposal used the Intents protocol (has a deposit address)
     const isIntentsRouted = !!depositAddress;
@@ -502,12 +512,12 @@ export function ProposalSidebar({
                             message={
                                 <span>
                                     <strong>
-                                        {isPaymentProposal
+                                        {isPaymentLikeProposal
                                             ? t("processingPayment")
                                             : t("exchangingTokens")}
                                     </strong>
                                     <br />
-                                    {isPaymentProposal
+                                    {isPaymentLikeProposal
                                         ? t("processingPaymentBody")
                                         : t("exchangingTokensBody")}
                                 </span>

--- a/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from "next-intl";
+import { useMemo } from "react";
 import { Amount } from "../amount";
 import { InfoDisplay, InfoItem } from "@/components/info-display";
 import { User } from "@/components/user";
@@ -6,13 +7,13 @@ import { PaymentRequestData } from "../../types/index";
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { useToken } from "@/hooks/use-treasury-queries";
-import { useIntentsWithdrawalFee } from "@/hooks/use-intents-withdrawal-fee";
 import { Address } from "@/components/address";
-import { useBridgeTokens } from "@/hooks/use-bridge-tokens";
 import { NetworkIconDisplay } from "@/components/token-display";
 import { NEAR_COM_ICON } from "@/constants/token";
 import { NEAR_COM_NETWORK_ID } from "@/constants/intents";
 import type { ChainIcons } from "@/lib/api";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatTokenDisplayAmount } from "@/lib/utils";
 
 interface TransferExpandedProps {
     data: PaymentRequestData;
@@ -23,42 +24,35 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
     const tIntents = useTranslations("intentsQuote");
     const { data: tokenData } = useToken(data.tokenId);
     const tokenChainName = tokenData?.network || "near";
-    const shouldFetchDestinationNetworkMeta =
-        !!data.receiverNetwork &&
-        data.receiverNetwork !== tokenChainName &&
-        data.receiverNetwork !== NEAR_COM_NETWORK_ID;
-    const { data: bridgeAssets = [] } = useBridgeTokens(
-        shouldFetchDestinationNetworkMeta,
-    );
+    const shouldFetchDestinationToken =
+        !!data.destinationAssetId &&
+        data.destinationAssetId !== NEAR_COM_NETWORK_ID &&
+        data.destinationAssetId !== "near";
+    const { data: destinationTokenData, isLoading: isLoadingDestinationToken } =
+        useToken(
+            shouldFetchDestinationToken ? data.destinationAssetId : undefined,
+        );
 
-    // For cross-chain intents payments use the destination network for the
-    // recipient profile link so the explorer link points to the right chain.
-    const recipientChainName = data.receiverNetwork ?? tokenChainName;
+    // For cross-chain intents payments, prefer resolved destination token
+    // network for recipient links when destinationNetwork carries a token id.
+    const recipientChainName =
+        data.destinationAssetId === NEAR_COM_NETWORK_ID
+            ? "near"
+            : destinationTokenData?.network ||
+              (!shouldFetchDestinationToken
+                  ? data.destinationAssetId
+                  : undefined) ||
+              tokenChainName;
+    const hasFeeData = !!data.networkFee;
 
-    const {
-        data: dynamicFeeData,
-        isError: hasFeeError,
-        isIntentsCrossChainToken,
-    } = useIntentsWithdrawalFee({
-        token: tokenData
-            ? {
-                  address: data.tokenId,
-                  network: tokenChainName,
-                  decimals: tokenData.decimals,
-              }
-            : null,
-        destinationAddress: data.receiver,
-    });
-    const hasFeeData =
-        isIntentsCrossChainToken &&
-        !hasFeeError &&
-        !!dynamicFeeData?.networkFee;
-
-    const destinationNetworkMeta = (() => {
-        if (!data.receiverNetwork || data.receiverNetwork === tokenChainName) {
+    const destinationNetworkMeta = useMemo(() => {
+        if (
+            !data.destinationAssetId ||
+            data.destinationAssetId === tokenChainName
+        ) {
             return null;
         }
-        if (data.receiverNetwork === NEAR_COM_NETWORK_ID) {
+        if (data.destinationAssetId === NEAR_COM_NETWORK_ID) {
             return {
                 name: NEAR_COM_NETWORK_ID,
                 chainIcons: {
@@ -67,26 +61,24 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
                 } as ChainIcons,
             };
         }
-
-        for (const asset of bridgeAssets) {
-            const network = asset.networks.find(
-                (n) =>
-                    n.id === data.receiverNetwork ||
-                    n.name === data.receiverNetwork,
-            );
-            if (!network) continue;
-
+        if (shouldFetchDestinationToken && destinationTokenData?.network) {
             return {
-                name: network.name,
-                chainIcons: network.chainIcons,
+                name: destinationTokenData.network,
+                chainIcons: destinationTokenData.chainIcons ?? null,
             };
         }
-
-        return {
-            name: data.receiverNetwork,
-            chainIcons: null,
-        };
-    })();
+        return null;
+    }, [
+        data.destinationAssetId,
+        destinationTokenData?.network,
+        destinationTokenData?.chainIcons,
+        shouldFetchDestinationToken,
+        tokenChainName,
+    ]);
+    const shouldShowDestinationNetworkSkeleton =
+        shouldFetchDestinationToken &&
+        !destinationNetworkMeta &&
+        isLoadingDestinationToken;
 
     const infoItems: InfoItem[] = [
         {
@@ -112,13 +104,15 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
         },
     ];
 
-    if (destinationNetworkMeta) {
+    if (destinationNetworkMeta || shouldShowDestinationNetworkSkeleton) {
         infoItems.push({
             label: t("destinationNetwork"),
-            value: (
+            value: shouldShowDestinationNetworkSkeleton ? (
+                <Skeleton className="h-5 w-28" />
+            ) : (
                 <NetworkIconDisplay
-                    chainIcons={destinationNetworkMeta.chainIcons}
-                    networkName={destinationNetworkMeta.name}
+                    chainIcons={destinationNetworkMeta!.chainIcons}
+                    networkName={destinationNetworkMeta!.name}
                     networkNameClassName="font-normal capitalize"
                 />
             ),
@@ -129,7 +123,7 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
         infoItems.push({
             label: t("networkFee"),
             info: tIntents("networkFeeTooltip"),
-            value: `${dynamicFeeData.networkFee} ${tokenData?.symbol || ""}`.trim(),
+            value: `${formatTokenDisplayAmount(data.networkFee!)} ${tokenData?.symbol || ""}`.trim(),
         });
     }
 

--- a/nt-fe/features/proposals/components/transaction-cell/token-cell.tsx
+++ b/nt-fe/features/proposals/components/transaction-cell/token-cell.tsx
@@ -37,12 +37,18 @@ export function TokenCell({
     );
     const { data: profile } = useProfile(data.receiver);
     const address = profile?.addressBookName ?? data.receiver;
+    const destinationAssetId =
+        "destinationAssetId" in data ? data.destinationAssetId : undefined;
 
     const subtitle = data.receiver ? (
         <>
             {effectivePrefix}
             {isUser ? (
-                <TooltipUser accountId={data.receiver} useAddressBook>
+                <TooltipUser
+                    accountId={data.receiver}
+                    useAddressBook
+                    chainName={destinationAssetId}
+                >
                     <span> {address}</span>
                 </TooltipUser>
             ) : (

--- a/nt-fe/features/proposals/types/index.ts
+++ b/nt-fe/features/proposals/types/index.ts
@@ -53,8 +53,10 @@ export interface PaymentRequestData {
     /** Present when the payment was routed through the 1Click Intents protocol */
     depositAddress?: string;
     quoteSignature?: string;
-    /** Destination chain name (e.g. "ethereum", "bitcoin") for cross-chain payments */
-    receiverNetwork?: string;
+    /** Network fee in token units (not raw smallest units) */
+    networkFee?: string;
+    /** Destination id (e.g. "near.com", "near", "nep141:...omft.near") */
+    destinationAssetId?: string;
 }
 
 export interface FunctionCallAction {

--- a/nt-fe/features/proposals/utils/proposal-extractors.ts
+++ b/nt-fe/features/proposals/utils/proposal-extractors.ts
@@ -29,6 +29,7 @@ import { getKindFromProposal } from "@/lib/config-utils";
 import { FunctionCallAction } from "@/lib/proposals-api";
 import { IntentsQuoteResponse } from "@/lib/api";
 import { NEAR_COM_NETWORK_ID } from "@/constants/intents";
+import { computeQuoteNetworkFee } from "@/lib/intents-fee";
 
 function extractFTTransferData(
     functionCall: FunctionCallKind["FunctionCall"],
@@ -173,19 +174,12 @@ export function extractPaymentRequestData(
     const quoteSignature =
         decodeProposalDescription("signature", proposal.description) ||
         undefined;
-    const destinationNetworkId =
+    const networkFee =
+        decodeProposalDescription("networkFee", proposal.description) ||
+        undefined;
+    const destinationAssetId =
         decodeProposalDescription("destinationNetwork", proposal.description) ||
         undefined;
-    const destinationNetworkName =
-        decodeProposalDescription(
-            "destinationNetworkName",
-            proposal.description,
-        ) || undefined;
-    const receiverNetwork =
-        destinationNetworkId === NEAR_COM_NETWORK_ID
-            ? NEAR_COM_NETWORK_ID
-            : destinationNetworkName || destinationNetworkId;
-
     return {
         tokenId,
         amount,
@@ -194,7 +188,8 @@ export function extractPaymentRequestData(
         url: url || "",
         depositAddress,
         quoteSignature,
-        receiverNetwork,
+        networkFee,
+        destinationAssetId,
     };
 }
 
@@ -808,6 +803,22 @@ export function extractConfidentialRequestData(
             };
             title = "Confidential Exchange";
         } else {
+            const destinationAsset = quoteRequest.destinationAsset;
+            const recipientType =
+                typeof quoteRequest.recipientType === "string"
+                    ? quoteRequest.recipientType
+                    : undefined;
+            const destinationAssetId =
+                destinationAsset &&
+                destinationAsset !== quoteRequest.originAsset
+                    ? destinationAsset
+                    : recipientType === "CONFIDENTIAL_INTENTS" ||
+                        recipientType === "INTENTS"
+                      ? NEAR_COM_NETWORK_ID
+                      : recipientType === "DESTINATION_CHAIN"
+                        ? "near"
+                        : undefined;
+            const networkFee = computeQuoteNetworkFee(quote);
             mapped = {
                 type: "payment",
                 data: {
@@ -815,6 +826,10 @@ export function extractConfidentialRequestData(
                     amount: quote.amountIn,
                     receiver: quoteRequest.recipient ?? "",
                     notes: meta?.notes ?? undefined,
+                    depositAddress: quote.depositAddress,
+                    quoteSignature: quoteResponse.signature,
+                    networkFee,
+                    destinationAssetId,
                 } as PaymentRequestData,
             };
             title = "Confidential Payment";

--- a/nt-fe/lib/intents-fee.ts
+++ b/nt-fe/lib/intents-fee.ts
@@ -2,6 +2,7 @@ import { IntentsSDK } from "@defuse-protocol/intents-sdk";
 import Big from "@/lib/big";
 import { validateAddress } from "@/lib/address-validation";
 import type { BlockchainType } from "@/lib/blockchain-utils";
+import { formatSmartAmount } from "@/lib/utils";
 
 const intentsSdk = new IntentsSDK({
     referral: "",
@@ -80,6 +81,22 @@ export function isNearChainFtToken(token: {
 
 function fromAmountRaw(rawAmount: bigint | string, decimals: number): Big {
     return Big(rawAmount.toString()).div(Big(10).pow(decimals));
+}
+
+export function computeQuoteNetworkFee(
+    args?: {
+        amountInFormatted?: string | null;
+        amountOutFormatted?: string | null;
+    } | null,
+): string | undefined {
+    try {
+        const fee = Big(args?.amountInFormatted || "0").minus(
+            Big(args?.amountOutFormatted || "0"),
+        );
+        return fee.gt(0) ? formatSmartAmount(fee.toString()) : undefined;
+    } catch {
+        return undefined;
+    }
 }
 
 export async function estimateIntentsNetworkFee(args: {


### PR DESCRIPTION
- Added confidential payment details to match public flow in request details: `destination network`, `deposit address`, `quote signature`, and `network fee`.
<img width="1695" height="796" alt="image" src="https://github.com/user-attachments/assets/9828eb27-db11-4ec1-8c0f-c0a00f297be1" />

- Saved the network fee in the public proposal description at creation time, so request details always show the exact fee used when the proposal was created (because it changes later).
- Simplified destination data to one field: `destinationAssetId` (removed extra name/id duplication).
