### PR TITLE
fix: align confidential payment/exchange copy and network labels

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -40,6 +40,7 @@ interface DepositModalProps {
 interface SelectOption {
     id: string;
     name: string;
+    description?: string;
     symbol?: string;
     icon: string;
     gradient?: string;
@@ -58,6 +59,7 @@ const assetSchema = z.object({
 const networkSchema = z.object({
     id: z.string(),
     name: z.string(),
+    description: z.string().optional(),
     symbol: z.string().optional(),
     icon: z.string(),
     gradient: z.string().optional(),
@@ -102,6 +104,7 @@ export function DepositModal({
     prefillNetworkId,
 }: DepositModalProps) {
     const t = useTranslations("depositModal");
+    const tRecipientNetwork = useTranslations("recipientNetworkSelect");
     const depositFormSchema = useMemo(
         () =>
             buildDepositFormSchema({
@@ -399,6 +402,9 @@ export function DepositModal({
         const nearDirectNetworkOption = (): SelectOption => ({
             id: NEAR_DIRECT_NETWORK_ID,
             name: "near.com",
+            description: isConfidential
+                ? tRecipientNetwork("nearComDescription")
+                : undefined,
             icon: NEAR_COM_ICON,
         });
 
@@ -525,13 +531,6 @@ export function DepositModal({
                 if (prefillNetwork) networkToSelect = prefillNetwork;
             }
 
-            if (!networkToSelect && isConfidential) {
-                networkToSelect =
-                    availableNetworks.find(
-                        (n) => n.id === NEAR_DIRECT_NETWORK_ID,
-                    ) || null;
-            }
-
             if (!networkToSelect && availableNetworks.length === 1) {
                 networkToSelect = availableNetworks[0];
             }
@@ -572,15 +571,9 @@ export function DepositModal({
                 networkBalancesByAsset.get(asset.id) || new Map(),
             );
 
-            const nearDirectNetwork = availableNetworks.find(
-                (n) => n.id === NEAR_DIRECT_NETWORK_ID,
-            );
-
-            // Auto-select network if only one is available, or near.com for confidential
+            // Auto-select network only when there is exactly one option.
             if (availableNetworks.length === 1) {
                 form.setValue("network", availableNetworks[0]);
-            } else if (isConfidential && nearDirectNetwork) {
-                form.setValue("network", nearDirectNetwork);
             } else if (
                 selectedNetwork &&
                 !availableNetworks.some((n) => n.id === selectedNetwork.id)
@@ -588,13 +581,7 @@ export function DepositModal({
                 form.setValue("network", null);
             }
         },
-        [
-            form,
-            assetNetworksMap,
-            selectedNetwork,
-            networkBalancesByAsset,
-            isConfidential,
-        ],
+        [form, assetNetworksMap, selectedNetwork, networkBalancesByAsset],
     );
 
     // Handle network selection
@@ -770,6 +757,10 @@ export function DepositModal({
     const onlyDepositNetworkName = selectedNetwork
         ? getNetworkDisplayName(selectedNetwork.name)
         : "";
+    const onlyDepositNetworkDisplayName =
+        onlyDepositNetworkName.toLowerCase() === "near.com"
+            ? "near.com"
+            : onlyDepositNetworkName;
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
@@ -907,11 +898,20 @@ export function DepositModal({
                                                                         </span>
                                                                     </div>
                                                                 )}
-                                                                <span className="text-foreground font-medium uppercase">
-                                                                    {getNetworkDisplayName(
-                                                                        selectedNetwork.name,
+                                                                <div className="flex flex-col">
+                                                                    <span className="text-foreground font-medium uppercase">
+                                                                        {getNetworkDisplayName(
+                                                                            selectedNetwork.name,
+                                                                        )}
+                                                                    </span>
+                                                                    {selectedNetwork.description && (
+                                                                        <span className="text-xs text-muted-foreground font-normal">
+                                                                            {
+                                                                                selectedNetwork.description
+                                                                            }
+                                                                        </span>
                                                                     )}
-                                                                </span>
+                                                                </div>
                                                             </div>
                                                             <ChevronDown className="w-5 h-5" />
                                                         </div>
@@ -1075,14 +1075,15 @@ export function DepositModal({
                                                 symbol:
                                                     selectedNetwork?.symbol ??
                                                     "",
-                                                network: onlyDepositNetworkName,
+                                                network:
+                                                    onlyDepositNetworkDisplayName,
                                                 symbolTag: (chunks) => (
                                                     <span className="text-foreground">
                                                         {chunks}
                                                     </span>
                                                 ),
                                                 networkTag: (chunks) => (
-                                                    <span className="text-foreground capitalize">
+                                                    <span className="text-foreground">
                                                         {chunks}
                                                     </span>
                                                 ),
@@ -1182,6 +1183,26 @@ export function DepositModal({
                             isLoading={isLoadingAssets}
                             fixNear
                             roundIcons={false}
+                            renderContent={(item) => {
+                                const option = item as SelectOption;
+                                return (
+                                    <div className="flex-1 text-left">
+                                        <div className="font-semibold uppercase">
+                                            {option.name || option.symbol}
+                                        </div>
+                                        {option.description && (
+                                            <div className="text-xs text-muted-foreground font-normal">
+                                                {option.description}
+                                            </div>
+                                        )}
+                                        {option.symbol && (
+                                            <div className="text-sm text-muted-foreground">
+                                                {option.symbol}
+                                            </div>
+                                        )}
+                                    </div>
+                                );
+                            }}
                             renderRight={(item) => {
                                 const networkBalance =
                                     selectedNetworkBalances.get(item.id);

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -757,10 +757,8 @@ export function DepositModal({
     const onlyDepositNetworkName = selectedNetwork
         ? getNetworkDisplayName(selectedNetwork.name)
         : "";
-    const onlyDepositNetworkDisplayName =
-        onlyDepositNetworkName.toLowerCase() === "near.com"
-            ? "near.com"
-            : onlyDepositNetworkName;
+    const shouldCapitalizeOnlyDepositNetwork =
+        onlyDepositNetworkName.toLowerCase() !== "near.com";
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
@@ -1075,15 +1073,20 @@ export function DepositModal({
                                                 symbol:
                                                     selectedNetwork?.symbol ??
                                                     "",
-                                                network:
-                                                    onlyDepositNetworkDisplayName,
+                                                network: onlyDepositNetworkName,
                                                 symbolTag: (chunks) => (
                                                     <span className="text-foreground">
                                                         {chunks}
                                                     </span>
                                                 ),
                                                 networkTag: (chunks) => (
-                                                    <span className="text-foreground">
+                                                    <span
+                                                        className={`text-foreground ${
+                                                            shouldCapitalizeOnlyDepositNetwork
+                                                                ? "capitalize"
+                                                                : ""
+                                                        }`}
+                                                    >
                                                         {chunks}
                                                     </span>
                                                 ),

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ArrowDown, ChevronRight, Loader2 } from "lucide-react";
+import { ArrowDown, ChevronRight, Loader2, Shield } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { trackEvent } from "@/lib/analytics";
@@ -23,6 +23,7 @@ import {
     StepWizard,
 } from "@/components/step-wizard";
 import { TokenInput, tokenSchema } from "@/components/token-input";
+import { Tooltip } from "@/components/tooltip";
 import { Form } from "@/components/ui/form";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WarningAlert } from "@/components/warning-alert";
@@ -253,7 +254,22 @@ function Step1({ handleNext }: StepProps) {
     return (
         <PageCard className="relative">
             <div className="flex items-center justify-between gap-2">
-                <StepperHeader title={tEx("heading")} />
+                <StepperHeader
+                    title={
+                        isConfidential ? (
+                            <span className="inline-flex items-center gap-1.5">
+                                <span>{tEx("heading")}</span>
+                                <Tooltip content={tEx("confidentialTooltip")}>
+                                    <span className="inline-flex">
+                                        <Shield className="size-4 fill-foreground" />
+                                    </span>
+                                </Tooltip>
+                            </span>
+                        ) : (
+                            tEx("heading")
+                        )
+                    }
+                />
                 <div className="flex items-center gap-2">
                     <PendingButton
                         id="exchange-pending-btn"
@@ -700,6 +716,7 @@ export default function ExchangePage() {
         [tValidation],
     );
     const { treasuryId: selectedTreasury, isConfidential } = useTreasury();
+    const pageTitle = isConfidential ? t("confidentialTitle") : t("title");
     const { createProposal } = useNear();
     const { data: policy } = useTreasuryPolicy(selectedTreasury);
     const [step, setStep] = useState(0);
@@ -825,7 +842,7 @@ export default function ExchangePage() {
     };
 
     return (
-        <PageComponentLayout title={t("title")} description={t("description")}>
+        <PageComponentLayout title={pageTitle} description={t("description")}>
             <Form {...form}>
                 <form
                     onSubmit={(e) => {

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
@@ -51,6 +51,7 @@ export default function BulkPaymentPage() {
     const router = useRouter();
     const queryClient = useQueryClient();
     const { treasuryId: selectedTreasury, isConfidential } = useTreasury();
+    const pageTitle = isConfidential ? t("confidentialTitle") : t("title");
     const { createProposal } = useNear();
     const { data: policy } = useTreasuryPolicy(selectedTreasury);
 
@@ -418,7 +419,7 @@ export default function BulkPaymentPage() {
         const payment = paymentData[editingIndex];
         return (
             <PageComponentLayout
-                title={t("title")}
+                title={pageTitle}
                 description={t("description")}
             >
                 <div className="w-full max-w-[600px] mx-auto">
@@ -437,7 +438,7 @@ export default function BulkPaymentPage() {
     }
 
     return (
-        <PageComponentLayout title={t("title")} description={t("description")}>
+        <PageComponentLayout title={pageTitle} description={t("description")}>
             <FormProvider {...form}>
                 <div
                     className={`w-full mx-auto ${step === 1 ? "max-w-3xl" : "max-w-7xl"}`}

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -11,6 +11,7 @@ import type { Token } from "@/components/token-input";
 import { NEAR_COM_NETWORK_ID } from "@/constants/intents";
 import { NEAR_COM_ICON } from "@/constants/token";
 import { useBridgeTokens } from "@/hooks/use-bridge-tokens";
+import { useTreasury } from "@/hooks/use-treasury";
 import { isValidAddress } from "@/lib/address-validation";
 import { getBlockchainType } from "@/lib/blockchain-utils";
 import {
@@ -122,6 +123,7 @@ export function RecipientNetworkSelect({
     onNetworkChange,
 }: RecipientNetworkSelectProps) {
     const t = useTranslations("recipientNetworkSelect");
+    const { isConfidential } = useTreasury();
     const { theme } = useThemeStore();
     const [open, setOpen] = useState(false);
 
@@ -133,11 +135,11 @@ export function RecipientNetworkSelect({
         () => ({
             id: NEAR_COM_NETWORK_ID,
             name: t("nearComName"),
-            description: t("nearComDescription"),
+            description: isConfidential ? t("nearComDescription") : undefined,
             icon: NEAR_COM_ICON,
             networkName: "near",
         }),
-        [t],
+        [isConfidential, t],
     );
 
     const tokenNetworkOptions = useMemo((): RecipientNetworkOption[] => {
@@ -157,11 +159,15 @@ export function RecipientNetworkSelect({
             return {
                 id: network.id,
                 name: getNetworkDisplayName(network.name),
+                description:
+                    isConfidential && getBlockchainType(network.name) === "near"
+                        ? t("nearDescription")
+                        : undefined,
                 icon: iconUrl,
                 networkName: network.name,
             };
         });
-    }, [bridgeAssets, token, theme]);
+    }, [bridgeAssets, isConfidential, t, token, theme]);
 
     const availableOptions = useMemo(
         () => [nearComOption, ...tokenNetworkOptions],

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ArrowDownToLine, Info } from "lucide-react";
+import { ArrowDownToLine, Info, Shield } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -164,7 +164,22 @@ function Step1({
     return (
         <PageCard>
             <div className="flex justify-between items-center">
-                <StepperHeader title={tPay("newPayment")} />
+                <StepperHeader
+                    title={
+                        isConfidential ? (
+                            <span className="inline-flex items-center gap-1.5">
+                                <span>{tPay("title")}</span>
+                                <Tooltip content={tPay("confidentialTooltip")}>
+                                    <span className="inline-flex">
+                                        <Shield className="size-4 fill-foreground" />
+                                    </span>
+                                </Tooltip>
+                            </span>
+                        ) : (
+                            tPay("title")
+                        )
+                    }
+                />
                 <div className="flex items-center gap-2">
                     {isConfidential ? (
                         <Button
@@ -592,6 +607,7 @@ export default function PaymentsPage() {
         [tValidation],
     );
     const { treasuryId, isConfidential } = useTreasury();
+    const pageTitle = isConfidential ? t("confidentialTitle") : t("title");
     const { createProposal } = useNear();
     const { data: policy } = useTreasuryPolicy(treasuryId);
     const [step, setStep] = useState(0);
@@ -1095,7 +1111,7 @@ export default function PaymentsPage() {
     );
 
     return (
-        <PageComponentLayout title={t("title")} description={t("description")}>
+        <PageComponentLayout title={pageTitle} description={t("description")}>
             <Form {...form}>
                 <form
                     onSubmit={form.handleSubmit(onSubmit)}

--- a/nt-fe/components/select-list.tsx
+++ b/nt-fe/components/select-list.tsx
@@ -72,7 +72,7 @@ export function SelectListIcon({
                     src={icon}
                     alt={alt}
                     className={cn(
-                        "w-full h-full p-2 object-cover",
+                        "w-full h-full p-2 object-contain",
                         roundIcons && "rounded-full",
                         fixNear && alt === "NEAR" && "p-3",
                     )}

--- a/nt-fe/components/step-wizard.tsx
+++ b/nt-fe/components/step-wizard.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from "react";
+import type { ReactNode } from "react";
 import { Button } from "./button";
 import { ArrowLeftIcon, Loader2 } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
@@ -145,7 +146,7 @@ export function StepWizard({
 }
 
 interface HandleBackWithTitleProps {
-    title: string;
+    title: ReactNode;
     description?: string;
     handleBack?: () => void;
 }

--- a/nt-fe/e2e/confidential-deposit.spec.ts
+++ b/nt-fe/e2e/confidential-deposit.spec.ts
@@ -267,20 +267,23 @@ test("Confidential deposit — dashboard deposit modal flow", async ({
         page.getByText("Select asset and network to see deposit address"),
     ).toBeVisible();
 
-    // Deposit modal auto-select priority in UI is:
-    // prefill token -> owned USDC -> first "Your Assets" token by USD balance.
-    // In this sandbox scenario, Near is the first available owned asset.
+    // Deposit modal starts without a selected network when multiple
+    // destinations are available. Choose near.com (direct) explicitly.
+    const networkSelectButton = page.getByRole("button", {
+        name: /Select network/i,
+    });
+    await expect(networkSelectButton).toBeVisible({ timeout: 10_000 });
+    await networkSelectButton.click();
     await expect(
-        page.getByRole("button", { name: "near.com near.com" }),
-    ).toBeVisible({
-        timeout: 10_000,
-    });
+        page.getByRole("heading", { name: "Select Network" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await page
+        .getByRole("button", { name: /near\.com/i })
+        .first()
+        .click();
 
-    // Confidential flow defaults the network to near.com (direct NEAR deposit).
-    // Address shown should be the treasury ID, no intents deposit-address call.
-    const nearDirectButton = page.getByRole("button", {
-        name: "near.com near.com",
-    });
+    // near.com (direct) shows treasury address and skips intents deposit-address call.
+    const nearDirectButton = page.getByRole("button", { name: /near\.com/i });
     await expect(nearDirectButton).toBeVisible({ timeout: 10_000 });
 
     await expect(
@@ -298,11 +301,12 @@ test("Confidential deposit — dashboard deposit modal flow", async ({
         page.getByRole("heading", { name: "Select Network" }),
     ).toBeVisible({ timeout: 10_000 });
     await page
-        .getByRole("button", { name: /Near Protocol Near Protocol/ })
+        .getByRole("button", { name: /Near Protocol/i })
+        .first()
         .click();
 
     await expect(
-        page.getByRole("button", { name: "Near Protocol Near Protocol" }),
+        page.getByRole("button", { name: /Near Protocol/i }),
     ).toBeVisible({ timeout: 10_000 });
 
     // Wait for deposit address section to appear

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "Zahlungen",
-            "description": "Senden und empfangen Sie Mittel sicher"
+            "confidentialTitle": "Vertrauliche Zahlungen",
+            "description": "Geld sicher und geschuetzt senden."
         },
         "exchange": {
-            "title": "Tauschen",
+            "title": "Tausch",
+            "confidentialTitle": "Vertraulicher Tausch",
             "description": "Tauschen Sie Ihre Token sicher und effizient"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "Betrag muss größer als 0 sein",
             "recipientTokenSame": "Empfänger- und Token-Adresse dürfen nicht identisch sein"
         },
-        "newPayment": "Neue Zahlung",
+        "title": "Zahlung",
         "reviewYourPayment": "Überprüfen Sie Ihre Zahlung",
         "reviewButton": "Zahlung prüfen",
         "reviewButtonDisabled": "Betrag und Adresse eingeben",
@@ -911,7 +913,8 @@
         "confirmSubmit": "Anfrage bestätigen und absenden",
         "useDifferentAddress": "Andere Adresse verwenden",
         "failed1ClickQuote": "Erstellung des 1Click-Transfer-Angebots fehlgeschlagen",
-        "paymentSubmitted": "Anfrage zum Senden der Zahlung übermittelt"
+        "paymentSubmitted": "Anfrage zum Senden der Zahlung übermittelt",
+        "confidentialTooltip": "Empfaengerdaten und der angeforderte Betrag sind vollstaendig vertraulich."
     },
     "bulkPayment": {
         "comingSoonToast": "Sammelzahlungen kommen demnächst!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "Bitte genehmigen Sie diese Anfrage innerhalb von 24 Stunden, andernfalls läuft sie ab. Wir empfehlen, so bald wie möglich zu bestätigen.",
         "confirmSubmit": "Anfrage bestätigen und absenden",
-        "refreshingIn": "Wechselkurs wird in {seconds}s aktualisiert"
+        "refreshingIn": "Wechselkurs wird in {seconds}s aktualisiert",
+        "confidentialTooltip": "Die Betraege, die Sie senden und erhalten, sind vollstaendig vertraulich."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "Demnächst verfügbar",
         "forMembersOnly": "Nur für Mitglieder",
         "nearComName": "near.com",
-        "nearComDescription": "Internes Netzwerk für near.com und Trezu"
+        "nearComDescription": "Vertrauliches Netzwerk für near.com und Trezu",
+        "nearDescription": "Netzwerk für öffentliche Auszahlungen"
     },
     "addressBookTable": {
         "emptyTitle": "Noch keine Empfänger",
@@ -1707,7 +1712,7 @@
         "vestedToken": "Gevestetes Token",
         "staked": "Gestaked",
         "fungibleToken": "Fungibles Token",
-        "intentsToken": "Intents-Token",
+        "intentsToken": "near.com",
         "nativeToken": "Natives Token"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "Payments",
-            "description": "Send and receive funds securely"
+            "confidentialTitle": "Confidential Payments",
+            "description": "Send funds safely and securely."
         },
         "exchange": {
             "title": "Exchange",
+            "confidentialTitle": "Confidential Exchange",
             "description": "Exchange your tokens securely and efficiently"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "Amount must be greater than 0",
             "recipientTokenSame": "Recipient and token address cannot be the same"
         },
-        "newPayment": "New Payment",
+        "title": "Payment",
         "reviewYourPayment": "Review Your Payment",
         "reviewButton": "Review Payment",
         "reviewButtonDisabled": "Enter amount and address",
@@ -911,7 +913,8 @@
         "confirmSubmit": "Confirm and Submit Request",
         "useDifferentAddress": "Use a different address",
         "failed1ClickQuote": "Failed to create 1Click transfer quote",
-        "paymentSubmitted": "Request to send payment submitted"
+        "paymentSubmitted": "Request to send payment submitted",
+        "confidentialTooltip": "Recipient details and the requested amount are fully confidential."
     },
     "bulkPayment": {
         "comingSoonToast": "Bulk payments are coming soon!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "Please approve this request within 24 hours, otherwise it will expire. We recommend confirming as soon as possible.",
         "confirmSubmit": "Confirm and Submit Request",
-        "refreshingIn": "Exchange rate will refresh in {seconds}s"
+        "refreshingIn": "Exchange rate will refresh in {seconds}s",
+        "confidentialTooltip": "The amounts you send and receive are completely confidential."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "Coming Soon",
         "forMembersOnly": "For Members Only",
         "nearComName": "near.com",
-        "nearComDescription": "Internal Network for near.com and trezu"
+        "nearComDescription": "Confidential network of near.com and trezu",
+        "nearDescription": "Network for public withdrawal"
     },
     "addressBookTable": {
         "emptyTitle": "No recipients yet",
@@ -1707,7 +1712,7 @@
         "vestedToken": "Vested Token",
         "staked": "Staked",
         "fungibleToken": "Fungible Token",
-        "intentsToken": "Intents Token",
+        "intentsToken": "near.com",
         "nativeToken": "Native Token"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "Pagos",
-            "description": "Envía y recibe fondos de forma segura"
+            "confidentialTitle": "Pagos confidenciales",
+            "description": "Envia fondos de forma segura y protegida."
         },
         "exchange": {
             "title": "Intercambio",
+            "confidentialTitle": "Intercambio confidencial",
             "description": "Intercambia tus tokens de forma segura y eficiente"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "El importe debe ser mayor que 0",
             "recipientTokenSame": "La dirección del destinatario y del token no pueden ser iguales"
         },
-        "newPayment": "Nuevo pago",
+        "title": "Pago",
         "reviewYourPayment": "Revisa tu pago",
         "reviewButton": "Revisar pago",
         "reviewButtonDisabled": "Introduce un importe y una dirección",
@@ -911,7 +913,8 @@
         "confirmSubmit": "Confirmar y enviar solicitud",
         "useDifferentAddress": "Usa una dirección diferente",
         "failed1ClickQuote": "No se pudo crear la cotización de transferencia 1Click",
-        "paymentSubmitted": "Solicitud de envío de pago enviada"
+        "paymentSubmitted": "Solicitud de envío de pago enviada",
+        "confidentialTooltip": "Los datos del destinatario y el importe solicitado son totalmente confidenciales."
     },
     "bulkPayment": {
         "comingSoonToast": "¡Los pagos masivos estarán disponibles pronto!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "Aprueba esta solicitud en 24 horas, de lo contrario caducará. Te recomendamos confirmar cuanto antes.",
         "confirmSubmit": "Confirmar y enviar solicitud",
-        "refreshingIn": "La tasa de cambio se actualizará en {seconds}s"
+        "refreshingIn": "La tasa de cambio se actualizará en {seconds}s",
+        "confidentialTooltip": "Los importes que envias y recibes son completamente confidenciales."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "Próximamente",
         "forMembersOnly": "Solo para miembros",
         "nearComName": "near.com",
-        "nearComDescription": "Red interna para near.com y trezu"
+        "nearComDescription": "Red confidencial para near.com y trezu",
+        "nearDescription": "Red para retiro público"
     },
     "addressBookTable": {
         "emptyTitle": "Aún no hay destinatarios",
@@ -1707,7 +1712,7 @@
         "vestedToken": "Token en vesting",
         "staked": "En staking",
         "fungibleToken": "Token fungible",
-        "intentsToken": "Token de intents",
+        "intentsToken": "near.com",
         "nativeToken": "Token nativo"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "Paiements",
-            "description": "Envoyez et recevez des fonds en toute sécurité"
+            "confidentialTitle": "Paiements confidentiels",
+            "description": "Envoyez des fonds de facon sure et securisee."
         },
         "exchange": {
-            "title": "Échange",
+            "title": "Echange",
+            "confidentialTitle": "Echange confidentiel",
             "description": "Échangez vos tokens en toute sécurité et efficacité"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "Le montant doit être supérieur à 0",
             "recipientTokenSame": "Le destinataire et l'adresse du token ne peuvent pas être identiques"
         },
-        "newPayment": "Nouveau paiement",
+        "title": "Paiement",
         "reviewYourPayment": "Vérifiez votre paiement",
         "reviewButton": "Vérifier le paiement",
         "reviewButtonDisabled": "Saisissez le montant et l'adresse",
@@ -911,7 +913,8 @@
         "confirmSubmit": "Confirmer et soumettre la demande",
         "useDifferentAddress": "Utiliser une adresse différente",
         "failed1ClickQuote": "Échec de la création du devis de transfert 1Click",
-        "paymentSubmitted": "Demande d'envoi de paiement soumise"
+        "paymentSubmitted": "Demande d'envoi de paiement soumise",
+        "confidentialTooltip": "Les informations du destinataire et le montant demande sont entierement confidentiels."
     },
     "bulkPayment": {
         "comingSoonToast": "Les paiements groupés arrivent bientôt !",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "Veuillez approuver cette demande dans les 24 heures, sinon elle expirera. Nous recommandons de confirmer dès que possible.",
         "confirmSubmit": "Confirmer et soumettre la demande",
-        "refreshingIn": "Le taux d'échange sera actualisé dans {seconds} s"
+        "refreshingIn": "Le taux d'échange sera actualisé dans {seconds} s",
+        "confidentialTooltip": "Les montants que vous envoyez et recevez sont entierement confidentiels."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "Bientôt disponible",
         "forMembersOnly": "Réservé aux membres",
         "nearComName": "near.com",
-        "nearComDescription": "Réseau interne pour near.com et trezu"
+        "nearComDescription": "Réseau confidentiel pour near.com et trezu",
+        "nearDescription": "Réseau pour retrait public"
     },
     "addressBookTable": {
         "emptyTitle": "Aucun destinataire pour l'instant",
@@ -1707,7 +1712,7 @@
         "vestedToken": "Token acquis",
         "staked": "Staké",
         "fungibleToken": "Token fongible",
-        "intentsToken": "Token Intents",
+        "intentsToken": "near.com",
         "nativeToken": "Token natif"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "תשלומים",
-            "description": "שלח וקבל כספים באופן מאובטח"
+            "confidentialTitle": "תשלומים חסויים",
+            "description": "שלחו כספים בבטחה ובאופן מאובטח."
         },
         "exchange": {
             "title": "החלפה",
+            "confidentialTitle": "החלפה חסויה",
             "description": "החלף את הטוקנים שלך באופן מאובטח ויעיל"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "הסכום חייב להיות גדול מ-0",
             "recipientTokenSame": "כתובת הנמען והטוקן אינן יכולות להיות זהות"
         },
-        "newPayment": "תשלום חדש",
+        "title": "תשלום",
         "reviewYourPayment": "סקור את התשלום שלך",
         "reviewButton": "סקור תשלום",
         "reviewButtonDisabled": "הזן סכום וכתובת",
@@ -911,7 +913,8 @@
         "confirmSubmit": "אשר ושלח בקשה",
         "useDifferentAddress": "השתמש בכתובת אחרת",
         "failed1ClickQuote": "יצירת ציטוט העברה של 1Click נכשלה",
-        "paymentSubmitted": "בקשה לשליחת תשלום נשלחה"
+        "paymentSubmitted": "בקשה לשליחת תשלום נשלחה",
+        "confidentialTooltip": "פרטי הנמען והסכום המבוקש חסויים לחלוטין."
     },
     "bulkPayment": {
         "comingSoonToast": "תשלומים בכמויות יגיעו בקרוב!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "אנא אשר בקשה זו בתוך 24 שעות, אחרת היא תפוג. אנו ממליצים לאשר בהקדם האפשרי.",
         "confirmSubmit": "אשר ושלח בקשה",
-        "refreshingIn": "שער ההחלפה יתרענן בעוד {seconds} שניות"
+        "refreshingIn": "שער ההחלפה יתרענן בעוד {seconds} שניות",
+        "confidentialTooltip": "הסכומים שאתם שולחים ומקבלים חסויים לחלוטין."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "בקרוב",
         "forMembersOnly": "לחברים בלבד",
         "nearComName": "near.com",
-        "nearComDescription": "רשת פנימית עבור near.com ו-Trezu"
+        "nearComDescription": "רשת סודית עבור near.com ו-Trezu",
+        "nearDescription": "רשת למשיכה ציבורית"
     },
     "addressBookTable": {
         "emptyTitle": "אין נמענים עדיין",
@@ -1707,7 +1712,7 @@
         "vestedToken": "טוקן שהובשל",
         "staked": "בסטייקינג",
         "fungibleToken": "טוקן סחיר",
-        "intentsToken": "טוקן Intents",
+        "intentsToken": "near.com",
         "nativeToken": "טוקן מקורי"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "Pembayaran",
-            "description": "Kirim dan terima dana dengan aman"
+            "confidentialTitle": "Pembayaran rahasia",
+            "description": "Kirim dana dengan aman dan terlindungi."
         },
         "exchange": {
-            "title": "Tukar",
+            "title": "Penukaran",
+            "confidentialTitle": "Penukaran rahasia",
             "description": "Tukar token Anda dengan aman dan efisien"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "Jumlah harus lebih besar dari 0",
             "recipientTokenSame": "Alamat penerima dan token tidak boleh sama"
         },
-        "newPayment": "Pembayaran Baru",
+        "title": "Pembayaran",
         "reviewYourPayment": "Tinjau Pembayaran Anda",
         "reviewButton": "Tinjau Pembayaran",
         "reviewButtonDisabled": "Masukkan jumlah dan alamat",
@@ -911,7 +913,8 @@
         "confirmSubmit": "Konfirmasi dan Kirim Permintaan",
         "useDifferentAddress": "Gunakan alamat berbeda",
         "failed1ClickQuote": "Gagal membuat kuotasi transfer 1Click",
-        "paymentSubmitted": "Permintaan untuk mengirim pembayaran telah dikirim"
+        "paymentSubmitted": "Permintaan untuk mengirim pembayaran telah dikirim",
+        "confidentialTooltip": "Detail penerima dan jumlah yang diminta sepenuhnya rahasia."
     },
     "bulkPayment": {
         "comingSoonToast": "Pembayaran massal akan segera hadir!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "Silakan setujui permintaan ini dalam 24 jam, jika tidak akan kedaluwarsa. Kami sarankan untuk mengonfirmasi sesegera mungkin.",
         "confirmSubmit": "Konfirmasi dan Kirim Permintaan",
-        "refreshingIn": "Nilai tukar akan diperbarui dalam {seconds}d"
+        "refreshingIn": "Nilai tukar akan diperbarui dalam {seconds}d",
+        "confidentialTooltip": "Jumlah yang Anda kirim dan terima sepenuhnya rahasia."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "Segera Hadir",
         "forMembersOnly": "Hanya untuk anggota",
         "nearComName": "near.com",
-        "nearComDescription": "Jaringan Internal untuk near.com dan trezu"
+        "nearComDescription": "Jaringan rahasia untuk near.com dan trezu",
+        "nearDescription": "Jaringan untuk penarikan publik"
     },
     "addressBookTable": {
         "emptyTitle": "Belum ada penerima",
@@ -1707,7 +1712,7 @@
         "vestedToken": "Token Tervesting",
         "staked": "Di-staking",
         "fungibleToken": "Token Fungible",
-        "intentsToken": "Token Intents",
+        "intentsToken": "near.com",
         "nativeToken": "Token Native"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "支払い",
-            "description": "資金を安全に送受信"
+            "confidentialTitle": "機密支払い",
+            "description": "資金を安全かつ確実に送金します。"
         },
         "exchange": {
             "title": "交換",
+            "confidentialTitle": "機密交換",
             "description": "トークンを安全かつ効率的に交換"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "金額は0より大きくなければなりません",
             "recipientTokenSame": "受取人とトークンアドレスは同じであってはなりません"
         },
-        "newPayment": "新しい支払い",
+        "title": "支払い",
         "reviewYourPayment": "支払いを確認",
         "reviewButton": "支払いを確認",
         "reviewButtonDisabled": "金額とアドレスを入力してください",
@@ -911,7 +913,8 @@
         "confirmSubmit": "確認してリクエストを送信",
         "useDifferentAddress": "別のアドレスを使用",
         "failed1ClickQuote": "1Click送金見積りの作成に失敗しました",
-        "paymentSubmitted": "支払い送信のリクエストを送信しました"
+        "paymentSubmitted": "支払い送信のリクエストを送信しました",
+        "confidentialTooltip": "受取人の詳細と要求金額は完全に機密です。"
     },
     "bulkPayment": {
         "comingSoonToast": "一括支払いは近日公開予定です!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "このリクエストは24時間以内に承認してください。期限を過ぎると失効します。できるだけ早く確認することをおすすめします。",
         "confirmSubmit": "確認してリクエストを送信",
-        "refreshingIn": "交換レートは{seconds}秒後に更新されます"
+        "refreshingIn": "交換レートは{seconds}秒後に更新されます",
+        "confidentialTooltip": "送信額と受取額は完全に機密です。"
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "近日公開",
         "forMembersOnly": "メンバー限定",
         "nearComName": "near.com",
-        "nearComDescription": "near.comとtrezuの内部ネットワーク"
+        "nearComDescription": "near.comとtrezuの機密ネットワーク",
+        "nearDescription": "公開出金用ネットワーク"
     },
     "addressBookTable": {
         "emptyTitle": "受取人はまだいません",
@@ -1707,7 +1712,7 @@
         "vestedToken": "ベスト済みトークン",
         "staked": "ステーキング中",
         "fungibleToken": "代替性トークン",
-        "intentsToken": "Intentsトークン",
+        "intentsToken": "near.com",
         "nativeToken": "ネイティブトークン"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "결제",
-            "description": "안전하게 자금을 송금하고 수신하세요"
+            "confidentialTitle": "기밀 결제",
+            "description": "자금을 안전하고 확실하게 보냅니다."
         },
         "exchange": {
             "title": "교환",
+            "confidentialTitle": "기밀 교환",
             "description": "토큰을 안전하고 효율적으로 교환하세요"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "금액은 0보다 커야 합니다",
             "recipientTokenSame": "수신자와 토큰 주소는 같을 수 없습니다"
         },
-        "newPayment": "새 결제",
+        "title": "결제",
         "reviewYourPayment": "결제 검토",
         "reviewButton": "결제 검토",
         "reviewButtonDisabled": "금액과 주소를 입력하세요",
@@ -911,7 +913,8 @@
         "confirmSubmit": "확인 및 요청 제출",
         "useDifferentAddress": "다른 주소 사용",
         "failed1ClickQuote": "1Click 전송 견적 생성에 실패했습니다",
-        "paymentSubmitted": "결제 송금 요청이 제출되었습니다"
+        "paymentSubmitted": "결제 송금 요청이 제출되었습니다",
+        "confidentialTooltip": "수취인 정보와 요청 금액은 완전히 기밀입니다."
     },
     "bulkPayment": {
         "comingSoonToast": "일괄 결제는 곧 출시됩니다!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "24시간 이내에 이 요청을 승인해 주세요. 그렇지 않으면 만료됩니다. 가능한 한 빨리 확인하는 것을 권장합니다.",
         "confirmSubmit": "확인 및 요청 제출",
-        "refreshingIn": "환율은 {seconds}초 후에 새로 고침됩니다"
+        "refreshingIn": "환율은 {seconds}초 후에 새로 고침됩니다",
+        "confidentialTooltip": "보내는 금액과 받는 금액은 완전히 기밀입니다."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "곧 제공",
         "forMembersOnly": "회원 전용",
         "nearComName": "near.com",
-        "nearComDescription": "near.com 및 trezu용 내부 네트워크"
+        "nearComDescription": "near.com 및 trezu용 기밀 네트워크",
+        "nearDescription": "공개 출금을 위한 네트워크"
     },
     "addressBookTable": {
         "emptyTitle": "아직 수신자가 없습니다",
@@ -1707,7 +1712,7 @@
         "vestedToken": "베스팅된 토큰",
         "staked": "스테이킹됨",
         "fungibleToken": "대체 가능 토큰",
-        "intentsToken": "Intents 토큰",
+        "intentsToken": "near.com",
         "nativeToken": "네이티브 토큰"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "Pagamentos",
-            "description": "Envie e receba fundos com segurança"
+            "confidentialTitle": "Pagamentos confidenciais",
+            "description": "Envie fundos com seguranca e protecao."
         },
         "exchange": {
             "title": "Troca",
+            "confidentialTitle": "Troca confidencial",
             "description": "Troque seus tokens de forma segura e eficiente"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "O valor deve ser maior que 0",
             "recipientTokenSame": "O destinatário e o endereço do token não podem ser iguais"
         },
-        "newPayment": "Novo pagamento",
+        "title": "Pagamento",
         "reviewYourPayment": "Revise seu pagamento",
         "reviewButton": "Revisar pagamento",
         "reviewButtonDisabled": "Insira o valor e o endereço",
@@ -911,7 +913,8 @@
         "confirmSubmit": "Confirmar e enviar solicitação",
         "useDifferentAddress": "Usar um endereço diferente",
         "failed1ClickQuote": "Falha ao criar cotação de transferência 1Click",
-        "paymentSubmitted": "Solicitação de envio de pagamento enviada"
+        "paymentSubmitted": "Solicitação de envio de pagamento enviada",
+        "confidentialTooltip": "Os dados do destinatario e o valor solicitado sao totalmente confidenciais."
     },
     "bulkPayment": {
         "comingSoonToast": "Pagamentos em massa estão chegando em breve!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "Por favor, aprove esta solicitação em até 24 horas, caso contrário ela expirará. Recomendamos confirmar o quanto antes.",
         "confirmSubmit": "Confirmar e enviar solicitação",
-        "refreshingIn": "A taxa de câmbio será atualizada em {seconds}s"
+        "refreshingIn": "A taxa de câmbio será atualizada em {seconds}s",
+        "confidentialTooltip": "Os valores que voce envia e recebe sao totalmente confidenciais."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "Em breve",
         "forMembersOnly": "Apenas para membros",
         "nearComName": "near.com",
-        "nearComDescription": "Rede interna para near.com e trezu"
+        "nearComDescription": "Rede confidencial da near.com e trezu",
+        "nearDescription": "Rede para saque público"
     },
     "addressBookTable": {
         "emptyTitle": "Nenhum destinatário ainda",
@@ -1707,7 +1712,7 @@
         "vestedToken": "Token liberado",
         "staked": "Em staking",
         "fungibleToken": "Token fungível",
-        "intentsToken": "Token de Intents",
+        "intentsToken": "near.com",
         "nativeToken": "Token nativo"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -159,11 +159,13 @@
             "description": "Kayıtlı alıcılarınızı yönetin"
         },
         "payments": {
-            "title": "Ödemeler",
-            "description": "Güvenle para gönderin ve alın"
+            "title": "Odemeler",
+            "confidentialTitle": "Gizli odemeler",
+            "description": "Fonlari guvenli ve emniyetli sekilde gonderin."
         },
         "exchange": {
             "title": "Takas",
+            "confidentialTitle": "Gizli takas",
             "description": "Tokenlerinizi güvenli ve verimli bir şekilde takas edin"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "Miktar 0'dan büyük olmalıdır",
             "recipientTokenSame": "Alıcı ve token adresi aynı olamaz"
         },
-        "newPayment": "Yeni Ödeme",
+        "title": "Odeme",
         "reviewYourPayment": "Ödemenizi İnceleyin",
         "reviewButton": "Ödemeyi İncele",
         "reviewButtonDisabled": "Miktar ve adres girin",
@@ -911,7 +913,8 @@
         "confirmSubmit": "Onayla ve Talebi Gönder",
         "useDifferentAddress": "Farklı bir adres kullan",
         "failed1ClickQuote": "1Click transfer teklifi oluşturulamadı",
-        "paymentSubmitted": "Ödeme gönderme talebi gönderildi"
+        "paymentSubmitted": "Ödeme gönderme talebi gönderildi",
+        "confidentialTooltip": "Alici bilgileri ve talep edilen tutar tamamen gizlidir."
     },
     "bulkPayment": {
         "comingSoonToast": "Toplu ödemeler yakında geliyor!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "Lütfen bu talebi 24 saat içinde onaylayın, aksi takdirde süresi dolacaktır. Mümkün olan en kısa sürede onaylamanızı öneririz.",
         "confirmSubmit": "Onayla ve Talebi Gönder",
-        "refreshingIn": "Takas oranı {seconds}sn içinde yenilenecek"
+        "refreshingIn": "Takas oranı {seconds}sn içinde yenilenecek",
+        "confidentialTooltip": "Gonderdiginiz ve aldiginiz tutarlar tamamen gizlidir."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "Yakında",
         "forMembersOnly": "Yalnızca Üyelere Özel",
         "nearComName": "near.com",
-        "nearComDescription": "near.com ve trezu için Dahili Ağ"
+        "nearComDescription": "near.com ve trezu için gizli ağ",
+        "nearDescription": "Herkese açık para çekme ağı"
     },
     "addressBookTable": {
         "emptyTitle": "Henüz alıcı yok",
@@ -1707,7 +1712,7 @@
         "vestedToken": "Vested Token",
         "staked": "Stake Edildi",
         "fungibleToken": "Fungible Token",
-        "intentsToken": "Intents Token",
+        "intentsToken": "near.com",
         "nativeToken": "Native Token"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "Платежі",
-            "description": "Безпечно надсилайте та отримуйте кошти"
+            "confidentialTitle": "Конфіденційні платежі",
+            "description": "Надсилайте кошти безпечно та надійно."
         },
         "exchange": {
             "title": "Обмін",
+            "confidentialTitle": "Конфіденційний обмін",
             "description": "Обмінюйте токени безпечно й ефективно"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "Сума має бути більшою за 0",
             "recipientTokenSame": "Адреса отримувача й токена не можуть збігатись"
         },
-        "newPayment": "Новий платіж",
+        "title": "Платіж",
         "reviewYourPayment": "Перегляньте ваш платіж",
         "reviewButton": "Переглянути платіж",
         "reviewButtonDisabled": "Введіть суму та адресу",
@@ -911,7 +913,8 @@
         "confirmSubmit": "Підтвердити та надіслати запит",
         "useDifferentAddress": "Використайте іншу адресу",
         "failed1ClickQuote": "Не вдалось створити котирування 1Click",
-        "paymentSubmitted": "Запит на надсилання платежу подано"
+        "paymentSubmitted": "Запит на надсилання платежу подано",
+        "confidentialTooltip": "Дані отримувача та запитана сума повністю конфіденційні."
     },
     "bulkPayment": {
         "comingSoonToast": "Масові платежі незабаром!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "Схваліть цей запит протягом 24 годин, інакше він спливе. Рекомендуємо підтвердити якнайшвидше.",
         "confirmSubmit": "Підтвердити та надіслати запит",
-        "refreshingIn": "Курс оновиться через {seconds}с"
+        "refreshingIn": "Курс оновиться через {seconds}с",
+        "confidentialTooltip": "Суми, які ви надсилаєте та отримуєте, повністю конфіденційні."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "Скоро",
         "forMembersOnly": "Лише для учасників",
         "nearComName": "near.com",
-        "nearComDescription": "Внутрішня мережа для near.com і trezu"
+        "nearComDescription": "Конфіденційна мережа near.com і trezu",
+        "nearDescription": "Мережа для публічного виведення"
     },
     "addressBookTable": {
         "emptyTitle": "Ще немає одержувачів",
@@ -1707,7 +1712,7 @@
         "vestedToken": "Токен вестингу",
         "staked": "Застейковано",
         "fungibleToken": "Фандж. токен",
-        "intentsToken": "Токен Intents",
+        "intentsToken": "near.com",
         "nativeToken": "Нативний токен"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -159,11 +159,13 @@
             "description": "Quản lý người nhận đã lưu của bạn"
         },
         "payments": {
-            "title": "Thanh toán",
-            "description": "Gửi và nhận tiền một cách an toàn"
+            "title": "Thanh toan",
+            "confidentialTitle": "Thanh toan bao mat",
+            "description": "Gui tien an toan va bao mat."
         },
         "exchange": {
-            "title": "Trao đổi",
+            "title": "Hoan doi",
+            "confidentialTitle": "Hoan doi bao mat",
             "description": "Trao đổi token một cách an toàn và hiệu quả"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "Số tiền phải lớn hơn 0",
             "recipientTokenSame": "Địa chỉ người nhận và token không thể giống nhau"
         },
-        "newPayment": "Thanh toán mới",
+        "title": "Thanh toan",
         "reviewYourPayment": "Xem lại thanh toán của bạn",
         "reviewButton": "Xem lại thanh toán",
         "reviewButtonDisabled": "Nhập số tiền và địa chỉ",
@@ -911,7 +913,8 @@
         "confirmSubmit": "Xác nhận và gửi yêu cầu",
         "useDifferentAddress": "Dùng một địa chỉ khác",
         "failed1ClickQuote": "Không thể tạo báo giá chuyển 1Click",
-        "paymentSubmitted": "Đã gửi yêu cầu thanh toán"
+        "paymentSubmitted": "Đã gửi yêu cầu thanh toán",
+        "confidentialTooltip": "Thong tin nguoi nhan va so tien yeu cau duoc bao mat hoan toan."
     },
     "bulkPayment": {
         "comingSoonToast": "Thanh toán hàng loạt sắp ra mắt!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "Vui lòng phê duyệt yêu cầu này trong vòng 24 giờ, nếu không nó sẽ hết hạn. Chúng tôi khuyên bạn xác nhận càng sớm càng tốt.",
         "confirmSubmit": "Xác nhận và gửi yêu cầu",
-        "refreshingIn": "Tỷ giá trao đổi sẽ làm mới trong {seconds}s"
+        "refreshingIn": "Tỷ giá trao đổi sẽ làm mới trong {seconds}s",
+        "confidentialTooltip": "So tien ban gui va nhan duoc bao mat hoan toan."
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "Sắp ra mắt",
         "forMembersOnly": "Chỉ dành cho thành viên",
         "nearComName": "near.com",
-        "nearComDescription": "Mạng nội bộ cho near.com và trezu"
+        "nearComDescription": "Mạng bảo mật của near.com và trezu",
+        "nearDescription": "Mạng dành cho rút tiền công khai"
     },
     "addressBookTable": {
         "emptyTitle": "Chưa có người nhận nào",
@@ -1707,7 +1712,7 @@
         "vestedToken": "Token đã vesting",
         "staked": "Đã stake",
         "fungibleToken": "Token có thể thay thế",
-        "intentsToken": "Token Intents",
+        "intentsToken": "near.com",
         "nativeToken": "Token gốc"
     },
     "exchangeErrors": {

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -160,10 +160,12 @@
         },
         "payments": {
             "title": "付款",
-            "description": "安全地发送与接收资金"
+            "confidentialTitle": "机密付款",
+            "description": "安全可靠地发送资金。"
         },
         "exchange": {
             "title": "兑换",
+            "confidentialTitle": "机密兑换",
             "description": "安全高效地兑换您的代币"
         },
         "vesting": {
@@ -897,7 +899,7 @@
             "amountPositive": "金额必须大于 0",
             "recipientTokenSame": "收款人地址不能与代币地址相同"
         },
-        "newPayment": "新建付款",
+        "title": "付款",
         "reviewYourPayment": "审核您的付款",
         "reviewButton": "审核付款",
         "reviewButtonDisabled": "请输入金额和地址",
@@ -911,7 +913,8 @@
         "confirmSubmit": "确认并提交请求",
         "useDifferentAddress": "使用其他地址",
         "failed1ClickQuote": "创建 1Click 转账报价失败",
-        "paymentSubmitted": "发送付款的请求已提交"
+        "paymentSubmitted": "发送付款的请求已提交",
+        "confidentialTooltip": "收款人信息和请求金额完全保密。"
     },
     "bulkPayment": {
         "comingSoonToast": "批量付款功能即将推出!",
@@ -1025,7 +1028,8 @@
         },
         "approveWithin24h": "请在 24 小时内批准此请求,否则它将过期。建议尽快确认。",
         "confirmSubmit": "确认并提交请求",
-        "refreshingIn": "兑换汇率将在 {seconds} 秒后刷新"
+        "refreshingIn": "兑换汇率将在 {seconds} 秒后刷新",
+        "confidentialTooltip": "您发送和接收的金额完全保密。"
     },
     "vesting": {
         "validation": {
@@ -1535,7 +1539,8 @@
         "comingSoon": "即将推出",
         "forMembersOnly": "仅限成员",
         "nearComName": "near.com",
-        "nearComDescription": "near.com 与 trezu 的内部网络"
+        "nearComDescription": "near.com 与 trezu 的机密网络",
+        "nearDescription": "用于公开提现的网络"
     },
     "addressBookTable": {
         "emptyTitle": "暂无收款人",
@@ -1707,7 +1712,7 @@
         "vestedToken": "归属代币",
         "staked": "已质押",
         "fungibleToken": "同质化代币",
-        "intentsToken": "Intents 代币",
+        "intentsToken": "near.com",
         "nativeToken": "原生代币"
     },
     "exchangeErrors": {


### PR DESCRIPTION
- Updated network descriptions for recipient selection:
  - In confidential mode:
    - `near.com` shows: “Confidential network of near.com and trezu”
    - `near` shows: “Network for public withdrawal”
  - In public mode: no network description is shown.

- Standardized `Intents Token` display in UI to use `near.com`.
- Fixed confidential deposit network behavior:
  - If token has multiple networks (example: USDC), no network is auto-selected.
  - Network is auto-selected only when there is exactly one available network.
- Added confidential `near.com` description to deposit network selector.
- Added confidential shield to payment and exchange form titles.
