### PR TITLE
fix: normalize NEAR vs near.com network display

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -16,6 +16,11 @@ import {
     DialogTitle,
 } from "@/components/modal";
 import { getNetworkDisplayName } from "@/components/token-display";
+import {
+    getNetworkDisplayCaseClass,
+    NEAR_COM_DIRECT_NETWORK_ID,
+    NEAR_COM_NETWORK_NAME,
+} from "@/constants/intents";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Form, FormField, FormItem, FormMessage } from "@/components/ui/form";
 import { useAggregatedTokens, useAssets } from "@/hooks/use-assets";
@@ -95,8 +100,6 @@ interface NetworkBalanceDisplay {
 }
 
 const STABLE_EMPTY_ARRAY: never[] = [];
-
-const NEAR_DIRECT_NETWORK_ID = "near.com:direct";
 
 export function DepositModal({
     isOpen,
@@ -204,7 +207,8 @@ export function DepositModal({
             return buildSectionedOptions(filteredNetworks, [
                 {
                     title: t("sections.available"),
-                    filter: (network) => network.id === NEAR_DIRECT_NETWORK_ID,
+                    filter: (network) =>
+                        network.id === NEAR_COM_DIRECT_NETWORK_ID,
                 },
                 {
                     title: t("sections.forMembersOnly"),
@@ -232,8 +236,8 @@ export function DepositModal({
                 return !balance || !Big(balance.amount).gt(0);
             })
             .sort((a, b) => {
-                if (a.id === NEAR_DIRECT_NETWORK_ID) return -1;
-                if (b.id === NEAR_DIRECT_NETWORK_ID) return 1;
+                if (a.id === NEAR_COM_DIRECT_NETWORK_ID) return -1;
+                if (b.id === NEAR_COM_DIRECT_NETWORK_ID) return 1;
                 return a.name.localeCompare(b.name);
             });
 
@@ -403,8 +407,8 @@ export function DepositModal({
         };
 
         const nearDirectNetworkOption = (): SelectOption => ({
-            id: NEAR_DIRECT_NETWORK_ID,
-            name: "near.com",
+            id: NEAR_COM_DIRECT_NETWORK_ID,
+            name: NEAR_COM_NETWORK_NAME,
             description: isConfidential
                 ? tRecipientNetwork("nearComDescription")
                 : undefined,
@@ -608,7 +612,7 @@ export function DepositModal({
             }
             const requestId = ++latestAddressRequestRef.current;
 
-            if (selectedNetwork.id === NEAR_DIRECT_NETWORK_ID) {
+            if (selectedNetwork.id === NEAR_COM_DIRECT_NETWORK_ID) {
                 if (requestId !== latestAddressRequestRef.current) return;
                 setDepositInfo({
                     address: treasuryId,
@@ -755,13 +759,15 @@ export function DepositModal({
         );
     };
 
-    const isNearComNetwork = selectedNetwork?.id === NEAR_DIRECT_NETWORK_ID;
-    const showConfidentialDepositWarning = isConfidential && !isNearComNetwork;
+    const isNearComSelected =
+        selectedNetwork?.id === NEAR_COM_DIRECT_NETWORK_ID;
+    const showConfidentialDepositWarning = isConfidential && !isNearComSelected;
     const onlyDepositNetworkName = selectedNetwork
         ? getNetworkDisplayName(selectedNetwork.name)
         : "";
-    const shouldCapitalizeOnlyDepositNetwork =
-        onlyDepositNetworkName.toLowerCase() !== "near.com";
+    const networkDisplayCaseClass = selectedNetwork
+        ? getNetworkDisplayCaseClass(selectedNetwork.name)
+        : "capitalize";
     const shouldBlurConfidentialAddress =
         showConfidentialDepositWarning && !hasAcknowledgedSingleUse;
 
@@ -906,7 +912,15 @@ export function DepositModal({
                                                                     </div>
                                                                 )}
                                                                 <div className="flex flex-col">
-                                                                    <span className="text-foreground font-medium uppercase">
+                                                                    <span
+                                                                        className={cn(
+                                                                            "text-foreground font-medium",
+                                                                            getNetworkDisplayCaseClass(
+                                                                                selectedNetwork.name,
+                                                                                "uppercase",
+                                                                            ),
+                                                                        )}
+                                                                    >
                                                                         {getNetworkDisplayName(
                                                                             selectedNetwork.name,
                                                                         )}
@@ -1119,11 +1133,10 @@ export function DepositModal({
                                                 ),
                                                 networkTag: (chunks) => (
                                                     <span
-                                                        className={`text-foreground ${
-                                                            shouldCapitalizeOnlyDepositNetwork
-                                                                ? "capitalize"
-                                                                : ""
-                                                        }`}
+                                                        className={cn(
+                                                            "text-foreground",
+                                                            networkDisplayCaseClass,
+                                                        )}
                                                     >
                                                         {chunks}
                                                     </span>
@@ -1228,7 +1241,15 @@ export function DepositModal({
                                 const option = item as SelectOption;
                                 return (
                                     <div className="flex-1 text-left">
-                                        <div className="font-semibold uppercase">
+                                        <div
+                                            className={cn(
+                                                "font-semibold",
+                                                getNetworkDisplayCaseClass(
+                                                    option.name,
+                                                    "uppercase",
+                                                ),
+                                            )}
+                                        >
                                             {option.name || option.symbol}
                                         </div>
                                         {option.description && (

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -17,10 +17,10 @@ import {
 } from "@/components/modal";
 import { getNetworkDisplayName } from "@/components/token-display";
 import {
-    getNetworkDisplayCaseClass,
+    NEAR_NETWORK_ID,
     NEAR_COM_DIRECT_NETWORK_ID,
     NEAR_COM_NETWORK_NAME,
-} from "@/constants/intents";
+} from "@/constants/network-ids";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Form, FormField, FormItem, FormMessage } from "@/components/ui/form";
 import { useAggregatedTokens, useAssets } from "@/hooks/use-assets";
@@ -29,6 +29,7 @@ import { type BridgeNetwork, useBridgeTokens } from "@/hooks/use-bridge-tokens";
 import { useTreasury } from "@/hooks/use-treasury";
 import Big from "@/lib/big";
 import { fetchDepositAddress } from "@/lib/bridge-api";
+import { getNetworkDisplayCaseClass } from "@/lib/intents-network";
 import { buildSectionedOptions } from "@/lib/section-rules";
 import { cn, formatBalance, formatSmartAmount } from "@/lib/utils";
 import { useThemeStore } from "@/stores/theme-store";
@@ -359,8 +360,8 @@ export function DepositModal({
 
                 const bridgeNetworkName = bridgeNetwork.name.toLowerCase();
                 const includeAllNearResidencies =
-                    assetId.toLowerCase() === "near" &&
-                    bridgeNetworkName === "near";
+                    assetId.toLowerCase() === NEAR_NETWORK_ID &&
+                    bridgeNetworkName === NEAR_NETWORK_ID;
 
                 const chainMatches = ownedAsset.networks.filter(
                     (network) =>
@@ -629,7 +630,7 @@ export function DepositModal({
                     selectedNetwork.chainId ?? selectedNetwork.id
                 )
                     .toLowerCase()
-                    .includes("near");
+                    .includes(NEAR_NETWORK_ID);
                 if (isNearNetwork) {
                     if (requestId !== latestAddressRequestRef.current) return;
                     setDepositInfo({
@@ -715,7 +716,7 @@ export function DepositModal({
             ""
         )
             .toLowerCase()
-            .includes("near");
+            .includes(NEAR_NETWORK_ID);
 
         if (isNearNetwork) {
             return <span>{address}</span>;

--- a/nt-fe/app/(treasury)/[treasuryId]/earn/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/earn/page.tsx
@@ -15,7 +15,7 @@ const earnAppConfigs: {
 }[] = [
     {
         id: "rhea",
-        goToHref: "https://rhea.finance",
+        goToHref: "https://x.rhea.finance/en/earn",
         howItWorksHref: "https://www.youtube.com/watch?v=gcXBmtbsw34",
     },
     {

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/hooks/use-exchange-quote.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/hooks/use-exchange-quote.ts
@@ -16,6 +16,7 @@ import {
     isNEARDeposit,
     isNEARWithdraw,
 } from "../utils";
+import { NEAR_NETWORK_ID, WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 
 interface UseExchangeQuoteParams {
     selectedTreasury: string | null | undefined;
@@ -71,7 +72,8 @@ export function useExchangeQuote({
                         .toFixed();
 
                     // Fetch token price for USD calculation
-                    const tokenMetadata = await getTokenMetadata("wrap.near");
+                    const tokenMetadata =
+                        await getTokenMetadata(WRAP_NEAR_TOKEN_ID);
                     const tokenPrice = tokenMetadata?.price || 0;
                     const amountUsd = (
                         parseFloat(sellAmount) * tokenPrice
@@ -99,9 +101,13 @@ export function useExchangeQuote({
                         quoteRequest: {
                             swapType: "EXACT_INPUT",
                             slippageTolerance: 0,
-                            originAsset: isDeposit ? "near" : "wrap.near",
+                            originAsset: isDeposit
+                                ? NEAR_NETWORK_ID
+                                : WRAP_NEAR_TOKEN_ID,
                             depositType: "DESTINATION_CHAIN",
-                            destinationAsset: isDeposit ? "wrap.near" : "near",
+                            destinationAsset: isDeposit
+                                ? WRAP_NEAR_TOKEN_ID
+                                : NEAR_NETWORK_ID,
                             amount: amountInRaw,
                             refundTo: selectedTreasury,
                             refundType: "DESTINATION_CHAIN",

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx
@@ -64,6 +64,7 @@ import {
     isNEARWithdraw,
     isNEARWrapConversion,
 } from "./utils";
+import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 import {
     buildFungibleTokenProposal,
     buildNativeNEARProposal,
@@ -100,7 +101,8 @@ function Step1({ handleNext }: StepProps) {
 
     // Check if sell token is wNEAR (FT NEAR with Ft residency, not Intents)
     const isSellTokenFTNEAR =
-        sellToken.address === "wrap.near" && sellToken.residency === "Ft";
+        sellToken.address === WRAP_NEAR_TOKEN_ID &&
+        sellToken.residency === "Ft";
 
     // Filter function for receive token
     const filterReceiveTokens = useCallback(

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/utils.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/utils.ts
@@ -1,5 +1,10 @@
 import Big from "@/lib/big";
 import { isNearChainFtToken, isNearChainNativeToken } from "@/lib/intents-fee";
+import {
+    NEAR_NETWORK_ID,
+    NEP141_WRAP_NEAR_ASSET_ID,
+    WRAP_NEAR_TOKEN_ID,
+} from "@/constants/network-ids";
 
 /**
  * Checks if a token is native NEAR
@@ -9,7 +14,7 @@ import { isNearChainFtToken, isNearChainNativeToken } from "@/lib/intents-fee";
 export function isNativeNEAR(address: string, residency?: string): boolean {
     return isNearChainNativeToken({
         address,
-        network: "near",
+        network: NEAR_NETWORK_ID,
         residency,
     });
 }
@@ -21,10 +26,10 @@ export function isNativeNEAR(address: string, residency?: string): boolean {
  */
 export function isFTNEAR(address: string, residency?: string): boolean {
     return (
-        address === "wrap.near" &&
+        address === WRAP_NEAR_TOKEN_ID &&
         isNearChainFtToken({
             address,
-            network: "near",
+            network: NEAR_NETWORK_ID,
             residency,
         })
     );
@@ -76,8 +81,8 @@ export function isNEARWrapConversion(
 export function formatAssetForIntentsAPI(tokenAddress: string): string {
     return tokenAddress.startsWith("nep")
         ? tokenAddress
-        : tokenAddress === "near"
-          ? "nep141:wrap.near"
+        : tokenAddress === NEAR_NETWORK_ID
+          ? NEP141_WRAP_NEAR_ASSET_ID
           : `nep141:${tokenAddress}`;
 }
 

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/utils/proposal-builder.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/utils/proposal-builder.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/near-proposal-builders";
 import { encodeToMarkdown, jsonToBase64 } from "@/lib/utils";
 import { getBatchStorageDepositIsRegistered } from "@/lib/api";
+import { NEAR_NETWORK_ID, WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 
 interface ProposalBuilderParams {
     proposalData: IntentsQuoteResponse;
@@ -117,7 +118,7 @@ export async function buildNativeNEARProposal(
 
     // Check if treasury is registered on wrap.near
     const registrations = await getBatchStorageDepositIsRegistered([
-        { accountId: treasuryId, tokenId: "wrap.near" },
+        { accountId: treasuryId, tokenId: WRAP_NEAR_TOKEN_ID },
     ]);
 
     const isTreasuryRegistered =
@@ -126,14 +127,14 @@ export async function buildNativeNEARProposal(
     // 1. Storage deposit for treasury account on wrap.near (only if not registered)
     if (!isTreasuryRegistered) {
         additionalTransactions.push(
-            buildNep141StorageDepositTx("wrap.near", treasuryId),
+            buildNep141StorageDepositTx(WRAP_NEAR_TOKEN_ID, treasuryId),
         );
     }
 
     // 2. Storage deposit for deposit address on wrap.near (always needed)
     additionalTransactions.push(
         buildNep141StorageDepositTx(
-            "wrap.near",
+            WRAP_NEAR_TOKEN_ID,
             proposalData.quote.depositAddress,
         ),
     );
@@ -148,7 +149,7 @@ export async function buildNativeNEARProposal(
             ),
             kind: {
                 FunctionCall: {
-                    receiver_id: "wrap.near",
+                    receiver_id: WRAP_NEAR_TOKEN_ID,
                     actions: [
                         {
                             method_name: "near_deposit",
@@ -195,7 +196,7 @@ export async function buildFungibleTokenProposal(
     const amountInSmallestUnit = proposalData.quote.amountIn;
     const originAsset = sellToken.address;
     const isNearToken =
-        sellToken.network === "near" &&
+        sellToken.network === NEAR_NETWORK_ID &&
         !sellToken.address.startsWith("nep141:") &&
         !sellToken.address.startsWith("nep245:");
 
@@ -318,7 +319,7 @@ export async function buildNEARDepositProposal(
 
     // Check if treasury is registered on wrap.near
     const registrations = await getBatchStorageDepositIsRegistered([
-        { accountId: treasuryId, tokenId: "wrap.near" },
+        { accountId: treasuryId, tokenId: WRAP_NEAR_TOKEN_ID },
     ]);
     const isTreasuryRegistered =
         registrations.length > 0 && registrations[0].isRegistered;
@@ -328,7 +329,7 @@ export async function buildNEARDepositProposal(
     // Only add storage deposit if not registered
     if (!isTreasuryRegistered) {
         additionalTransactions.push(
-            buildNep141StorageDepositTx("wrap.near", treasuryId),
+            buildNep141StorageDepositTx(WRAP_NEAR_TOKEN_ID, treasuryId),
         );
     }
 
@@ -342,7 +343,7 @@ export async function buildNEARDepositProposal(
             ),
             kind: {
                 FunctionCall: {
-                    receiver_id: "wrap.near",
+                    receiver_id: WRAP_NEAR_TOKEN_ID,
                     actions: [
                         {
                             method_name: "near_deposit",
@@ -380,7 +381,7 @@ export function buildNEARWithdrawProposal(
             ),
             kind: {
                 FunctionCall: {
-                    receiver_id: "wrap.near",
+                    receiver_id: WRAP_NEAR_TOKEN_ID,
                     actions: [
                         {
                             method_name: "near_withdraw",

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { PageComponentLayout } from "@/components/page-component-layout";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 import { default_near_token } from "@/constants/token";
 import { useTreasury } from "@/hooks/use-treasury";
 import { useTreasuryPolicy } from "@/hooks/use-treasury-queries";
@@ -189,7 +190,7 @@ export default function BulkPaymentPage() {
             // Determine token IDs
             const isNEAR =
                 selectedToken.address === default_near_token(false).address &&
-                selectedToken.residency?.toLowerCase() === "near";
+                selectedToken.residency?.toLowerCase() === NEAR_NETWORK_ID;
 
             const tokenIdForHash = isNEAR ? "native" : selectedToken.address;
             const tokenIdForProposal = selectedToken.address;

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.ts
@@ -24,6 +24,7 @@ import {
 import type { BulkPaymentData } from "../schemas";
 import type { TreasuryAsset } from "@/lib/api";
 import Big from "@/lib/big";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 export { parseCsv };
 
@@ -267,7 +268,7 @@ export function parseAmount(
  */
 function validateRecipientAddress(
     address: string,
-    blockchainType: string = "near",
+    blockchainType: string = NEAR_NETWORK_ID,
     labels: Pick<
         BulkParsingLabels,
         | "missingRecipientFirstColumn"
@@ -280,7 +281,7 @@ function validateRecipientAddress(
     }
 
     // For NEAR blockchain, use NEAR-specific validation
-    if (blockchainType === "near") {
+    if (blockchainType === NEAR_NETWORK_ID) {
         if (!isValidNearAddressFormat(address)) {
             return labels.invalidNearAddress(address);
         }
@@ -306,7 +307,7 @@ export function parsePaymentData(
     amountIdx: number,
     startRow: number,
     labels: BulkParsingLabels,
-    blockchain: string = "near",
+    blockchain: string = NEAR_NETWORK_ID,
     expectedTokenSymbol?: string,
 ): {
     payments: BulkPaymentData[];
@@ -521,7 +522,7 @@ function parseAndValidateData(
     input: string,
     fallbackParseErrorMessage: string,
     labels: BulkParsingLabels,
-    blockchain: string = "near",
+    blockchain: string = NEAR_NETWORK_ID,
     expectedTokenSymbol?: string,
 ): {
     payments: BulkPaymentData[];
@@ -600,7 +601,7 @@ export function parseAndValidateCsv(
 } {
     const blockchain = selectedToken?.network
         ? getBlockchainType(selectedToken.network)
-        : "near";
+        : NEAR_NETWORK_ID;
     const tokenSymbol = selectedToken?.symbol;
     return parseAndValidateData(
         csvData,
@@ -626,7 +627,7 @@ export function parseAndValidatePasteData(
     const normalizedInput = pasteData.replace(/\\n/g, "\n").trim();
     const blockchain = selectedToken?.network
         ? getBlockchainType(selectedToken.network)
-        : "near";
+        : NEAR_NETWORK_ID;
     const tokenSymbol = selectedToken?.symbol;
     return parseAndValidateData(
         normalizedInput,

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
@@ -31,6 +31,7 @@ import {
     type RecipientNetworkRuleOption,
 } from "./recipient-network-select";
 import { cn } from "@/lib/utils";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 interface PaymentFormSectionProps<
     TFieldValues extends FieldValues = FieldValues,
@@ -179,7 +180,7 @@ export function PaymentFormSection<
     // the network selector sections instead.
     const blockchainType = useMemo(() => {
         if (!hideRecipientNetwork) return "unknown";
-        if (!selectedNetworkName) return "near";
+        if (!selectedNetworkName) return NEAR_NETWORK_ID;
         return getBlockchainType(selectedNetworkName);
     }, [hideRecipientNetwork, selectedNetworkName]);
 

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -8,11 +8,11 @@ import { Button } from "@/components/button";
 import { InputBlock } from "@/components/input-block";
 import { getNetworkDisplayName } from "@/components/token-display";
 import type { Token } from "@/components/token-input";
+import { NEAR_NETWORK_ID, NEAR_COM_NETWORK_ID } from "@/constants/network-ids";
 import {
     getNetworkDisplayCaseClass,
     getLocalizedNetworkDisplayName,
-    NEAR_COM_NETWORK_ID,
-} from "@/constants/intents";
+} from "@/lib/intents-network";
 import { NEAR_COM_ICON } from "@/constants/token";
 import { useBridgeTokens } from "@/hooks/use-bridge-tokens";
 import { useTreasury } from "@/hooks/use-treasury";
@@ -64,7 +64,7 @@ function isAddressCompatibleWithNetwork(
 ): boolean {
     if (!address) return true;
     const blockchain = getBlockchainType(networkName);
-    if (blockchain === "near") {
+    if (blockchain === NEAR_NETWORK_ID) {
         // ETH-format addresses (0x + 40 hex chars) are valid NEAR ETH-implicit
         // accounts, but only the near.com (Intents) route can handle them.
         // The raw "near" network entry stays visible but moves to incompatible.
@@ -96,7 +96,8 @@ function NetworkRow({
                 alt={`${option.name} network`}
                 className={cn(
                     "size-8",
-                    option.name.toLowerCase() === "near" && "p-1",
+                    option.networkName.toLowerCase() === NEAR_NETWORK_ID &&
+                        "p-1",
                 )}
             />
             <div className="flex flex-col items-start text-left">
@@ -146,7 +147,7 @@ export function RecipientNetworkSelect({
             }),
             description: isConfidential ? t("nearComDescription") : undefined,
             icon: NEAR_COM_ICON,
-            networkName: "near",
+            networkName: NEAR_NETWORK_ID,
         }),
         [isConfidential, t, tAddressBookTable],
     );
@@ -169,7 +170,8 @@ export function RecipientNetworkSelect({
                 id: network.id,
                 name: getNetworkDisplayName(network.name),
                 description:
-                    isConfidential && getBlockchainType(network.name) === "near"
+                    isConfidential &&
+                    getBlockchainType(network.name) === NEAR_NETWORK_ID
                         ? t("nearDescription")
                         : undefined,
                 icon: iconUrl,

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -8,7 +8,11 @@ import { Button } from "@/components/button";
 import { InputBlock } from "@/components/input-block";
 import { getNetworkDisplayName } from "@/components/token-display";
 import type { Token } from "@/components/token-input";
-import { NEAR_COM_NETWORK_ID } from "@/constants/intents";
+import {
+    getNetworkDisplayCaseClass,
+    getLocalizedNetworkDisplayName,
+    NEAR_COM_NETWORK_ID,
+} from "@/constants/intents";
 import { NEAR_COM_ICON } from "@/constants/token";
 import { useBridgeTokens } from "@/hooks/use-bridge-tokens";
 import { useTreasury } from "@/hooks/use-treasury";
@@ -99,7 +103,7 @@ function NetworkRow({
                 <span
                     className={cn(
                         "text-base font-semibold",
-                        option.name !== "near.com" && "capitalize",
+                        getNetworkDisplayCaseClass(option.id),
                     )}
                 >
                     {option.name}
@@ -123,6 +127,7 @@ export function RecipientNetworkSelect({
     onNetworkChange,
 }: RecipientNetworkSelectProps) {
     const t = useTranslations("recipientNetworkSelect");
+    const tAddressBookTable = useTranslations("addressBookTable");
     const { isConfidential } = useTreasury();
     const { theme } = useThemeStore();
     const [open, setOpen] = useState(false);
@@ -134,12 +139,16 @@ export function RecipientNetworkSelect({
     const nearComOption: RecipientNetworkOption = useMemo(
         () => ({
             id: NEAR_COM_NETWORK_ID,
-            name: t("nearComName"),
+            name: getLocalizedNetworkDisplayName({
+                networkName: NEAR_COM_NETWORK_ID,
+                networkLabel: tAddressBookTable("network"),
+                fallbackName: "near.com",
+            }),
             description: isConfidential ? t("nearComDescription") : undefined,
             icon: NEAR_COM_ICON,
             networkName: "near",
         }),
-        [isConfidential, t],
+        [isConfidential, t, tAddressBookTable],
     );
 
     const tokenNetworkOptions = useMemo((): RecipientNetworkOption[] => {

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -56,10 +56,9 @@ import { Address } from "@/components/address";
 import {
     useIntentsQuote,
     buildIntentsQuoteRequest,
-    NEAR_COM_NETWORK_ID,
     type IntentsAmountMode,
 } from "@/hooks/use-intents-quote";
-import { getNearComChainIcons, isNearComNetwork } from "@/constants/intents";
+import { getNearComChainIcons, isNearComNetwork } from "@/lib/intents-network";
 import { parseTokenQueryParam } from "@/lib/token-query-param";
 import {
     cn,

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -27,7 +27,7 @@ import { Textarea } from "@/components/textarea";
 import { Tooltip } from "@/components/tooltip";
 import { type Token, tokenSchema } from "@/components/token-input";
 import { Form, FormField } from "@/components/ui/form";
-import { default_near_token, NEAR_COM_ICON } from "@/constants/token";
+import { default_near_token } from "@/constants/token";
 import { useAddressBook } from "@/features/address-book";
 import {
     PAGE_TOUR_NAMES,
@@ -59,6 +59,7 @@ import {
     NEAR_COM_NETWORK_ID,
     type IntentsAmountMode,
 } from "@/hooks/use-intents-quote";
+import { getNearComChainIcons, isNearComNetwork } from "@/constants/intents";
 import { parseTokenQueryParam } from "@/lib/token-query-param";
 import {
     cn,
@@ -272,11 +273,8 @@ function Step2({
         if (!destinationNetwork) {
             return undefined;
         }
-        if (destinationNetwork === NEAR_COM_NETWORK_ID) {
-            return {
-                dark: NEAR_COM_ICON,
-                light: NEAR_COM_ICON,
-            };
+        if (isNearComNetwork(destinationNetwork)) {
+            return getNearComChainIcons();
         }
         for (const asset of bridgeAssets) {
             const network = asset.networks.find(
@@ -482,7 +480,7 @@ function classifyPaymentToken(
 ): PaymentTokenClassification {
     const isNearNativeToken = isNearChainNativeToken(token);
     const isNearFtToken = isNearChainFtToken(token);
-    const isNearComRoute = destinationNetwork === NEAR_COM_NETWORK_ID;
+    const isNearComRoute = isNearComNetwork(destinationNetwork);
     const intentsOriginAsset = isNearNativeToken
         ? "nep141:wrap.near"
         : isNearFtToken

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/utils/proposal-builder.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/utils/proposal-builder.ts
@@ -5,6 +5,7 @@ import {
 import type { FunctionCallKind, TransferKind } from "@/lib/proposals-api";
 import type { Token } from "@/components/token-input";
 import { default_near_token } from "@/constants/token";
+import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 import {
     type AdditionalTx,
     buildNativeNearIntentsKind,
@@ -73,19 +74,19 @@ export async function buildNativeNEARIntentsProposal(params: {
     const { treasuryId, depositAddress, amountIn } = params;
 
     const registrations = await getBatchStorageDepositIsRegistered([
-        { accountId: treasuryId, tokenId: "wrap.near" },
-        { accountId: depositAddress, tokenId: "wrap.near" },
+        { accountId: treasuryId, tokenId: WRAP_NEAR_TOKEN_ID },
+        { accountId: depositAddress, tokenId: WRAP_NEAR_TOKEN_ID },
     ]);
 
     const additionalTransactions: AdditionalTx[] = [];
     if (!registrations[0]?.isRegistered) {
         additionalTransactions.push(
-            buildNep141StorageDepositTx("wrap.near", treasuryId),
+            buildNep141StorageDepositTx(WRAP_NEAR_TOKEN_ID, treasuryId),
         );
     }
     if (!registrations[1]?.isRegistered) {
         additionalTransactions.push(
-            buildNep141StorageDepositTx("wrap.near", depositAddress),
+            buildNep141StorageDepositTx(WRAP_NEAR_TOKEN_ID, depositAddress),
         );
     }
 

--- a/nt-fe/components/account-input.tsx
+++ b/nt-fe/components/account-input.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/near-validation";
 import { translateNearValidationError } from "@/lib/near-validation-i18n";
 import type { BlockchainType } from "@/lib/blockchain-utils";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 /**
  * Unified Account Input Component
@@ -56,12 +57,12 @@ const AccountInput = ({
     const [hasValidated, setHasValidated] = useState(false); // Track if validation completed
     const hasUserInteractedRef = useRef(false);
 
-    const isNear = blockchain === "near";
+    const isNear = blockchain === NEAR_NETWORK_ID;
 
     // Get blockchain-specific configuration
     const config = useMemo(() => {
         const example =
-            blockchain === "near"
+            blockchain === NEAR_NETWORK_ID
                 ? t("nearExample")
                 : getAddressExample(blockchain);
         return {

--- a/nt-fe/components/assets-table.tsx
+++ b/nt-fe/components/assets-table.tsx
@@ -87,7 +87,6 @@ interface AssetMetrics {
     hasEarning: boolean;
 }
 
-const DEFAULT_DECIMALS = 24;
 const SORT_BUTTON_CLASS =
     "inline-flex items-center gap-1 hover:text-foreground hover:bg-transparent px-1! uppercase text-xxs";
 
@@ -184,6 +183,17 @@ function displayAmount(rawAmount: Big.Big, decimals: number): Big.Big {
     return Big(formatBalance(rawAmount, decimals, decimals));
 }
 
+function sumTokenAmountsByNetwork(
+    networks: NetworkAsset[],
+    getRawAmount: (network: NetworkAsset) => Big.Big,
+): Big.Big {
+    return networks.reduce(
+        (sum, network) =>
+            sum.add(displayAmount(getRawAmount(network), network.decimals)),
+        Big(0),
+    );
+}
+
 function defaultSortForView(view: ViewMode): {
     key: SortKey;
     dir: SortDirection;
@@ -234,8 +244,7 @@ interface MobileEarningPoolRow {
 }
 
 interface MobileModalData {
-    primaryDecimals: number;
-    summaryRaw: Big.Big;
+    summaryAmount: Big.Big;
     summaryUsd: number;
     summaryLabel: string;
     listLabel: string;
@@ -279,10 +288,7 @@ function MobileAssetViewModal({
                                 {mobileModalData.summaryLabel}
                             </span>
                             <BalanceCell
-                                balance={displayAmount(
-                                    mobileModalData.summaryRaw,
-                                    mobileModalData.primaryDecimals,
-                                )}
+                                balance={mobileModalData.summaryAmount}
                                 symbol={selectedAsset.id}
                                 balanceUSD={mobileModalData.summaryUsd}
                             />
@@ -426,23 +432,15 @@ function buildMobileModalData(
         return [];
     });
 
-    const primaryDecimals =
-        selectedAsset.networks[0]?.decimals ?? DEFAULT_DECIMALS;
-    const summaryRaw =
+    const summaryAmount =
         view === "available"
-            ? availableNetworks.reduce(
-                  (sum, n) => sum.add(networkAvailableRawForAvailableView(n)),
-                  Big(0),
+            ? sumTokenAmountsByNetwork(
+                  availableNetworks,
+                  networkAvailableRawForAvailableView,
               )
             : view === "locked"
-              ? lockedNetworks.reduce(
-                    (sum, n) => sum.add(networkLockedRaw(n)),
-                    Big(0),
-                )
-              : earningNetworks.reduce(
-                    (sum, n) => sum.add(networkEarningRaw(n)),
-                    Big(0),
-                );
+              ? sumTokenAmountsByNetwork(lockedNetworks, networkLockedRaw)
+              : sumTokenAmountsByNetwork(earningNetworks, networkEarningRaw);
     const summaryUsd =
         view === "available"
             ? availableNetworks.reduce(
@@ -480,8 +478,7 @@ function buildMobileModalData(
               : labels.poolBreakdown;
 
     return {
-        primaryDecimals,
-        summaryRaw,
+        summaryAmount,
         summaryUsd,
         summaryLabel,
         listLabel,
@@ -501,11 +498,10 @@ interface BaseAssetViewProps {
     asset: AggregatedAsset;
     isMobile: boolean;
     isExpanded: boolean;
-    primaryDecimals?: number;
 }
 
 interface AvailableViewProps extends BaseAssetViewProps {
-    availableRaw?: Big.Big;
+    availableAmount?: Big.Big;
     availableUsd?: number;
     weight?: number;
     availableNetworks?: NetworkAsset[];
@@ -518,8 +514,7 @@ function AvailableView({
     asset,
     isMobile,
     isExpanded,
-    primaryDecimals,
-    availableRaw,
+    availableAmount,
     availableUsd,
     weight,
     availableNetworks,
@@ -533,10 +528,7 @@ function AvailableView({
             <>
                 <TableCell className="p-4 text-right">
                     <BalanceCell
-                        balance={displayAmount(
-                            availableRaw ?? Big(0),
-                            primaryDecimals ?? DEFAULT_DECIMALS,
-                        )}
+                        balance={availableAmount ?? Big(0)}
                         symbol={asset.id}
                         balanceUSD={availableUsd ?? 0}
                     />
@@ -777,11 +769,11 @@ function mergeAvailableNetworks(
 }
 
 interface LockedViewProps extends BaseAssetViewProps {
-    lockedRaw?: Big.Big;
+    lockedAmount?: Big.Big;
     lockedUsd?: number;
-    unlockedRaw?: Big.Big;
+    unlockedAmount?: Big.Big;
     unlockedUsd?: number;
-    totalAllocatedRaw?: Big.Big;
+    totalAllocatedAmount?: Big.Big;
     totalAllocatedUsd?: number;
     lockedNetworks?: NetworkAsset[];
     ftLockupInstanceCount?: number;
@@ -793,12 +785,11 @@ function LockedView({
     asset,
     isMobile,
     isExpanded,
-    primaryDecimals,
-    lockedRaw,
+    lockedAmount,
     lockedUsd,
-    unlockedRaw,
+    unlockedAmount,
     unlockedUsd,
-    totalAllocatedRaw,
+    totalAllocatedAmount,
     totalAllocatedUsd,
     lockedNetworks,
     ftLockupInstanceCount,
@@ -811,20 +802,14 @@ function LockedView({
             <>
                 <TableCell className="p-4 text-right hidden sm:table-cell">
                     <BalanceCell
-                        balance={displayAmount(
-                            lockedRaw ?? Big(0),
-                            primaryDecimals ?? DEFAULT_DECIMALS,
-                        )}
+                        balance={lockedAmount ?? Big(0)}
                         symbol={asset.id}
                         balanceUSD={lockedUsd ?? 0}
                     />
                 </TableCell>
                 <TableCell className="p-4 text-right">
                     <BalanceCell
-                        balance={displayAmount(
-                            unlockedRaw ?? Big(0),
-                            primaryDecimals ?? DEFAULT_DECIMALS,
-                        )}
+                        balance={unlockedAmount ?? Big(0)}
                         symbol={asset.id}
                         balanceUSD={unlockedUsd ?? 0}
                     />
@@ -834,10 +819,7 @@ function LockedView({
                 </TableCell>
                 <TableCell className="p-4 text-right hidden sm:table-cell">
                     <BalanceCell
-                        balance={displayAmount(
-                            totalAllocatedRaw ?? Big(0),
-                            primaryDecimals ?? DEFAULT_DECIMALS,
-                        )}
+                        balance={totalAllocatedAmount ?? Big(0)}
                         symbol={asset.id}
                         balanceUSD={totalAllocatedUsd ?? 0}
                     />
@@ -1017,9 +999,9 @@ function LockedView({
 }
 
 interface EarningViewProps extends BaseAssetViewProps {
-    earningRaw?: Big.Big;
+    earningAmount?: Big.Big;
     earningUsd?: number;
-    earningWithdrawRaw?: Big.Big;
+    earningWithdrawAmount?: Big.Big;
     earningWithdrawUsd?: number;
     earningNetworks?: NetworkAsset[];
     earningPoolRows?: MobileEarningPoolRow[];
@@ -1030,10 +1012,9 @@ function EarningView({
     asset,
     isMobile,
     isExpanded,
-    primaryDecimals,
-    earningRaw,
+    earningAmount,
     earningUsd,
-    earningWithdrawRaw,
+    earningWithdrawAmount,
     earningWithdrawUsd,
     earningNetworks,
     earningPoolRows,
@@ -1045,10 +1026,7 @@ function EarningView({
             <>
                 <TableCell className="p-4 text-right">
                     <BalanceCell
-                        balance={displayAmount(
-                            earningRaw ?? Big(0),
-                            primaryDecimals ?? DEFAULT_DECIMALS,
-                        )}
+                        balance={earningAmount ?? Big(0)}
                         symbol={asset.id}
                         balanceUSD={earningUsd ?? 0}
                     />
@@ -1058,10 +1036,7 @@ function EarningView({
                 </TableCell>
                 <TableCell className="p-4 text-right hidden sm:table-cell">
                     <BalanceCell
-                        balance={displayAmount(
-                            earningWithdrawRaw ?? Big(0),
-                            primaryDecimals ?? DEFAULT_DECIMALS,
-                        )}
+                        balance={earningWithdrawAmount ?? Big(0)}
                         symbol={asset.id}
                         balanceUSD={earningWithdrawUsd ?? 0}
                     />
@@ -1838,8 +1813,6 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                     <TableBody>
                         {viewAssets.map(({ asset, weight }) => {
                             const isExpanded = !!expanded[asset.id];
-                            const primaryDecimals =
-                                asset.networks[0]?.decimals ?? DEFAULT_DECIMALS;
                             const availableNetworks = asset.networks.filter(
                                 (n) =>
                                     n.residency !== "Staked" &&
@@ -1871,34 +1844,30 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                             n.balance.lockup.staked.gt(0))) &&
                                     networkEarningRaw(n).gt(0),
                             );
-                            const earningFromLockedRaw = lockedNetworks.reduce(
-                                (sum, n) =>
+                            const earningFromLockedAmount =
+                                sumTokenAmountsByNetwork(lockedNetworks, (n) =>
                                     n.balance.type === "Vested"
-                                        ? sum.add(n.balance.lockup.staked)
-                                        : sum,
-                                Big(0),
-                            );
-                            const allocatedLockedRaw = lockedNetworks.reduce(
-                                (sum, n) =>
-                                    sum.add(
-                                        networkLockedRaw(n).add(
-                                            networkAvailableRaw(n),
-                                        ),
+                                        ? n.balance.lockup.staked
+                                        : Big(0),
+                                );
+                            const allocatedLockedAmount =
+                                sumTokenAmountsByNetwork(lockedNetworks, (n) =>
+                                    networkLockedRaw(n).add(
+                                        networkAvailableRaw(n),
                                     ),
-                                Big(0),
-                            );
+                                );
                             const hasLockedEarningNotice =
-                                view === "locked" && earningFromLockedRaw.gt(0);
+                                view === "locked" &&
+                                earningFromLockedAmount.gt(0);
                             const isFullLockedInEarning =
-                                allocatedLockedRaw.gt(0) &&
-                                earningFromLockedRaw.gte(allocatedLockedRaw);
+                                allocatedLockedAmount.gt(0) &&
+                                earningFromLockedAmount.gte(
+                                    allocatedLockedAmount,
+                                );
 
-                            const availableRaw = availableNetworks.reduce(
-                                (sum, n) =>
-                                    sum.add(
-                                        networkAvailableRawForAvailableView(n),
-                                    ),
-                                Big(0),
+                            const availableAmount = sumTokenAmountsByNetwork(
+                                availableNetworks,
+                                networkAvailableRawForAvailableView,
                             );
                             const availableUsd = availableNetworks.reduce(
                                 (sum, n) =>
@@ -1911,16 +1880,16 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                 0,
                             );
 
-                            const lockedRaw = lockedNetworks.reduce(
-                                (sum, n) => sum.add(networkLockedRaw(n)),
-                                Big(0),
+                            const lockedAmount = sumTokenAmountsByNetwork(
+                                lockedNetworks,
+                                networkLockedRaw,
                             );
-                            const unlockedRaw = lockedNetworks.reduce(
-                                (sum, n) => sum.add(networkAvailableRaw(n)),
-                                Big(0),
+                            const unlockedAmount = sumTokenAmountsByNetwork(
+                                lockedNetworks,
+                                networkAvailableRaw,
                             );
-                            const totalAllocatedRaw =
-                                lockedRaw.add(unlockedRaw);
+                            const totalAllocatedAmount =
+                                lockedAmount.add(unlockedAmount);
                             const lockedUsd = lockedNetworks.reduce(
                                 (sum, n) =>
                                     sum +
@@ -1943,21 +1912,9 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                             );
                             const totalAllocatedUsd = lockedUsd + unlockedUsd;
 
-                            const earningRaw = earningNetworks.reduce(
-                                (sum, n) => sum.add(networkEarningRaw(n)),
-                                Big(0),
-                            );
-                            const earningWithdrawRaw = earningNetworks.reduce(
-                                (sum, n) =>
-                                    n.balance.type === "Vested"
-                                        ? sum.add(
-                                              n.balance.lockup.canWithdraw
-                                                  ? n.balance.lockup
-                                                        .unstakedBalance
-                                                  : Big(0),
-                                          )
-                                        : sum.add(availableBalance(n.balance)),
-                                Big(0),
+                            const earningAmount = sumTokenAmountsByNetwork(
+                                earningNetworks,
+                                networkEarningRaw,
                             );
                             const earningUsd = earningNetworks.reduce(
                                 (sum, n) =>
@@ -1969,6 +1926,17 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                     ),
                                 0,
                             );
+                            const earningWithdrawAmount =
+                                sumTokenAmountsByNetwork(
+                                    earningNetworks,
+                                    (n) =>
+                                        n.balance.type === "Vested"
+                                            ? n.balance.lockup.canWithdraw
+                                                ? n.balance.lockup
+                                                      .unstakedBalance
+                                                : Big(0)
+                                            : availableBalance(n.balance),
+                                );
                             const earningWithdrawUsd = earningNetworks.reduce(
                                 (sum, n) =>
                                     sum +
@@ -2024,10 +1992,9 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                                 asset={asset}
                                                 isMobile={false}
                                                 isExpanded={false}
-                                                primaryDecimals={
-                                                    primaryDecimals
+                                                availableAmount={
+                                                    availableAmount
                                                 }
-                                                availableRaw={availableRaw}
                                                 availableUsd={availableUsd}
                                                 weight={weight}
                                             />
@@ -2038,15 +2005,12 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                                 asset={asset}
                                                 isMobile={false}
                                                 isExpanded={false}
-                                                primaryDecimals={
-                                                    primaryDecimals
-                                                }
-                                                lockedRaw={lockedRaw}
+                                                lockedAmount={lockedAmount}
                                                 lockedUsd={lockedUsd}
-                                                unlockedRaw={unlockedRaw}
+                                                unlockedAmount={unlockedAmount}
                                                 unlockedUsd={unlockedUsd}
-                                                totalAllocatedRaw={
-                                                    totalAllocatedRaw
+                                                totalAllocatedAmount={
+                                                    totalAllocatedAmount
                                                 }
                                                 totalAllocatedUsd={
                                                     totalAllocatedUsd
@@ -2059,13 +2023,10 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                                 asset={asset}
                                                 isMobile={false}
                                                 isExpanded={false}
-                                                primaryDecimals={
-                                                    primaryDecimals
-                                                }
-                                                earningRaw={earningRaw}
+                                                earningAmount={earningAmount}
                                                 earningUsd={earningUsd}
-                                                earningWithdrawRaw={
-                                                    earningWithdrawRaw
+                                                earningWithdrawAmount={
+                                                    earningWithdrawAmount
                                                 }
                                                 earningWithdrawUsd={
                                                     earningWithdrawUsd
@@ -2124,10 +2085,7 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                                               )}{" "}
                                                         {t("currentlyEarning", {
                                                             amount: formatSmartAmount(
-                                                                displayAmount(
-                                                                    earningFromLockedRaw,
-                                                                    primaryDecimals,
-                                                                ),
+                                                                earningFromLockedAmount,
                                                             ),
                                                             symbol: asset.id,
                                                         })}

--- a/nt-fe/components/network-badge.tsx
+++ b/nt-fe/components/network-badge.tsx
@@ -4,7 +4,7 @@ import { getNetworkDisplayName } from "@/components/token-display";
 import {
     getNetworkDisplayCaseClass,
     getLocalizedNetworkDisplayName,
-} from "@/constants/intents";
+} from "@/lib/intents-network";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/use-media-query";

--- a/nt-fe/components/network-badge.tsx
+++ b/nt-fe/components/network-badge.tsx
@@ -1,5 +1,11 @@
 import { useThemeStore } from "@/stores/theme-store";
 import { cva, type VariantProps } from "class-variance-authority";
+import { getNetworkDisplayName } from "@/components/token-display";
+import {
+    getNetworkDisplayCaseClass,
+    getLocalizedNetworkDisplayName,
+} from "@/constants/intents";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { Tooltip } from "@/components/tooltip";
@@ -54,6 +60,12 @@ export function NetworkBadge({
 }: NetworkBadgeProps) {
     const { theme } = useThemeStore();
     const isMobile = useMediaQuery("(max-width: 768px)");
+    const tAddressBookTable = useTranslations("addressBookTable");
+    const displayName = getLocalizedNetworkDisplayName({
+        networkName: name,
+        networkLabel: tAddressBookTable("network"),
+        fallbackName: getNetworkDisplayName(name),
+    });
     const icon =
         theme === "dark" ? (iconDark ?? iconLight) : (iconLight ?? iconDark);
     const iconSize = iconSizeMap[isMobile ? "icon" : (size ?? "sm")];
@@ -64,7 +76,7 @@ export function NetworkBadge({
             {icon && (
                 <img
                     src={icon}
-                    alt={name}
+                    alt={displayName}
                     className={cn(
                         iconSize,
                         name.toLowerCase() === "near protocol"
@@ -73,12 +85,16 @@ export function NetworkBadge({
                     )}
                 />
             )}
-            {!iconOnly && <span>{name}</span>}
+            {!iconOnly && (
+                <span className={cn(getNetworkDisplayCaseClass(name))}>
+                    {displayName}
+                </span>
+            )}
         </span>
     );
 
     if (iconOnly) {
-        return <Tooltip content={name}>{badge}</Tooltip>;
+        return <Tooltip content={displayName}>{badge}</Tooltip>;
     }
 
     return badge;

--- a/nt-fe/components/page-component-layout.tsx
+++ b/nt-fe/components/page-component-layout.tsx
@@ -3,9 +3,10 @@
 import { ArrowLeft, Moon, PanelLeft, Sun } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { type ReactNode, useEffect } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { Button } from "@/components/button";
 import { LanguageSwitcher } from "@/components/language-switcher";
+import { Pill } from "@/components/pill";
 import { SignIn } from "@/components/sign-in";
 import { SystemStatusBanner } from "@/components/system-status-banner";
 import { ConfidentialBanner } from "@/features/confidential/components/confidential-banner";
@@ -34,12 +35,24 @@ export function PageComponentLayout({
     const { toggleSidebar } = useSidebarStore();
     const { theme, toggleTheme } = useThemeStore();
     const tHeader = useTranslations("header");
+    const [showStagingTag, setShowStagingTag] = useState(
+        process.env.NEXT_PUBLIC_STAGING === "true",
+    );
 
     useEffect(() => {
         if (typeof window !== "undefined") {
             document.documentElement.classList.toggle("dark", theme === "dark");
         }
     }, [theme]);
+
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            setShowStagingTag(
+                process.env.NEXT_PUBLIC_STAGING === "true" ||
+                    window.location.hostname.includes("testenv.trezu"),
+            );
+        }
+    }, []);
 
     const router = useRouter();
 
@@ -94,6 +107,15 @@ export function PageComponentLayout({
 
                 {!hideLogin && (
                     <div className="flex items-center gap-3">
+                        {showStagingTag && (
+                            <Pill
+                                title="Staging"
+                                icon={
+                                    <span className="size-1.5 rounded-full bg-general-orange-foreground" />
+                                }
+                                className="bg-general-orange-background-faded text-general-orange-foreground"
+                            />
+                        )}
                         <LanguageSwitcher />
                         <Button
                             variant="ghost"

--- a/nt-fe/components/page-component-layout.tsx
+++ b/nt-fe/components/page-component-layout.tsx
@@ -3,12 +3,13 @@
 import { ArrowLeft, Moon, PanelLeft, Sun } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect } from "react";
 import { Button } from "@/components/button";
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { Pill } from "@/components/pill";
 import { SignIn } from "@/components/sign-in";
 import { SystemStatusBanner } from "@/components/system-status-banner";
+import { isStaging } from "@/constants/features";
 import { ConfidentialBanner } from "@/features/confidential/components/confidential-banner";
 import { useSidebarStore } from "@/stores/sidebar-store";
 import { useThemeStore } from "@/stores/theme-store";
@@ -35,24 +36,12 @@ export function PageComponentLayout({
     const { toggleSidebar } = useSidebarStore();
     const { theme, toggleTheme } = useThemeStore();
     const tHeader = useTranslations("header");
-    const [showStagingTag, setShowStagingTag] = useState(
-        process.env.NEXT_PUBLIC_STAGING === "true",
-    );
 
     useEffect(() => {
         if (typeof window !== "undefined") {
             document.documentElement.classList.toggle("dark", theme === "dark");
         }
     }, [theme]);
-
-    useEffect(() => {
-        if (typeof window !== "undefined") {
-            setShowStagingTag(
-                process.env.NEXT_PUBLIC_STAGING === "true" ||
-                    window.location.hostname.includes("testenv.trezu"),
-            );
-        }
-    }, []);
 
     const router = useRouter();
 
@@ -107,7 +96,7 @@ export function PageComponentLayout({
 
                 {!hideLogin && (
                     <div className="flex items-center gap-3">
-                        {showStagingTag && (
+                        {isStaging && (
                             <Pill
                                 title="Staging"
                                 icon={

--- a/nt-fe/components/token-display.tsx
+++ b/nt-fe/components/token-display.tsx
@@ -3,6 +3,10 @@ import { ChainIcons, TreasuryAsset } from "@/lib/api";
 import { cn, formatCurrency, formatSmartAmount } from "@/lib/utils";
 import { useThemeStore } from "@/stores/theme-store";
 import Big from "@/lib/big";
+import {
+    getNetworkDisplayCaseClass,
+    getLocalizedNetworkDisplayName,
+} from "@/constants/intents";
 import { TokenDisplay as TokenWithNetworkDisplay } from "./token-display-with-network";
 
 interface NetworkIconDisplayProps {
@@ -10,23 +14,36 @@ interface NetworkIconDisplayProps {
     networkName: string;
     residency?: string;
     networkNameClassName?: string;
+    expandNearComLabel?: boolean;
 }
 
 const NETWORK_DISPLAY_NAMES: Record<string, string> = {
     eth: "Ethereum",
+    ethereum: "Ethereum",
     btc: "Bitcoin",
+    bitcoin: "Bitcoin",
     sol: "Solana",
+    solana: "Solana",
     arb: "Arbitrum",
+    arbitrum: "Arbitrum",
     pol: "Polygon",
+    polygon: "Polygon",
     bsc: "BNB Chain",
     trx: "Tron",
+    tron: "Tron",
     xlm: "Stellar",
+    stellar: "Stellar",
     apt: "Aptos",
+    aptos: "Aptos",
     ada: "Cardano",
+    cardano: "Cardano",
     doge: "Dogecoin",
+    dogecoin: "Dogecoin",
     zec: "Zcash",
+    zcash: "Zcash",
     xrp: "XRP",
     bera: "Berachain",
+    berachain: "Berachain",
     near: "NEAR",
 };
 
@@ -59,9 +76,11 @@ export const NetworkIconDisplay = ({
     networkName,
     residency,
     networkNameClassName,
+    expandNearComLabel = false,
 }: NetworkIconDisplayProps) => {
     const { theme } = useThemeStore();
     const getResidencyLabel = useResidencyLabel();
+    const tAddressBookTable = useTranslations("addressBookTable");
 
     const iconUrl = chainIcons
         ? theme === "dark"
@@ -70,6 +89,12 @@ export const NetworkIconDisplay = ({
         : null;
 
     const isNEAR = networkName.toLowerCase() === "near";
+    const displayName = getLocalizedNetworkDisplayName({
+        networkName,
+        networkLabel: tAddressBookTable("network"),
+        fallbackName: getNetworkDisplayName(networkName),
+        expandNearComLabel,
+    });
 
     return (
         <div className="flex items-center gap-3">
@@ -87,13 +112,14 @@ export const NetworkIconDisplay = ({
             <div className="flex flex-col gap-0 items-baseline text-left">
                 <span
                     className={cn(
-                        "font-semibold capitalize",
+                        "font-semibold",
+                        getNetworkDisplayCaseClass(networkName),
                         networkNameClassName,
                     )}
                 >
-                    {getNetworkDisplayName(networkName)}
+                    {displayName}
                 </span>
-                {isNEAR && (
+                {isNEAR && residency && (
                     <span className="text-xs text-muted-foreground">
                         {getResidencyLabel(residency)}
                     </span>
@@ -112,6 +138,7 @@ export const NetworkDisplay = ({
 }) => {
     const { theme } = useThemeStore();
     const tRes = useTranslations("residency");
+    const tAddressBookTable = useTranslations("addressBookTable");
 
     let type;
     switch (asset.residency) {
@@ -125,7 +152,11 @@ export const NetworkDisplay = ({
             type = tRes("fungibleToken");
             break;
         case "Intents":
-            type = "near.com";
+            type = getLocalizedNetworkDisplayName({
+                networkName: "near.com",
+                networkLabel: tAddressBookTable("network"),
+                fallbackName: "near.com",
+            });
             break;
         case "Near":
             type = tRes("nativeToken");

--- a/nt-fe/components/token-display.tsx
+++ b/nt-fe/components/token-display.tsx
@@ -6,7 +6,8 @@ import Big from "@/lib/big";
 import {
     getNetworkDisplayCaseClass,
     getLocalizedNetworkDisplayName,
-} from "@/constants/intents";
+} from "@/lib/intents-network";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 import { TokenDisplay as TokenWithNetworkDisplay } from "./token-display-with-network";
 
 interface NetworkIconDisplayProps {
@@ -88,7 +89,7 @@ export const NetworkIconDisplay = ({
             : chainIcons.light
         : null;
 
-    const isNEAR = networkName.toLowerCase() === "near";
+    const isNEAR = networkName.toLowerCase() === NEAR_NETWORK_ID;
     const displayName = getLocalizedNetworkDisplayName({
         networkName,
         networkLabel: tAddressBookTable("network"),

--- a/nt-fe/components/user.tsx
+++ b/nt-fe/components/user.tsx
@@ -11,6 +11,7 @@ import { Skeleton } from "./ui/skeleton";
 import { CopyButton } from "./copy-button";
 import { Address } from "./address";
 import { getExplorerAddressUrl } from "@/lib/blockchain-utils";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
@@ -73,7 +74,7 @@ export function UserWithData({
     iconOnly = false,
     withLink = true,
     withHoverCard = false,
-    chainName = "near",
+    chainName = NEAR_NETWORK_ID,
     useAddressBook = false,
 }: UserWithDataProps) {
     const image = `https://i.near.social/magic/large/https://near.social/magic/img/account/${address}`;
@@ -146,7 +147,7 @@ interface TooltipUserProps {
 export function TooltipUser({
     accountId,
     name,
-    chainName = "near",
+    chainName = NEAR_NETWORK_ID,
     useAddressBook = false,
     children,
     triggerProps,
@@ -235,7 +236,7 @@ export function User({
     withLink = true,
     withName = true,
     withHoverCard = false,
-    chainName = "near",
+    chainName = NEAR_NETWORK_ID,
 }: UserProps) {
     const { data: profile, isLoading } = useProfile(
         withName && !nameProp ? accountId : undefined,

--- a/nt-fe/constants/features.ts
+++ b/nt-fe/constants/features.ts
@@ -8,11 +8,11 @@
  *   NEXT_PUBLIC_STAGING=true
  */
 
-const staging =
+export const isStaging =
     process.env.NEXT_PUBLIC_STAGING === "true" ||
     process.env.NODE_ENV === "development";
 
-export const features = staging
+export const features = isStaging
     ? {
           integrations: true,
           extraLocales: true,

--- a/nt-fe/constants/intents.ts
+++ b/nt-fe/constants/intents.ts
@@ -1,1 +1,82 @@
+import type { ChainIcons } from "@/lib/api";
+import { NEAR_COM_ICON } from "@/constants/token";
+
 export const NEAR_COM_NETWORK_ID = "near.com";
+// UI-only network id used to represent direct treasury deposits (no intents/bridge route).
+// Intentionally different from NEAR_COM_NETWORK_ID ("near.com"), which represents the intents route.
+export const NEAR_COM_DIRECT_NETWORK_ID = "near.com:direct";
+
+export const NEAR_COM_NETWORK_NAME = "near.com";
+
+export function isNearComNetwork(value?: string | null): boolean {
+    const normalized = value?.toLowerCase();
+    return (
+        normalized === NEAR_COM_NETWORK_ID ||
+        normalized === NEAR_COM_DIRECT_NETWORK_ID
+    );
+}
+
+/**
+ * Detect near.com payment routes from decoded proposal metadata.
+ */
+export function isNearComPaymentRoute({
+    destinationAssetId,
+    depositAddress,
+    quoteSignature,
+    networkFee,
+}: {
+    destinationAssetId?: string;
+    depositAddress?: string;
+    quoteSignature?: string;
+    networkFee?: string;
+}): boolean {
+    if (isNearComNetwork(destinationAssetId)) {
+        return true;
+    }
+
+    return (
+        !destinationAssetId &&
+        !!(depositAddress || quoteSignature || networkFee)
+    );
+}
+
+export function getNearComChainIcons(): ChainIcons {
+    return {
+        dark: NEAR_COM_ICON,
+        light: NEAR_COM_ICON,
+    };
+}
+
+export function formatNearComNetworkLabel({
+    networkLabel,
+}: {
+    networkLabel: string;
+}): string {
+    return `NEAR (${NEAR_COM_NETWORK_NAME}) ${networkLabel}`;
+}
+
+export function getLocalizedNetworkDisplayName({
+    networkName,
+    networkLabel,
+    fallbackName,
+    expandNearComLabel = false,
+}: {
+    networkName: string;
+    networkLabel: string;
+    fallbackName: string;
+    expandNearComLabel?: boolean;
+}): string {
+    if (isNearComNetwork(networkName)) {
+        return expandNearComLabel
+            ? formatNearComNetworkLabel({ networkLabel })
+            : fallbackName;
+    }
+    return fallbackName;
+}
+
+export function getNetworkDisplayCaseClass(
+    networkName: string,
+    nonNearComCase: "capitalize" | "uppercase" = "capitalize",
+): string {
+    return isNearComNetwork(networkName) ? "normal-case" : nonNearComCase;
+}

--- a/nt-fe/constants/network-ids.ts
+++ b/nt-fe/constants/network-ids.ts
@@ -1,0 +1,9 @@
+export const NEAR_NETWORK_ID = "near";
+export const WRAP_NEAR_TOKEN_ID = "wrap.near";
+export const NEP141_WRAP_NEAR_ASSET_ID = `nep141:${WRAP_NEAR_TOKEN_ID}`;
+
+export const NEAR_COM_NETWORK_ID = "near.com";
+// UI-only network id used to represent direct treasury deposits (no intents/bridge route).
+// Intentionally different from NEAR_COM_NETWORK_ID ("near.com"), which represents the intents route.
+export const NEAR_COM_DIRECT_NETWORK_ID = "near.com:direct";
+export const NEAR_COM_NETWORK_NAME = NEAR_COM_NETWORK_ID;

--- a/nt-fe/constants/token.ts
+++ b/nt-fe/constants/token.ts
@@ -1,5 +1,9 @@
 import { Token } from "@/components/token-input";
 import { ChainIcons } from "@/lib/api";
+import {
+    NEAR_NETWORK_ID,
+    NEP141_WRAP_NEAR_ASSET_ID,
+} from "@/constants/network-ids";
 
 export const NEAR_CHAIN_ICONS: ChainIcons = {
     dark: "https://near-intents.org/static/icons/network/near.svg",
@@ -11,8 +15,8 @@ export const NEAR_COM_ICON = "/near.com.svg";
 export const default_near_token = (isConfidential: boolean) => {
     return {
         symbol: "NEAR",
-        address: isConfidential ? "nep141:wrap.near" : "near",
-        network: "near",
+        address: isConfidential ? NEP141_WRAP_NEAR_ASSET_ID : NEAR_NETWORK_ID,
+        network: NEAR_NETWORK_ID,
         decimals: 24,
         icon: "https://s2.coinmarketcap.com/static/img/coins/128x128/6535.png",
         name: "NEAR",

--- a/nt-fe/features/activity/components/recent-activity-card.tsx
+++ b/nt-fe/features/activity/components/recent-activity-card.tsx
@@ -59,6 +59,7 @@ import Link from "next/link";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { StepperHeader } from "@/components/step-wizard";
 import { ConfidentialState } from "@/components/confidential-state";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 const ITEMS_ON_DASHBOARD = 10;
 const MAX_ITEMS = 100;
@@ -68,7 +69,10 @@ const columnHelper = createColumnHelper<GroupedActivity>();
 // Helper function to detect if an activity is a staking reward
 const isStakingReward = (activity: RecentActivityType): boolean => {
     // Must be NEAR token with positive amount
-    if (activity.tokenId !== "near" || parseFloat(activity.amount) <= 0) {
+    if (
+        activity.tokenId !== NEAR_NETWORK_ID ||
+        parseFloat(activity.amount) <= 0
+    ) {
         return false;
     }
 

--- a/nt-fe/features/activity/components/transaction-details-modal.tsx
+++ b/nt-fe/features/activity/components/transaction-details-modal.tsx
@@ -23,6 +23,7 @@ import { ExchangeSummaryCard } from "@/app/(treasury)/[treasuryId]/exchange/comp
 import { formatActivityAmount, formatSmartAmount } from "@/lib/utils";
 import { TransactionHashCell } from "./transaction-hash-cell";
 import { useTreasury } from "@/hooks/use-treasury";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 interface TransactionDetailsModalProps {
     activity: RecentActivity | null;
@@ -135,7 +136,7 @@ export function TransactionDetailsModal({
                                                 .icon || "",
                                         network:
                                             activity.swap.sentTokenMetadata
-                                                .network || "near",
+                                                .network || NEAR_NETWORK_ID,
                                         chainIcons:
                                             activity.swap.sentTokenMetadata
                                                 .chainIcons,
@@ -172,7 +173,7 @@ export function TransactionDetailsModal({
                                             .icon || "",
                                     network:
                                         activity.swap.receivedTokenMetadata
-                                            .network || "near",
+                                            .network || NEAR_NETWORK_ID,
                                     chainIcons:
                                         activity.swap.receivedTokenMetadata
                                             .chainIcons,
@@ -199,7 +200,8 @@ export function TransactionDetailsModal({
                                 name: activity.tokenMetadata.name,
                                 icon: activity.tokenMetadata.icon || "",
                                 network:
-                                    activity.tokenMetadata.network || "near",
+                                    activity.tokenMetadata.network ||
+                                    NEAR_NETWORK_ID,
                                 chainIcons: activity.tokenMetadata.chainIcons,
                             }}
                         />

--- a/nt-fe/features/address-book/compatible-chains.ts
+++ b/nt-fe/features/address-book/compatible-chains.ts
@@ -2,6 +2,7 @@ import { getBlockchainType } from "@/lib/blockchain-utils";
 import { getAddressPattern } from "@/lib/address-validation";
 import { isValidNearAddressFormat } from "@/lib/near-validation";
 import type { ChainInfo } from "./chains";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 /**
  * Given a validated address, returns the subset of known chains that are
@@ -23,7 +24,7 @@ export function getCompatibleChains(
     const nearCompatible = isValidNearAddressFormat(address);
 
     return chains.filter((chain) => {
-        if (chain.key === "near") return nearCompatible;
+        if (chain.key === NEAR_NETWORK_ID) return nearCompatible;
 
         const blockchainType = getBlockchainType(chain.key);
         if (blockchainType === "unknown") return false;

--- a/nt-fe/features/address-book/utils/resolve-network.ts
+++ b/nt-fe/features/address-book/utils/resolve-network.ts
@@ -1,4 +1,5 @@
 import type { ChainInfo } from "../chains";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 /**
  * Build a case-insensitive lookup map from various network name aliases to chain keys.
@@ -13,7 +14,7 @@ export function buildNetworkLookup(chains: ChainInfo[]): Map<string, string> {
 
     // Common aliases not covered by key/name
     const aliases: Record<string, string> = {
-        "near protocol": "near",
+        "near protocol": NEAR_NETWORK_ID,
         ethereum: "eth",
         ether: "eth",
         bnb: "bsc",

--- a/nt-fe/features/onboarding/components/onboarding-questions-step.tsx
+++ b/nt-fe/features/onboarding/components/onboarding-questions-step.tsx
@@ -8,6 +8,7 @@ import z from "zod";
 import { type StepProps } from "@/components/step-wizard";
 import { useChains } from "@/features/address-book/chains";
 import { OnboardingQuestionnaireCard } from "./onboarding-questionnaire-card";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 const questionnaireAnswerSchema = z.object({
     selected: z.array(z.string()),
@@ -101,7 +102,7 @@ const TEAM_SIZE_OPTION_IDS = [
 ] as const;
 
 const NETWORK_OPTION_IDS = [
-    "near",
+    NEAR_NETWORK_ID,
     "bitcoin",
     "ethereum",
     "solana",
@@ -165,7 +166,7 @@ const MULTISIG_BEGINNER_EXPERIENCE_OPTIONS = new Set([
 ]);
 
 const NETWORK_OPTION_CHAIN_KEY: Record<string, string> = {
-    near: "near",
+    [NEAR_NETWORK_ID]: NEAR_NETWORK_ID,
     bitcoin: "bitcoin",
     ethereum: "eth",
     solana: "solana",
@@ -627,7 +628,8 @@ export function OnboardingQuestionsStep({
             ...option,
             iconDark: chain.iconDark,
             iconLight: chain.iconLight,
-            iconImageClassName: option.id === "near" ? "p-0.5" : "rounded-full",
+            iconImageClassName:
+                option.id === NEAR_NETWORK_ID ? "p-0.5" : "rounded-full",
         };
     });
 

--- a/nt-fe/features/proposals/components/amount.tsx
+++ b/nt-fe/features/proposals/components/amount.tsx
@@ -3,6 +3,9 @@
 import { useTranslations } from "next-intl";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TokenDisplay } from "@/components/token-display-with-network";
+import { getNetworkDisplayName } from "@/components/token-display";
+import { Tooltip } from "@/components/tooltip";
+import { getLocalizedNetworkDisplayName } from "@/constants/intents";
 import { useToken } from "@/hooks/use-treasury-queries";
 import {
     formatBalance,
@@ -18,6 +21,8 @@ interface AmountProps {
     tokenId: string;
     showUSDValue?: boolean;
     showNetwork?: boolean;
+    showNetworkTooltip?: boolean;
+    expandNearComLabel?: boolean;
     network?: string; // Optional override for network display
     textOnly?: boolean;
     iconSize?: "sm" | "md" | "lg";
@@ -30,11 +35,14 @@ export function Amount({
     tokenId,
     showUSDValue = true,
     showNetwork = false,
+    showNetworkTooltip = false,
+    expandNearComLabel = false,
     network,
     iconSize = "lg",
 }: AmountProps) {
     const tCommon = useTranslations("common");
     const tAmount = useTranslations("amount");
+    const tAddressBookTable = useTranslations("addressBookTable");
     const { data: tokenData, isLoading } = useToken(tokenId);
     const rawAmountValue = amount
         ? formatBalance(amount, tokenData?.decimals || 24)
@@ -50,6 +58,34 @@ export function Amount({
         const price = tokenData?.price;
         return `≈ ${formatCurrency(parsedAmount * price!)}`;
     }, [tokenData, rawAmountValue, tCommon]);
+    const normalizedTokenId = tokenId.trim().toLowerCase();
+    const isNativeNearToken =
+        normalizedTokenId.length === 0 || normalizedTokenId === "near";
+    const resolvedNetwork = network ?? tokenData?.network;
+    const resolvedNetworkForLabel = isNativeNearToken
+        ? "near"
+        : resolvedNetwork;
+    const nearTypeLabel = getNearTokenTypeLabel(
+        isNativeNearToken ? "near" : tokenId,
+        resolvedNetworkForLabel,
+    );
+    const normalizedNearTypeLabel =
+        !expandNearComLabel && nearTypeLabel === "NEAR (near.com) Network"
+            ? "near.com"
+            : nearTypeLabel;
+    const networkLabel =
+        normalizedNearTypeLabel ??
+        (resolvedNetworkForLabel
+            ? getLocalizedNetworkDisplayName({
+                  networkName: resolvedNetworkForLabel,
+                  networkLabel: tAddressBookTable("network"),
+                  fallbackName: getNetworkDisplayName(resolvedNetworkForLabel),
+                  expandNearComLabel,
+              })
+            : undefined);
+    const networkTooltipContent = networkLabel
+        ? tAmount("network", { network: networkLabel })
+        : null;
 
     if (isLoading) {
         if (textOnly) {
@@ -68,18 +104,31 @@ export function Amount({
     }
 
     if (textOnly) {
-        return (
-            <p className="text-sm font-semibold">
-                {amountValue} {tokenData?.symbol}
+        const textOnlyAmount = (
+            <div className="flex flex-col items-end gap-0.5">
+                <p className="text-sm font-semibold">
+                    {amountValue} {tokenData?.symbol}
+                </p>
                 {showUSDValue && (
                     <span className="text-muted-foreground text-xs">
-                        ({estimatedUSDValue})
+                        {estimatedUSDValue}
                     </span>
                 )}
-            </p>
+            </div>
         );
+
+        if (showNetworkTooltip && networkTooltipContent) {
+            return (
+                <Tooltip content={networkTooltipContent}>
+                    <span>{textOnlyAmount}</span>
+                </Tooltip>
+            );
+        }
+
+        return textOnlyAmount;
     }
-    return (
+
+    const amountContent = (
         <div className="flex flex-col items-end gap-1">
             <div className="flex items-center gap-2">
                 {tokenData && (
@@ -95,27 +144,30 @@ export function Amount({
                         {amountValue} {tokenData?.symbol}
                     </span>
                 )}
-                {showUSDValue && (
-                    <span className="text-muted-foreground text-xs">
-                        ({estimatedUSDValue})
-                    </span>
-                )}
             </div>
+            {showUSDValue && (
+                <span className="text-muted-foreground text-xs">
+                    {estimatedUSDValue}
+                </span>
+            )}
             {showNetwork &&
                 (() => {
-                    const resolvedNetwork = network ?? tokenData?.network;
-                    const nearTypeLabel = getNearTokenTypeLabel(
-                        tokenId,
-                        resolvedNetwork,
-                    );
-                    const label =
-                        nearTypeLabel ?? resolvedNetwork?.toUpperCase();
-                    return label ? (
+                    return networkLabel ? (
                         <span className="text-muted-foreground text-xs">
-                            {tAmount("network", { network: label })}
+                            {tAmount("network", { network: networkLabel })}
                         </span>
                     ) : null;
                 })()}
         </div>
     );
+
+    if (showNetworkTooltip && networkTooltipContent) {
+        return (
+            <Tooltip content={networkTooltipContent}>
+                <div>{amountContent}</div>
+            </Tooltip>
+        );
+    }
+
+    return amountContent;
 }

--- a/nt-fe/features/proposals/components/amount.tsx
+++ b/nt-fe/features/proposals/components/amount.tsx
@@ -28,6 +28,50 @@ interface AmountProps {
     iconSize?: "sm" | "md" | "lg";
 }
 
+function resolveAmountNetworkLabel({
+    tokenId,
+    tokenNetwork,
+    networkOverride,
+    networkLabelText,
+    expandNearComLabel,
+}: {
+    tokenId: string;
+    tokenNetwork?: string;
+    networkOverride?: string;
+    networkLabelText: string;
+    expandNearComLabel: boolean;
+}): string | undefined {
+    const normalizedTokenId = tokenId.trim().toLowerCase();
+    const isNativeNearToken =
+        normalizedTokenId.length === 0 || normalizedTokenId === "near";
+    const resolvedNetwork = isNativeNearToken
+        ? "near"
+        : (networkOverride ?? tokenNetwork);
+
+    const nearTypeLabel = getNearTokenTypeLabel(
+        isNativeNearToken ? "near" : tokenId,
+        resolvedNetwork,
+    );
+
+    if (nearTypeLabel) {
+        return !expandNearComLabel &&
+            nearTypeLabel === "NEAR (near.com) Network"
+            ? "near.com"
+            : nearTypeLabel;
+    }
+
+    if (!resolvedNetwork) {
+        return undefined;
+    }
+
+    return getLocalizedNetworkDisplayName({
+        networkName: resolvedNetwork,
+        networkLabel: networkLabelText,
+        fallbackName: getNetworkDisplayName(resolvedNetwork),
+        expandNearComLabel,
+    });
+}
+
 export function Amount({
     amount,
     amountWithDecimals,
@@ -58,31 +102,13 @@ export function Amount({
         const price = tokenData?.price;
         return `≈ ${formatCurrency(parsedAmount * price!)}`;
     }, [tokenData, rawAmountValue, tCommon]);
-    const normalizedTokenId = tokenId.trim().toLowerCase();
-    const isNativeNearToken =
-        normalizedTokenId.length === 0 || normalizedTokenId === "near";
-    const resolvedNetwork = network ?? tokenData?.network;
-    const resolvedNetworkForLabel = isNativeNearToken
-        ? "near"
-        : resolvedNetwork;
-    const nearTypeLabel = getNearTokenTypeLabel(
-        isNativeNearToken ? "near" : tokenId,
-        resolvedNetworkForLabel,
-    );
-    const normalizedNearTypeLabel =
-        !expandNearComLabel && nearTypeLabel === "NEAR (near.com) Network"
-            ? "near.com"
-            : nearTypeLabel;
-    const networkLabel =
-        normalizedNearTypeLabel ??
-        (resolvedNetworkForLabel
-            ? getLocalizedNetworkDisplayName({
-                  networkName: resolvedNetworkForLabel,
-                  networkLabel: tAddressBookTable("network"),
-                  fallbackName: getNetworkDisplayName(resolvedNetworkForLabel),
-                  expandNearComLabel,
-              })
-            : undefined);
+    const networkLabel = resolveAmountNetworkLabel({
+        tokenId,
+        tokenNetwork: tokenData?.network,
+        networkOverride: network,
+        networkLabelText: tAddressBookTable("network"),
+        expandNearComLabel,
+    });
     const networkTooltipContent = networkLabel
         ? tAmount("network", { network: networkLabel })
         : null;
@@ -151,13 +177,11 @@ export function Amount({
                 </span>
             )}
             {showNetwork &&
-                (() => {
-                    return networkLabel ? (
-                        <span className="text-muted-foreground text-xs">
-                            {tAmount("network", { network: networkLabel })}
-                        </span>
-                    ) : null;
-                })()}
+                (networkLabel ? (
+                    <span className="text-muted-foreground text-xs">
+                        {tAmount("network", { network: networkLabel })}
+                    </span>
+                ) : null)}
         </div>
     );
 

--- a/nt-fe/features/proposals/components/amount.tsx
+++ b/nt-fe/features/proposals/components/amount.tsx
@@ -5,8 +5,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { TokenDisplay } from "@/components/token-display-with-network";
 import { getNetworkDisplayName } from "@/components/token-display";
 import { Tooltip } from "@/components/tooltip";
-import { getLocalizedNetworkDisplayName } from "@/constants/intents";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 import { useToken } from "@/hooks/use-treasury-queries";
+import { getLocalizedNetworkDisplayName } from "@/lib/intents-network";
 import {
     formatBalance,
     formatCurrency,
@@ -43,21 +44,19 @@ function resolveAmountNetworkLabel({
 }): string | undefined {
     const normalizedTokenId = tokenId.trim().toLowerCase();
     const isNativeNearToken =
-        normalizedTokenId.length === 0 || normalizedTokenId === "near";
+        normalizedTokenId.length === 0 || normalizedTokenId === NEAR_NETWORK_ID;
     const resolvedNetwork = isNativeNearToken
-        ? "near"
+        ? NEAR_NETWORK_ID
         : (networkOverride ?? tokenNetwork);
 
     const nearTypeLabel = getNearTokenTypeLabel(
-        isNativeNearToken ? "near" : tokenId,
+        isNativeNearToken ? NEAR_NETWORK_ID : tokenId,
         resolvedNetwork,
+        { expandNearComLabel },
     );
 
     if (nearTypeLabel) {
-        return !expandNearComLabel &&
-            nearTypeLabel === "NEAR (near.com) Network"
-            ? "near.com"
-            : nearTypeLabel;
+        return nearTypeLabel;
     }
 
     if (!resolvedNetwork) {

--- a/nt-fe/features/proposals/components/expanded-view/batch-payment-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/batch-payment-expanded.tsx
@@ -25,6 +25,7 @@ import { Proposal } from "@/lib/proposals-api";
 import { getProposalStatus } from "../../utils/proposal-utils";
 import { Policy } from "@/types/policy";
 import Big from "@/lib/big";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 interface PaymentDisplayProps {
     number: number;
@@ -61,7 +62,7 @@ function PaymentDisplay({
 
     // Get token metadata to determine blockchain network for recipient address
     const { data: tokenData } = useToken(tokenId);
-    const chainName = tokenData?.network || "near";
+    const chainName = tokenData?.network || NEAR_NETWORK_ID;
 
     // Transaction links are always NEAR (nearblocks)
     const nearBlocksUrl = transactionHash
@@ -74,7 +75,7 @@ function PaymentDisplay({
             value: (
                 <User
                     useAddressBook
-                    withName={chainName === "near"}
+                    withName={chainName === NEAR_NETWORK_ID}
                     accountId={payment.recipient}
                     chainName={chainName}
                 />
@@ -195,7 +196,7 @@ export function BatchPaymentRequestExpanded({
 
     let tokenId = data.tokenId;
     if (activeBatchData?.tokenId?.toLowerCase() === "native") {
-        tokenId = "near";
+        tokenId = NEAR_NETWORK_ID;
     }
     const { data: tokenData } = useToken(tokenId);
 
@@ -208,7 +209,7 @@ export function BatchPaymentRequestExpanded({
         token: tokenData
             ? {
                   address: tokenId,
-                  network: tokenData.network || "near",
+                  network: tokenData.network || NEAR_NETWORK_ID,
                   decimals: tokenData.decimals,
               }
             : null,

--- a/nt-fe/features/proposals/components/expanded-view/change-policy-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/change-policy-expanded.tsx
@@ -29,6 +29,7 @@ import { useTreasuryPolicy } from "@/hooks/use-treasury-queries";
 import { useTreasury } from "@/hooks/use-treasury";
 import { computePolicyDiff } from "../../utils/policy-diff-utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 interface ChangePolicyExpandedProps {
     data: ChangePolicyData;
@@ -59,7 +60,7 @@ function formatFieldValue(
         field === "proposal_period" || field === "bounty_forgiveness_period";
 
     if (isAmountField) {
-        return <Amount amount={value} showNetwork tokenId="near" />;
+        return <Amount amount={value} showNetwork tokenId={NEAR_NETWORK_ID} />;
     }
     if (isDurationField) {
         return <span>{formatNanosecondDuration(value)}</span>;

--- a/nt-fe/features/proposals/components/expanded-view/swap-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/swap-expanded.tsx
@@ -9,6 +9,7 @@ import { Address } from "@/components/address";
 import { Rate } from "@/components/rate";
 import { useToken, useSearchIntentsTokens } from "@/hooks/use-treasury-queries";
 import { FormattedDate } from "@/components/formatted-date";
+import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 
 interface SwapExpandedProps {
     data: SwapRequestData;
@@ -246,7 +247,7 @@ export function SwapExpanded({ data }: SwapExpandedProps) {
     switch (data.source) {
         case "exchange":
             return <IntentsSwapExpanded data={data} />;
-        case "wrap.near":
+        case WRAP_NEAR_TOKEN_ID:
             return <NearWrapSwapExpanded data={data} />;
         default:
             return null;

--- a/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
@@ -8,12 +8,18 @@ import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
 import { useToken } from "@/hooks/use-treasury-queries";
 import { Address } from "@/components/address";
-import { NetworkIconDisplay } from "@/components/token-display";
-import { NEAR_COM_ICON } from "@/constants/token";
-import { NEAR_COM_NETWORK_ID } from "@/constants/intents";
-import type { ChainIcons } from "@/lib/api";
+import {
+    getNetworkDisplayName,
+    NetworkIconDisplay,
+} from "@/components/token-display";
+import {
+    getNearComChainIcons,
+    isNearComPaymentRoute,
+    NEAR_COM_NETWORK_ID,
+} from "@/constants/intents";
 import { Skeleton } from "@/components/ui/skeleton";
-import { formatTokenDisplayAmount } from "@/lib/utils";
+import { formatTokenDisplayAmount, getNearTokenTypeLabel } from "@/lib/utils";
+import { Tooltip } from "@/components/tooltip";
 
 interface TransferExpandedProps {
     data: PaymentRequestData;
@@ -24,10 +30,10 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
     const tIntents = useTranslations("intentsQuote");
     const { data: tokenData } = useToken(data.tokenId);
     const tokenChainName = tokenData?.network || "near";
+    const isNearComDestination = isNearComPaymentRoute(data);
+
     const shouldFetchDestinationToken =
-        !!data.destinationAssetId &&
-        data.destinationAssetId !== NEAR_COM_NETWORK_ID &&
-        data.destinationAssetId !== "near";
+        !!data.destinationAssetId && !isNearComDestination;
     const { data: destinationTokenData, isLoading: isLoadingDestinationToken } =
         useToken(
             shouldFetchDestinationToken ? data.destinationAssetId : undefined,
@@ -35,30 +41,35 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
 
     // For cross-chain intents payments, prefer resolved destination token
     // network for recipient links when destinationNetwork carries a token id.
-    const recipientChainName =
-        data.destinationAssetId === NEAR_COM_NETWORK_ID
-            ? "near"
-            : destinationTokenData?.network ||
-              (!shouldFetchDestinationToken
-                  ? data.destinationAssetId
-                  : undefined) ||
-              tokenChainName;
+    const recipientChainName = isNearComDestination
+        ? "near"
+        : destinationTokenData?.network ||
+          (!shouldFetchDestinationToken
+              ? data.destinationAssetId
+              : undefined) ||
+          tokenChainName;
     const hasFeeData = !!data.networkFee;
+    const amountNetworkLabel =
+        getNearTokenTypeLabel(data.tokenId, tokenChainName) ??
+        getNetworkDisplayName(tokenChainName);
 
     const destinationNetworkMeta = useMemo(() => {
-        if (
-            !data.destinationAssetId ||
-            data.destinationAssetId === tokenChainName
-        ) {
-            return null;
-        }
-        if (data.destinationAssetId === NEAR_COM_NETWORK_ID) {
+        if (isNearComDestination) {
             return {
                 name: NEAR_COM_NETWORK_ID,
-                chainIcons: {
-                    dark: NEAR_COM_ICON,
-                    light: NEAR_COM_ICON,
-                } as ChainIcons,
+                chainIcons: getNearComChainIcons(),
+            };
+        }
+        if (!data.destinationAssetId) {
+            return {
+                name: tokenChainName,
+                chainIcons: tokenData?.chainIcons ?? null,
+            };
+        }
+        if (data.destinationAssetId === tokenChainName) {
+            return {
+                name: tokenChainName,
+                chainIcons: tokenData?.chainIcons ?? null,
             };
         }
         if (shouldFetchDestinationToken && destinationTokenData?.network) {
@@ -67,18 +78,21 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
                 chainIcons: destinationTokenData.chainIcons ?? null,
             };
         }
-        return null;
+        return {
+            name: data.destinationAssetId,
+            chainIcons: null,
+        };
     }, [
         data.destinationAssetId,
         destinationTokenData?.network,
         destinationTokenData?.chainIcons,
+        isNearComDestination,
         shouldFetchDestinationToken,
         tokenChainName,
+        tokenData?.chainIcons,
     ]);
     const shouldShowDestinationNetworkSkeleton =
-        shouldFetchDestinationToken &&
-        !destinationNetworkMeta &&
-        isLoadingDestinationToken;
+        shouldFetchDestinationToken && isLoadingDestinationToken;
 
     const infoItems: InfoItem[] = [
         {
@@ -95,29 +109,27 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
         {
             label: t("amount"),
             value: (
-                <Amount
-                    amount={data.amount}
-                    showNetwork
-                    tokenId={data.tokenId}
-                />
+                <Tooltip content={amountNetworkLabel}>
+                    <div>
+                        <Amount amount={data.amount} tokenId={data.tokenId} />
+                    </div>
+                </Tooltip>
             ),
         },
-    ];
-
-    if (destinationNetworkMeta || shouldShowDestinationNetworkSkeleton) {
-        infoItems.push({
+        {
             label: t("destinationNetwork"),
             value: shouldShowDestinationNetworkSkeleton ? (
                 <Skeleton className="h-5 w-28" />
             ) : (
                 <NetworkIconDisplay
-                    chainIcons={destinationNetworkMeta!.chainIcons}
-                    networkName={destinationNetworkMeta!.name}
-                    networkNameClassName="font-normal capitalize"
+                    chainIcons={destinationNetworkMeta.chainIcons}
+                    networkName={destinationNetworkMeta.name}
+                    networkNameClassName="font-normal"
+                    expandNearComLabel
                 />
             ),
-        });
-    }
+        },
+    ];
 
     if (hasFeeData) {
         infoItems.push({

--- a/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
@@ -12,11 +12,11 @@ import {
     getNetworkDisplayName,
     NetworkIconDisplay,
 } from "@/components/token-display";
+import { NEAR_NETWORK_ID, NEAR_COM_NETWORK_ID } from "@/constants/network-ids";
 import {
     getNearComChainIcons,
     isNearComPaymentRoute,
-    NEAR_COM_NETWORK_ID,
-} from "@/constants/intents";
+} from "@/lib/intents-network";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatTokenDisplayAmount, getNearTokenTypeLabel } from "@/lib/utils";
 import { Tooltip } from "@/components/tooltip";
@@ -29,7 +29,7 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
     const t = useTranslations("proposals.expanded");
     const tIntents = useTranslations("intentsQuote");
     const { data: tokenData } = useToken(data.tokenId);
-    const tokenChainName = tokenData?.network || "near";
+    const tokenChainName = tokenData?.network || NEAR_NETWORK_ID;
     const isNearComDestination = isNearComPaymentRoute(data);
 
     const shouldFetchDestinationToken =
@@ -42,7 +42,7 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
     // For cross-chain intents payments, prefer resolved destination token
     // network for recipient links when destinationNetwork carries a token id.
     const recipientChainName = isNearComDestination
-        ? "near"
+        ? NEAR_NETWORK_ID
         : destinationTokenData?.network ||
           (!shouldFetchDestinationToken
               ? data.destinationAssetId

--- a/nt-fe/features/proposals/components/transaction-cell/batch-payment-cell.tsx
+++ b/nt-fe/features/proposals/components/transaction-cell/batch-payment-cell.tsx
@@ -6,6 +6,7 @@ import {
 import { useBatchPayment } from "@/hooks/use-treasury-queries";
 import { TokenCell } from "./token-cell";
 import { Skeleton } from "@/components/ui/skeleton";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 interface BatchPaymentCellProps {
     data: BatchPaymentRequestData;
@@ -37,7 +38,7 @@ export function BatchPaymentCell({
 
     let tokenId = data.tokenId;
     if (batchData?.tokenId?.toLowerCase() === "native") {
-        tokenId = "near";
+        tokenId = NEAR_NETWORK_ID;
     }
 
     const tokenData = {

--- a/nt-fe/features/proposals/components/transaction-cell/swap-cell.tsx
+++ b/nt-fe/features/proposals/components/transaction-cell/swap-cell.tsx
@@ -3,6 +3,7 @@ import { SwapRequestData } from "../../types/index";
 import { Amount } from "../amount";
 import { useSearchIntentsTokens } from "@/hooks/use-treasury-queries";
 import { TitleSubtitleCell } from "./title-subtitle-cell";
+import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 
 interface SwapCellProps {
     data: SwapRequestData;
@@ -84,7 +85,7 @@ export function SwapCell(props: SwapCellProps) {
         case "exchange":
             title = <IntentsSwapCell {...props} />;
             break;
-        case "wrap.near":
+        case WRAP_NEAR_TOKEN_ID:
             title = <NearWrapSwapCell {...props} />;
             break;
         default:

--- a/nt-fe/features/proposals/components/transaction-cell/token-cell.tsx
+++ b/nt-fe/features/proposals/components/transaction-cell/token-cell.tsx
@@ -31,6 +31,8 @@ export function TokenCell({
             amount={data.amount}
             tokenId={data.tokenId}
             showUSDValue={false}
+            showNetworkTooltip
+            expandNearComLabel={"destinationAssetId" in data}
             iconSize="sm"
             textOnly={textOnly}
         />

--- a/nt-fe/features/proposals/hooks/use-proposal-insufficient-balance.ts
+++ b/nt-fe/features/proposals/hooks/use-proposal-insufficient-balance.ts
@@ -7,6 +7,7 @@ import { useAssets } from "@/hooks/use-assets";
 import { getProposalRequiredFunds } from "../utils/proposal-utils";
 import { formatBalance } from "@/lib/utils";
 import { availableBalance } from "@/lib/balance";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 export interface InsufficientBalanceInfo {
     hasInsufficientBalance: boolean;
@@ -41,7 +42,7 @@ export function useProposalInsufficientBalance(
             const token = assets.tokens.find(
                 (t) =>
                     t.contractId === requiredFunds.tokenId ||
-                    (requiredFunds.tokenId.toLowerCase() === "near" &&
+                    (requiredFunds.tokenId.toLowerCase() === NEAR_NETWORK_ID &&
                         t.contractId == null &&
                         t.residency === "Near"),
             );

--- a/nt-fe/features/proposals/hooks/use-proposals-insufficient-balance.ts
+++ b/nt-fe/features/proposals/hooks/use-proposals-insufficient-balance.ts
@@ -6,6 +6,7 @@ import { Proposal } from "@/lib/proposals-api";
 import { useAssets } from "@/hooks/use-assets";
 import { getProposalRequiredFunds } from "../utils/proposal-utils";
 import { availableBalance } from "@/lib/balance";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 /**
  * Hook to check which proposals in a list have insufficient treasury balance for approval.
@@ -34,7 +35,7 @@ export function useProposalsInsufficientBalance(
             const token = assets.tokens.find(
                 (t) =>
                     t.contractId === requiredFunds.tokenId ||
-                    (requiredFunds.tokenId.toLowerCase() === "near" &&
+                    (requiredFunds.tokenId.toLowerCase() === NEAR_NETWORK_ID &&
                         t.contractId == null &&
                         t.residency === "Near"),
             );

--- a/nt-fe/features/proposals/types/index.ts
+++ b/nt-fe/features/proposals/types/index.ts
@@ -1,6 +1,7 @@
 import { ProposalPermissionKind } from "@/lib/config-utils";
 import { Proposal } from "@/lib/proposals-api";
 import { Policy } from "@/types/policy";
+import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 
 /**
  * UI representation of proposal kinds
@@ -193,7 +194,7 @@ export interface ConfidentialRequestData {
 }
 
 export interface SwapRequestData {
-    source: "exchange" | "wrap.near";
+    source: "exchange" | typeof WRAP_NEAR_TOKEN_ID;
     timeEstimate?: string;
     intentsTokenContractId?: string;
     quoteSignature?: string;

--- a/nt-fe/features/proposals/utils/proposal-extractors.ts
+++ b/nt-fe/features/proposals/utils/proposal-extractors.ts
@@ -63,18 +63,8 @@ function extractFTTransferData(
             const hasNearDeposit = actions.some(
                 (a) => a.method_name === "near_deposit",
             );
-            const isDirectNativeNearTransfer =
-                action.method_name === "transfer";
-            const isWrappedNativeNearTransfer =
-                hasNearDeposit &&
-                (action.method_name === "ft_transfer" ||
-                    action.method_name === "ft_transfer_call") &&
-                functionCall.receiver_id === "wrap.near";
             return {
-                tokenId:
-                    isDirectNativeNearTransfer || isWrappedNativeNearTransfer
-                        ? "near"
-                        : functionCall.receiver_id,
+                tokenId: hasNearDeposit ? "near" : functionCall.receiver_id,
                 amount: args.amount || "0",
                 receiver: args.receiver_id || "",
             };

--- a/nt-fe/features/proposals/utils/proposal-extractors.ts
+++ b/nt-fe/features/proposals/utils/proposal-extractors.ts
@@ -60,9 +60,19 @@ function extractFTTransferData(
         }
         const args = decodeArgs(action.args);
         if (args) {
+            const hasNearDeposit = actions.some(
+                (a) => a.method_name === "near_deposit",
+            );
+            const isDirectNativeNearTransfer =
+                action.method_name === "transfer";
+            const isWrappedNativeNearTransfer =
+                hasNearDeposit &&
+                (action.method_name === "ft_transfer" ||
+                    action.method_name === "ft_transfer_call") &&
+                functionCall.receiver_id === "wrap.near";
             return {
                 tokenId:
-                    action.method_name === "transfer"
+                    isDirectNativeNearTransfer || isWrappedNativeNearTransfer
                         ? "near"
                         : functionCall.receiver_id,
                 amount: args.amount || "0",
@@ -139,7 +149,11 @@ export function extractPaymentRequestData(
 
     if ("Transfer" in proposal.kind) {
         const transfer = proposal.kind.Transfer;
-        tokenId = transfer.token_id.length > 0 ? transfer.token_id : "near";
+        const normalizedTokenId = transfer.token_id?.trim();
+        tokenId =
+            normalizedTokenId && normalizedTokenId.length > 0
+                ? normalizedTokenId
+                : "near";
         amount = transfer.amount;
         receiver = transfer.receiver_id;
     } else if ("FunctionCall" in proposal.kind) {
@@ -168,18 +182,28 @@ export function extractPaymentRequestData(
     }
 
     // Intents routing metadata (only present on proposals created via 1Click)
-    const depositAddress =
-        decodeProposalDescription("depositAddress", proposal.description) ||
-        undefined;
-    const quoteSignature =
-        decodeProposalDescription("signature", proposal.description) ||
-        undefined;
-    const networkFee =
-        decodeProposalDescription("networkFee", proposal.description) ||
-        undefined;
-    const destinationAssetId =
-        decodeProposalDescription("destinationNetwork", proposal.description) ||
-        undefined;
+    const depositAddress = decodeProposalDescription(
+        "depositAddress",
+        proposal.description,
+    );
+    const quoteSignature = decodeProposalDescription(
+        "signature",
+        proposal.description,
+    );
+    const networkFee = decodeProposalDescription(
+        "networkFee",
+        proposal.description,
+    );
+    let destinationAssetId = decodeProposalDescription(
+        "destinationNetwork",
+        proposal.description,
+    );
+
+    // Plain native NEAR transfers without 1Click metadata should resolve to
+    // NEAR network (not near.com route) in destination display.
+    if (!destinationAssetId && tokenId === "near" && !depositAddress) {
+        destinationAssetId = "near";
+    }
     return {
         tokenId,
         amount,
@@ -402,7 +426,7 @@ export function extractExchangeRequestData(
         throw new Error("Proposal is not a Exchange proposal");
     }
 
-    const args = decodeArgs(action?.args);
+    const args = decodeArgs(action.args);
     if (!args) {
         throw new Error("Proposal is not a Exchange proposal");
     }

--- a/nt-fe/features/proposals/utils/proposal-extractors.ts
+++ b/nt-fe/features/proposals/utils/proposal-extractors.ts
@@ -28,7 +28,11 @@ import { Policy } from "@/types/policy";
 import { getKindFromProposal } from "@/lib/config-utils";
 import { FunctionCallAction } from "@/lib/proposals-api";
 import { IntentsQuoteResponse } from "@/lib/api";
-import { NEAR_COM_NETWORK_ID } from "@/constants/intents";
+import {
+    NEAR_COM_NETWORK_ID,
+    NEAR_NETWORK_ID,
+    WRAP_NEAR_TOKEN_ID,
+} from "@/constants/network-ids";
 import { computeQuoteNetworkFee } from "@/lib/intents-fee";
 
 function extractFTTransferData(
@@ -64,7 +68,9 @@ function extractFTTransferData(
                 (a) => a.method_name === "near_deposit",
             );
             return {
-                tokenId: hasNearDeposit ? "near" : functionCall.receiver_id,
+                tokenId: hasNearDeposit
+                    ? NEAR_NETWORK_ID
+                    : functionCall.receiver_id,
                 amount: args.amount || "0",
                 receiver: args.receiver_id || "",
             };
@@ -73,7 +79,7 @@ function extractFTTransferData(
         const args = decodeArgs(actionMTTransfer.args);
         if (args) {
             return {
-                tokenId: args.token_id || "near",
+                tokenId: args.token_id || NEAR_NETWORK_ID,
                 amount: args.amount || "0",
                 receiver: args.receiver_id || "",
             };
@@ -129,7 +135,7 @@ function extractFTTransferData(
 export function extractPaymentRequestData(
     proposal: Proposal,
 ): PaymentRequestData {
-    let tokenId = "near";
+    let tokenId = NEAR_NETWORK_ID;
     let amount = "0";
     let receiver = "";
     const proposalAction = decodeProposalDescription(
@@ -143,7 +149,7 @@ export function extractPaymentRequestData(
         tokenId =
             normalizedTokenId && normalizedTokenId.length > 0
                 ? normalizedTokenId
-                : "near";
+                : NEAR_NETWORK_ID;
         amount = transfer.amount;
         receiver = transfer.receiver_id;
     } else if ("FunctionCall" in proposal.kind) {
@@ -191,8 +197,8 @@ export function extractPaymentRequestData(
 
     // Plain native NEAR transfers without 1Click metadata should resolve to
     // NEAR network (not near.com route) in destination display.
-    if (!destinationAssetId && tokenId === "near" && !depositAddress) {
-        destinationAssetId = "near";
+    if (!destinationAssetId && tokenId === NEAR_NETWORK_ID && !depositAddress) {
+        destinationAssetId = NEAR_NETWORK_ID;
     }
     return {
         tokenId,
@@ -305,7 +311,7 @@ export function extractStakingData(proposal: Proposal): StakingData {
     );
 
     return {
-        tokenId: "near",
+        tokenId: NEAR_NETWORK_ID,
         amount: isFullAmount
             ? "0"
             : args?.amount || stakingAction?.deposit || withdrawAmount || "0",
@@ -334,7 +340,7 @@ export function extractVestingData(proposal: Proposal): VestingData {
 
     if (!firstAction || firstAction.method_name !== "create") {
         return {
-            tokenId: "near",
+            tokenId: NEAR_NETWORK_ID,
             amount: "0",
             receiver: "",
             vestingSchedule: null,
@@ -349,7 +355,7 @@ export function extractVestingData(proposal: Proposal): VestingData {
     const args = decodeArgs(firstAction.args);
     if (!args) {
         return {
-            tokenId: "near",
+            tokenId: NEAR_NETWORK_ID,
             amount: "0",
             receiver: "",
             vestingSchedule: null,
@@ -376,7 +382,7 @@ export function extractVestingData(proposal: Proposal): VestingData {
     const notes = decodeProposalDescription("notes", proposal.description);
 
     return {
-        tokenId: "near",
+        tokenId: NEAR_NETWORK_ID,
         amount: firstAction.deposit,
         receiver: recipient,
         vestingSchedule,
@@ -491,9 +497,9 @@ export function extractExchangeRequestData(
             (a) => a.method_name === "near_deposit",
         );
 
-        if (hasNearDeposit && functionCall.receiver_id === "wrap.near") {
+        if (hasNearDeposit && functionCall.receiver_id === WRAP_NEAR_TOKEN_ID) {
             // Native NEAR exchange: near -> other token
-            tokenIn = "near";
+            tokenIn = NEAR_NETWORK_ID;
         } else {
             // FT token or wNEAR exchange
             tokenIn = functionCall.receiver_id;
@@ -515,7 +521,7 @@ export function extractExchangeRequestData(
         amountIn,
         amountOut,
         destinationNetwork, // LEGACY: for old proposals
-        sourceNetwork: "near",
+        sourceNetwork: NEAR_NETWORK_ID,
         quoteSignature,
         depositAddress,
         timeEstimate: timeEstimate || undefined,
@@ -549,13 +555,13 @@ export function extractNearWrapSwapRequestData(
     const amount = isWrap ? action.deposit || "0" : args.amount || "0";
 
     return {
-        source: "wrap.near",
-        tokenIn: isWrap ? "near" : "wrap.near",
+        source: WRAP_NEAR_TOKEN_ID,
+        tokenIn: isWrap ? NEAR_NETWORK_ID : WRAP_NEAR_TOKEN_ID,
         amountIn: amount,
-        tokenOut: isWrap ? "wrap.near" : "near",
+        tokenOut: isWrap ? WRAP_NEAR_TOKEN_ID : NEAR_NETWORK_ID,
         amountOut: amount,
-        destinationNetwork: "near",
-        sourceNetwork: "near",
+        destinationNetwork: NEAR_NETWORK_ID,
+        sourceNetwork: NEAR_NETWORK_ID,
     };
 }
 
@@ -830,7 +836,7 @@ export function extractConfidentialRequestData(
                         recipientType === "INTENTS"
                       ? NEAR_COM_NETWORK_ID
                       : recipientType === "DESTINATION_CHAIN"
-                        ? "near"
+                        ? NEAR_NETWORK_ID
                         : undefined;
             const networkFee = computeQuoteNetworkFee(quote);
             mapped = {
@@ -905,7 +911,7 @@ export function extractProposalData(
 
                 // Check if this is a simple wrap/unwrap (no exchange)
                 const isSimpleWrapUnwrap =
-                    functionCall.receiver_id === "wrap.near" &&
+                    functionCall.receiver_id === WRAP_NEAR_TOKEN_ID &&
                     functionCall.actions.length === 1 &&
                     functionCall.actions.some(
                         (action) =>

--- a/nt-fe/features/proposals/utils/proposal-utils.ts
+++ b/nt-fe/features/proposals/utils/proposal-utils.ts
@@ -12,6 +12,7 @@ import {
 } from "../types/index";
 import { decodeArgs, decodeProposalDescription, nanosToMs } from "@/lib/utils";
 import { extractProposalData } from "./proposal-extractors";
+import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 
 // Exchange custom deadline (capped by proposal_period).
 // Pure wrap/unwrap (single wrap.near near_deposit/near_withdraw) uses normal proposal period.
@@ -109,7 +110,7 @@ function processFTTransferProposal(
     }
 
     if (
-        functionCall.receiver_id === "wrap.near" &&
+        functionCall.receiver_id === WRAP_NEAR_TOKEN_ID &&
         functionCall.actions.some(
             (action) =>
                 action.method_name === "near_withdraw" ||
@@ -309,7 +310,10 @@ function isNormalPeriodWrapProposal(proposal: Proposal): boolean {
     const functionCall = proposal.kind.FunctionCall;
     const actions = functionCall.actions ?? [];
 
-    if (functionCall.receiver_id !== "wrap.near" || actions.length !== 1) {
+    if (
+        functionCall.receiver_id !== WRAP_NEAR_TOKEN_ID ||
+        actions.length !== 1
+    ) {
         return false;
     }
 

--- a/nt-fe/hooks/use-intents-quote.ts
+++ b/nt-fe/hooks/use-intents-quote.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useDebounce } from "use-debounce";
 import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
-import { NEAR_COM_NETWORK_ID } from "@/constants/intents";
+import { isNearComNetwork, NEAR_COM_NETWORK_ID } from "@/constants/intents";
 import { getAddressPattern } from "@/lib/address-validation";
 import Big from "@/lib/big";
 import { getBlockchainType } from "@/lib/blockchain-utils";
@@ -57,9 +57,9 @@ export function buildIntentsQuoteRequest(
 
     // Empty destinationNetwork = no explicit selection. Only near.com is
     // user-selectable today, so default to it.
-    const isNearComNetwork =
-        !destinationNetwork || destinationNetwork === NEAR_COM_NETWORK_ID;
-    const recipientType = isNearComNetwork
+    const isNearComRoute =
+        !destinationNetwork || isNearComNetwork(destinationNetwork);
+    const recipientType = isNearComRoute
         ? isConfidential
             ? ("CONFIDENTIAL_INTENTS" as const)
             : ("INTENTS" as const)
@@ -68,7 +68,7 @@ export function buildIntentsQuoteRequest(
     // near.com → keep origin token address (stays on Intents).
     // Other networks → destinationNetwork IS the bridge network id (e.g.
     // `nep141:usdc-eth.omft.near`) and serves as the destinationAsset.
-    const destinationAsset = isNearComNetwork
+    const destinationAsset = isNearComRoute
         ? token.address
         : destinationNetwork!;
     const normalizedRecipient = isEthImplicitNearAddress(address)

--- a/nt-fe/hooks/use-intents-quote.ts
+++ b/nt-fe/hooks/use-intents-quote.ts
@@ -4,10 +4,11 @@ import { useCallback, useMemo, useState } from "react";
 import { useDebounce } from "use-debounce";
 import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
-import { isNearComNetwork, NEAR_COM_NETWORK_ID } from "@/constants/intents";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 import { getAddressPattern } from "@/lib/address-validation";
 import Big from "@/lib/big";
 import { getBlockchainType } from "@/lib/blockchain-utils";
+import { isNearComNetwork } from "@/lib/intents-network";
 import {
     isEthImplicitNearAddress,
     isValidNearAddressFormat,
@@ -19,12 +20,12 @@ import { isIntentsToken } from "@/lib/intents-fee";
 
 export type IntentsAmountMode = "recipient" | "total";
 const MAX_FEE_TO_RECIPIENT_RATIO = Big(1);
-export { NEAR_COM_NETWORK_ID };
 
 function isAddressValidForToken(address: string, token: Token): boolean {
     if (!address) return false;
     const blockchain = getBlockchainType(token.network);
-    if (blockchain === "near") return isValidNearAddressFormat(address);
+    if (blockchain === NEAR_NETWORK_ID)
+        return isValidNearAddressFormat(address);
     if (blockchain === "unknown") return true;
     const pattern = getAddressPattern(blockchain);
     return pattern ? pattern.test(address) : true;

--- a/nt-fe/hooks/use-merged-tokens.ts
+++ b/nt-fe/hooks/use-merged-tokens.ts
@@ -12,6 +12,7 @@ import {
 import { useTreasury } from "@/hooks/use-treasury";
 import { NEAR_CHAIN_ICONS } from "@/constants/token";
 import type { ChainIcons } from "@/lib/api";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 export interface MergedNetwork {
     id: string;
@@ -61,7 +62,9 @@ const mapTreasuryNetwork = (n: TreasuryNetwork): MergedNetwork => ({
     symbol: n.symbol,
     chainIcons:
         n.chainIcons ||
-        (n.id === "near" && n.residency === "Near" ? NEAR_CHAIN_ICONS : null),
+        (n.id === NEAR_NETWORK_ID && n.residency === "Near"
+            ? NEAR_CHAIN_ICONS
+            : null),
     chainId: n.network,
     decimals: n.decimals,
     residency: n.residency,
@@ -83,7 +86,8 @@ const mapBridgeMatchedNetwork = (
     symbol: treasuryNetwork.symbol,
     chainIcons:
         treasuryNetwork.chainIcons ||
-        (treasuryNetwork.id === "near" && treasuryNetwork.residency === "Near"
+        (treasuryNetwork.id === NEAR_NETWORK_ID &&
+        treasuryNetwork.residency === "Near"
             ? NEAR_CHAIN_ICONS
             : bridgeNetwork.chainIcons),
     chainId: bridgeNetwork.chainId,

--- a/nt-fe/hooks/use-treasury-queries.ts
+++ b/nt-fe/hooks/use-treasury-queries.ts
@@ -25,6 +25,7 @@ import {
 import { useTreasury } from "./use-treasury";
 import { useAssets } from "./use-assets";
 import { availableBalance } from "@/lib/balance";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 /**
  * Query hook to get user's treasuries with config data
@@ -104,7 +105,7 @@ export function useTokenBalance(
     const balance = assets?.tokens.find(
         (asset) =>
             asset.contractId === tokenId ||
-            (tokenId?.toLowerCase() === "near" &&
+            (tokenId?.toLowerCase() === NEAR_NETWORK_ID &&
                 asset.contractId == null &&
                 asset.residency === "Near"),
     )?.balance;

--- a/nt-fe/lib/address-validation.ts
+++ b/nt-fe/lib/address-validation.ts
@@ -6,6 +6,7 @@
  */
 
 import { BlockchainType } from "./blockchain-utils";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 /**
  * Validation result with optional error message
@@ -144,7 +145,7 @@ export function validateAddress(
     const trimmedAddress = address.trim();
 
     // NEAR addresses are handled by near-validation.ts
-    if (blockchain === "near") {
+    if (blockchain === NEAR_NETWORK_ID) {
         // For synchronous validation, we can only check format
         // Full validation (including blockchain check) must be done async
         return {

--- a/nt-fe/lib/api.ts
+++ b/nt-fe/lib/api.ts
@@ -1,6 +1,7 @@
 import { Policy } from "@/types/policy";
 import axios from "axios";
 import Big from "@/lib/big";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 import { Balance, BalanceRaw, transformBalance } from "./balance";
 
 const BACKEND_API_BASE = `${process.env.NEXT_PUBLIC_BACKEND_API_BASE}/api`;
@@ -590,7 +591,7 @@ export async function getTokenMetadata(
     const noPrefixNoNear =
         !token.startsWith("nep141:") &&
         !token.startsWith("nep245:") &&
-        token.toLowerCase() !== "near";
+        token.toLowerCase() !== NEAR_NETWORK_ID;
 
     if (noPrefixNoNear && token.split(":").length === 2) {
         token = `nep245:${token}`;

--- a/nt-fe/lib/blockchain-utils.ts
+++ b/nt-fe/lib/blockchain-utils.ts
@@ -1,3 +1,5 @@
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
+
 /**
  * Maps chainName from backend to blockchain identifiers for address validation
  *
@@ -6,7 +8,7 @@
  */
 
 export type BlockchainType =
-    | "near"
+    | typeof NEAR_NETWORK_ID
     | "bitcoin"
     | "bitcoincash"
     | "litecoin"
@@ -33,8 +35,8 @@ export function getBlockchainType(chainName: string): BlockchainType {
     const chainLower = chainName.toLowerCase();
 
     // NEAR chains
-    if (chainLower === "near") {
-        return "near";
+    if (chainLower === NEAR_NETWORK_ID) {
+        return NEAR_NETWORK_ID;
     }
 
     // Bitcoin
@@ -173,7 +175,7 @@ export function getBlockchainType(chainName: string): BlockchainType {
  */
 export function isNearToken(chainName?: string, residency?: string): boolean {
     if (!chainName) return true; // Default to NEAR if no chainName
-    return getBlockchainType(chainName) === "near";
+    return getBlockchainType(chainName) === NEAR_NETWORK_ID;
 }
 
 /**
@@ -185,7 +187,7 @@ export function requiresCrossChainValidation(
 ): boolean {
     if (!chainName) return false;
     const blockchainType = getBlockchainType(chainName);
-    return blockchainType !== "near" && blockchainType !== "unknown";
+    return blockchainType !== NEAR_NETWORK_ID && blockchainType !== "unknown";
 }
 
 /**
@@ -199,7 +201,7 @@ export function getExplorerAddressUrl(
     const chainLower = chainName.toLowerCase();
 
     switch (blockchainType) {
-        case "near":
+        case NEAR_NETWORK_ID:
             return `https://nearblocks.io/address/${address}`;
 
         case "ethereum":

--- a/nt-fe/lib/intents-fee.ts
+++ b/nt-fe/lib/intents-fee.ts
@@ -3,6 +3,7 @@ import Big from "@/lib/big";
 import { validateAddress } from "@/lib/address-validation";
 import type { BlockchainType } from "@/lib/blockchain-utils";
 import { formatSmartAmount } from "@/lib/utils";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 
 const intentsSdk = new IntentsSDK({
     referral: "",
@@ -41,7 +42,7 @@ export function isIntentsCrossChainToken(token: {
         !!token.address &&
         (token.address.startsWith("nep141:") ||
             token.address.startsWith("nep245:")) &&
-        (token.network || "").toLowerCase() !== "near"
+        (token.network || "").toLowerCase() !== NEAR_NETWORK_ID
     );
 }
 
@@ -55,9 +56,9 @@ export function isNearChainNativeToken(token: {
     const residency = (token.residency || "").toLowerCase();
 
     return (
-        address === "near" &&
-        (!network || network === "near") &&
-        (!residency || residency === "near")
+        address === NEAR_NETWORK_ID &&
+        (!network || network === NEAR_NETWORK_ID) &&
+        (!residency || residency === NEAR_NETWORK_ID)
     );
 }
 
@@ -69,10 +70,10 @@ export function isNearChainFtToken(token: {
     const address = (token.address || "").toLowerCase();
     const network = (token.network || "").toLowerCase();
     const residency = (token.residency || "").toLowerCase();
-    const isNearNetwork = !network || network === "near";
+    const isNearNetwork = !network || network === NEAR_NETWORK_ID;
     const isNearStyleFtAddress =
         !!address &&
-        address !== "near" &&
+        address !== NEAR_NETWORK_ID &&
         !address.startsWith("nep141:") &&
         !address.startsWith("nep245:");
 

--- a/nt-fe/lib/intents-network.ts
+++ b/nt-fe/lib/intents-network.ts
@@ -1,12 +1,10 @@
 import type { ChainIcons } from "@/lib/api";
 import { NEAR_COM_ICON } from "@/constants/token";
-
-export const NEAR_COM_NETWORK_ID = "near.com";
-// UI-only network id used to represent direct treasury deposits (no intents/bridge route).
-// Intentionally different from NEAR_COM_NETWORK_ID ("near.com"), which represents the intents route.
-export const NEAR_COM_DIRECT_NETWORK_ID = "near.com:direct";
-
-export const NEAR_COM_NETWORK_NAME = "near.com";
+import {
+    NEAR_COM_DIRECT_NETWORK_ID,
+    NEAR_COM_NETWORK_ID,
+    NEAR_COM_NETWORK_NAME,
+} from "@/constants/network-ids";
 
 export function isNearComNetwork(value?: string | null): boolean {
     const normalized = value?.toLowerCase();

--- a/nt-fe/lib/near-proposal-builders.ts
+++ b/nt-fe/lib/near-proposal-builders.ts
@@ -5,6 +5,7 @@ import {
     STORAGE_DEPOSIT_GAS,
 } from "@/lib/near-ft-gas";
 import { jsonToBase64 } from "@/lib/utils";
+import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 
 type FunctionCallTxAction = {
     type: "FunctionCall";
@@ -74,7 +75,7 @@ export function buildNativeNearIntentsKind(
 ): FunctionCallKind {
     return {
         FunctionCall: {
-            receiver_id: "wrap.near",
+            receiver_id: WRAP_NEAR_TOKEN_ID,
             actions: [
                 {
                     method_name: "near_deposit",

--- a/nt-fe/lib/utils.ts
+++ b/nt-fe/lib/utils.ts
@@ -573,7 +573,7 @@ export const decodeProposalDescription = (key: string, description: string) => {
         }
     }
 
-    return null; // Return null if key not found
+    return undefined;
 };
 
 /** Convert a nanosecond timestamp/duration (string) to milliseconds. */
@@ -589,7 +589,7 @@ export function msToNanos(ms: number): string {
 /**
  * Returns a human-readable NEAR token type label based on the tokenId.
  * - "" or "near" → "Native Token"
- * - starts with "nep141:" or "nep245:" → "Intents Token"
+ * - starts with "nep141:" or "nep245:" → "near.com Network"
  * - anything else (contract address) → "Fungible Token"
  *
  * Returns null for non-NEAR networks so callers can fall back to the chain name.

--- a/nt-fe/lib/utils.ts
+++ b/nt-fe/lib/utils.ts
@@ -1,4 +1,5 @@
 import Big from "@/lib/big";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 import { clsx, type ClassValue } from "clsx";
 import { format } from "date-fns";
 import { twMerge } from "tailwind-merge";
@@ -588,23 +589,27 @@ export function msToNanos(ms: number): string {
 
 /**
  * Returns a human-readable NEAR token type label based on the tokenId.
- * - "" or "near" → "Native Token"
- * - starts with "nep141:" or "nep245:" → "near.com Network"
- * - anything else (contract address) → "Fungible Token"
+ * - "" or "near" → "NEAR (Native Token)"
+ * - starts with "nep141:" or "nep245:" → "NEAR (near.com)" or "near.com"
+ * - anything else (contract address) → "NEAR (Fungible Token)"
  *
  * Returns null for non-NEAR networks so callers can fall back to the chain name.
  */
 export function getNearTokenTypeLabel(
     tokenId: string,
     network?: string,
+    options?: { expandNearComLabel?: boolean },
 ): string | null {
-    const resolvedNetwork = network?.toLowerCase() ?? "near";
-    if (resolvedNetwork !== "near") return null;
+    const resolvedNetwork = network?.toLowerCase() ?? NEAR_NETWORK_ID;
+    if (resolvedNetwork !== NEAR_NETWORK_ID) return null;
 
     const id = tokenId.toLowerCase();
-    if (id === "" || id === "near") return "NEAR (Native Token)";
-    if (id.startsWith("nep141:") || id.startsWith("nep245:"))
-        return "NEAR (near.com)";
+    if (id === "" || id === NEAR_NETWORK_ID) return "NEAR (Native Token)";
+    if (id.startsWith("nep141:") || id.startsWith("nep245:")) {
+        return options?.expandNearComLabel === false
+            ? "near.com"
+            : "NEAR (near.com)";
+    }
     return "NEAR (Fungible Token)";
 }
 

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -1539,7 +1539,6 @@
         "incompatible": "Inkompatibel",
         "comingSoon": "Demnächst verfügbar",
         "forMembersOnly": "Nur für Mitglieder",
-        "nearComName": "near.com",
         "nearComDescription": "Vertrauliches Netzwerk für near.com und Trezu",
         "nearDescription": "Netzwerk für öffentliche Auszahlungen"
     },

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -1539,7 +1539,6 @@
         "incompatible": "Incompatible",
         "comingSoon": "Coming Soon",
         "forMembersOnly": "For Members Only",
-        "nearComName": "near.com",
         "nearComDescription": "Confidential network of near.com and trezu",
         "nearDescription": "Network for public withdrawal"
     },

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -1539,7 +1539,6 @@
         "incompatible": "Incompatible",
         "comingSoon": "Próximamente",
         "forMembersOnly": "Solo para miembros",
-        "nearComName": "near.com",
         "nearComDescription": "Red confidencial para near.com y trezu",
         "nearDescription": "Red para retiro público"
     },

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -1539,7 +1539,6 @@
         "incompatible": "Incompatible",
         "comingSoon": "Bientôt disponible",
         "forMembersOnly": "Réservé aux membres",
-        "nearComName": "near.com",
         "nearComDescription": "Réseau confidentiel pour near.com et trezu",
         "nearDescription": "Réseau pour retrait public"
     },

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -1539,7 +1539,6 @@
         "incompatible": "לא תואם",
         "comingSoon": "בקרוב",
         "forMembersOnly": "לחברים בלבד",
-        "nearComName": "near.com",
         "nearComDescription": "רשת סודית עבור near.com ו-Trezu",
         "nearDescription": "רשת למשיכה ציבורית"
     },

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -1539,7 +1539,6 @@
         "incompatible": "Tidak Kompatibel",
         "comingSoon": "Segera Hadir",
         "forMembersOnly": "Hanya untuk anggota",
-        "nearComName": "near.com",
         "nearComDescription": "Jaringan rahasia untuk near.com dan trezu",
         "nearDescription": "Jaringan untuk penarikan publik"
     },

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -1539,7 +1539,6 @@
         "incompatible": "非互換",
         "comingSoon": "近日公開",
         "forMembersOnly": "メンバー限定",
-        "nearComName": "near.com",
         "nearComDescription": "near.comとtrezuの機密ネットワーク",
         "nearDescription": "公開出金用ネットワーク"
     },

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -1539,7 +1539,6 @@
         "incompatible": "호환되지 않음",
         "comingSoon": "곧 제공",
         "forMembersOnly": "회원 전용",
-        "nearComName": "near.com",
         "nearComDescription": "near.com 및 trezu용 기밀 네트워크",
         "nearDescription": "공개 출금을 위한 네트워크"
     },

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -1539,7 +1539,6 @@
         "incompatible": "Incompatível",
         "comingSoon": "Em breve",
         "forMembersOnly": "Apenas para membros",
-        "nearComName": "near.com",
         "nearComDescription": "Rede confidencial da near.com e trezu",
         "nearDescription": "Rede para saque público"
     },

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -1539,7 +1539,6 @@
         "incompatible": "Uyumsuz",
         "comingSoon": "Yakında",
         "forMembersOnly": "Yalnızca Üyelere Özel",
-        "nearComName": "near.com",
         "nearComDescription": "near.com ve trezu için gizli ağ",
         "nearDescription": "Herkese açık para çekme ağı"
     },

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -1539,7 +1539,6 @@
         "incompatible": "Несумісні",
         "comingSoon": "Скоро",
         "forMembersOnly": "Лише для учасників",
-        "nearComName": "near.com",
         "nearComDescription": "Конфіденційна мережа near.com і trezu",
         "nearDescription": "Мережа для публічного виведення"
     },

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -1539,7 +1539,6 @@
         "incompatible": "Không tương thích",
         "comingSoon": "Sắp ra mắt",
         "forMembersOnly": "Chỉ dành cho thành viên",
-        "nearComName": "near.com",
         "nearComDescription": "Mạng bảo mật của near.com và trezu",
         "nearDescription": "Mạng dành cho rút tiền công khai"
     },

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -1539,7 +1539,6 @@
         "incompatible": "不兼容",
         "comingSoon": "即将推出",
         "forMembersOnly": "仅限成员",
-        "nearComName": "near.com",
         "nearComDescription": "near.com 与 trezu 的机密网络",
         "nearDescription": "用于公开提现的网络"
     },


### PR DESCRIPTION
- Added Staging pill in header.
- In Payment Request details:
  - moved hover info to the Amount
  - always show Destination Network row
- Cleaned casing behavior for near.com. (Near.com -> near.com)
- Fixed network detection edge cases for NEAR token, it showed Native token as Fungible.
- Updated rhea link.
- [x] #636