### PR TITLE
fix: resolve confidential payment destination network from recipient and destination asset

### DIFF
--- a/nt-fe/components/page-component-layout.tsx
+++ b/nt-fe/components/page-component-layout.tsx
@@ -95,6 +95,15 @@ export function PageComponentLayout({
                 </div>
 
                 <div className="flex items-center gap-3">
+                    {isStaging && (
+                        <Pill
+                            title="Staging"
+                            icon={
+                                <span className="size-1.5 rounded-full bg-general-orange-foreground" />
+                            }
+                            className="bg-general-orange-background-faded text-general-orange-foreground"
+                        />
+                    )}
                     <LanguageSwitcher />
                     <Button
                         variant="ghost"

--- a/nt-fe/features/proposals/utils/proposal-extractors.ts
+++ b/nt-fe/features/proposals/utils/proposal-extractors.ts
@@ -34,7 +34,6 @@ import {
     WRAP_NEAR_TOKEN_ID,
 } from "@/constants/network-ids";
 import { computeQuoteNetworkFee } from "@/lib/intents-fee";
-import { isValidNearAddressFormat } from "@/lib/near-validation";
 
 function normalizeTimeEstimateSeconds(value?: string): string | undefined {
     if (!value) return undefined;

--- a/nt-fe/features/proposals/utils/proposal-extractors.ts
+++ b/nt-fe/features/proposals/utils/proposal-extractors.ts
@@ -849,10 +849,8 @@ export function extractConfidentialRequestData(
                 typeof quoteRequest.recipientType === "string"
                     ? quoteRequest.recipientType
                     : undefined;
-            const isValidNearRecipient = isValidNearAddressFormat(recipient);
             const isNearComIntentsRoute =
-                recipientType === "CONFIDENTIAL_INTENTS" &&
-                isValidNearRecipient;
+                recipientType === "CONFIDENTIAL_INTENTS";
             const destinationAssetId = isNearComIntentsRoute
                 ? NEAR_COM_NETWORK_ID
                 : destinationAsset;

--- a/nt-fe/features/proposals/utils/proposal-extractors.ts
+++ b/nt-fe/features/proposals/utils/proposal-extractors.ts
@@ -34,6 +34,7 @@ import {
     WRAP_NEAR_TOKEN_ID,
 } from "@/constants/network-ids";
 import { computeQuoteNetworkFee } from "@/lib/intents-fee";
+import { isValidNearAddressFormat } from "@/lib/near-validation";
 
 function normalizeTimeEstimateSeconds(value?: string): string | undefined {
     if (!value) return undefined;
@@ -843,27 +844,25 @@ export function extractConfidentialRequestData(
             title = "Confidential Exchange";
         } else {
             const destinationAsset = quoteRequest.destinationAsset;
+            const recipient = quoteRequest.recipient ?? "";
             const recipientType =
                 typeof quoteRequest.recipientType === "string"
                     ? quoteRequest.recipientType
                     : undefined;
-            const destinationAssetId =
-                destinationAsset &&
-                destinationAsset !== quoteRequest.originAsset
-                    ? destinationAsset
-                    : recipientType === "CONFIDENTIAL_INTENTS" ||
-                        recipientType === "INTENTS"
-                      ? NEAR_COM_NETWORK_ID
-                      : recipientType === "DESTINATION_CHAIN"
-                        ? NEAR_NETWORK_ID
-                        : undefined;
+            const isValidNearRecipient = isValidNearAddressFormat(recipient);
+            const isNearComIntentsRoute =
+                recipientType === "CONFIDENTIAL_INTENTS" &&
+                isValidNearRecipient;
+            const destinationAssetId = isNearComIntentsRoute
+                ? NEAR_COM_NETWORK_ID
+                : destinationAsset;
             const networkFee = computeQuoteNetworkFee(quote);
             mapped = {
                 type: "payment",
                 data: {
                     tokenId: quoteRequest.originAsset,
                     amount: quote.amountIn,
-                    receiver: quoteRequest.recipient ?? "",
+                    receiver: recipient,
                     notes: meta?.notes ?? undefined,
                     depositAddress: quote.depositAddress,
                     quoteSignature: quoteResponse.signature,


### PR DESCRIPTION
#653 
- Confirmed with Artur: near.com route is now applied only when `recipientType` is `CONFIDENTIAL_INTENTS`.
- In all other cases, destination network is derived from `destinationAsset`.
- Added back staging pill