### PR TITLE
fix: fixed dark-mode toast contrast

### DIFF
--- a/nt-fe/components/toaster.tsx
+++ b/nt-fe/components/toaster.tsx
@@ -41,7 +41,9 @@ export function Toaster() {
     );
 
     useEffect(() => {
-        const isDarkMode = document.documentElement.classList.contains("dark");
+        const isDarkMode =
+            theme === "dark" ||
+            document.documentElement.classList.contains("dark");
         setResolvedTheme(isDarkMode ? "dark" : "light");
     }, [theme]);
 
@@ -53,11 +55,11 @@ export function Toaster() {
             toastOptions={{
                 unstyled: false,
                 classNames: {
-                    toast: "bg-white dark:bg-white border border-border shadow-lg",
-                    title: "text-foreground font-medium text-sm",
-                    description: " text-muted-foreground",
-                    success: "bg-white dark:bg-white",
-                    error: "bg-white dark:bg-white",
+                    toast: "bg-card text-card-foreground border border-border shadow-lg",
+                    title: "text-card-foreground font-medium text-sm",
+                    description: "text-muted-foreground",
+                    success: "bg-card text-card-foreground",
+                    error: "bg-card text-card-foreground",
                 },
             }}
             icons={{


### PR DESCRIPTION
#601  #659 

Fixes dark-mode toast contrast by updating the shared Sonner toaster styles to use app theme tokens instead of hard-coded white backgrounds.

- Replaced forced `bg-white dark:bg-white` toast styling with `bg-card text-card-foreground`.
- Updated toast title/description styling to align with theme variables.
- Kept success/error toasts on the same themed surface.