### PR TITLE
fix: normalize NEAR naming and polish network labels/icons

### DIFF
--- a/nt-be/data/tokens.json
+++ b/nt-be/data/tokens.json
@@ -355,7 +355,7 @@
     {
       "unifiedAssetId": "near",
       "symbol": "NEAR",
-      "name": "NEAR Protocol",
+      "name": "NEAR",
       "icon": "https://s2.coinmarketcap.com/static/img/coins/128x128/6535.png",
       "groupedTokens": [
         {

--- a/nt-be/src/handlers/token/metadata.rs
+++ b/nt-be/src/handlers/token/metadata.rs
@@ -96,6 +96,14 @@ impl TokenMetadata {
             chain_icons: get_chain_metadata_by_name("near").map(|m| m.icon),
         }
     }
+
+    /// Forces canonical branding for NEAR and wrap.near, regardless of source metadata.
+    pub fn apply_near_symbol_name_override(&mut self) {
+        if is_near_or_wrap_token_id(&self.token_id) {
+            self.name = "NEAR".to_string();
+            self.symbol = "NEAR".to_string();
+        }
+    }
 }
 
 const CHAINDEFUSER_TOKENS_URL: &str = "https://api-mng-console.chaindefuser.com/api/tokens";
@@ -398,6 +406,13 @@ fn push_unique(values: &mut Vec<String>, value: String) {
     if !value.is_empty() && !values.iter().any(|v| v == &value) {
         values.push(value);
     }
+}
+
+fn is_near_or_wrap_token_id(token_id: &str) -> bool {
+    let raw = token_id.trim();
+    let stripped = raw.strip_prefix("intents.near:").unwrap_or(raw);
+    let normalized = stripped.strip_prefix("nep141:").unwrap_or(stripped);
+    normalized.eq_ignore_ascii_case("near") || normalized.eq_ignore_ascii_case("wrap.near")
 }
 
 #[derive(Clone, Default)]
@@ -756,7 +771,8 @@ pub async fn fetch_tokens_with_fallback(
             }
         }
 
-        if let Some(meta) = metadata {
+        if let Some(mut meta) = metadata {
+            meta.apply_near_symbol_name_override();
             result.insert(token_id, meta);
         } else {
             unresolved_tokens.push(token_id);

--- a/nt-be/tests/test_data/snapshots/csv_export_snapshot.csv
+++ b/nt-be/tests/test_data/snapshots/csv_export_snapshot.csv
@@ -155,10 +155,10 @@ date,time,direction,from_address,to_address,asset_symbol,asset_contract_address,
 2025-06-30,10:27:18 UTC,in,petersalomonsen.near,webassemblymusic-treasury.sputnik-dao.near,NEAR,near,0.1000501008069668,11.300956541897098499999997,2.26,0.22611322782374496,,HMBKbt19gxrXrcxLy2cNZwHJwpVxhENusCxZqkukEdWG
 2025-06-21,19:45:33 UTC,in,petersalomonsen.near,webassemblymusic-treasury.sputnik-dao.near,NEAR,near,0.1000460385893233,11.200906441090131699999997,2.08,0.20809576026579246,,AEFMQijzJkZRMJKnLAEDHLojNio1FCviXgEzf9rT6rXQ
 2025-06-20,19:13:02 UTC,out,webassemblymusic-treasury.sputnik-dao.near,intents.near,NEAR,near,0.0999448362149807,11.100860402500808399999997,2.18,0.21787974294865795,,43HYSS3sKjVH6De42nPgnRSFEFrhEYCQAQUiAyfo9H1a
-2025-06-20,19:13:00 UTC,out,webassemblymusic-treasury.sputnik-dao.near,webassemblymusic-treasury.sputnik-dao.near,wNEAR,nep141:wrap.near,0.2,0.8000,2.18,0.43600000000000005,,7KCRHvnFyYBkazJm55AGaooVFemmfWeEsiHSk4Uk7iF6
+2025-06-20,19:13:00 UTC,out,webassemblymusic-treasury.sputnik-dao.near,webassemblymusic-treasury.sputnik-dao.near,NEAR,nep141:wrap.near,0.2,0.8000,2.18,0.43600000000000005,,7KCRHvnFyYBkazJm55AGaooVFemmfWeEsiHSk4Uk7iF6
 2025-06-20,19:13:00 UTC,in,petersalomonsen.near,webassemblymusic-treasury.sputnik-dao.near,NEAR,near,0.0000750713335008,11.200805238715789099999997,2.18,0.00016365550703174403,,AVxZqcWR2YKbBtk6XWFkDFyFgeJpTGDhrAyJkUC7QK8u
 2025-06-20,19:04:00 UTC,in,petersalomonsen.near,webassemblymusic-treasury.sputnik-dao.near,NEAR,near,0.1000467916460243,11.200730167382288299999998,2.18,0.218102005788333,,8nFVaGGzbZ85jpLgnoUmgcdJckMUF5S6QxQCXgYiZyqo
-2025-06-20,19:01:56 UTC,in,UNKNOWN,webassemblymusic-treasury.sputnik-dao.near,wNEAR,nep141:wrap.near,1,1,2.18,2.18,,
+2025-06-20,19:01:56 UTC,in,UNKNOWN,webassemblymusic-treasury.sputnik-dao.near,NEAR,nep141:wrap.near,1,1,2.18,2.18,,
 2025-06-17,17:00:43 UTC,out,webassemblymusic-treasury.sputnik-dao.near,petersalomonsen.near,NEAR,near,0.0999351924465066,11.100683375736263999999998,0.971232,0.0970602568302055,,GDJsHLbLSoYvGr7joKqxggSQsfacebx6Uxu7J4kTsApw
 2025-06-17,17:00:16 UTC,in,petersalomonsen.near,webassemblymusic-treasury.sputnik-dao.near,NEAR,near,0.1000487056947091,11.200618568182770599999998,0.971232,0.0971705045292837,,DaAaywvwec2iooBZcEMR9EjNo9YfEfiWzRDtBvk1PKm3
 2025-06-16,18:59:00 UTC,out,webassemblymusic-treasury.sputnik-dao.near,intents.near,NEAR,near,0.0999438502470234,11.100569862488061499999998,2.23,0.2228747860508622,,Ehpke68jDFbpRusYWyZbeBEVoGLqeF8jkT7SjSeuCtEE

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -88,7 +88,7 @@ function NetworkRow({
                 src={option.icon}
                 alt={`${option.name} network`}
                 className={cn(
-                    "size-8",
+                    "size-8 rounded-full object-cover",
                     option.networkName.toLowerCase() === NEAR_NETWORK_ID &&
                         "p-1",
                 )}

--- a/nt-fe/components/token-display.tsx
+++ b/nt-fe/components/token-display.tsx
@@ -97,7 +97,7 @@ export const NetworkIconDisplay = ({
                 <img
                     src={iconUrl}
                     alt={`${networkName} network`}
-                    className="size-6"
+                    className="size-6 rounded-full object-cover"
                 />
             ) : (
                 <div className="size-6 rounded-full bg-gradient-cyan-blue flex items-center justify-center text-white text-xs font-bold">

--- a/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
@@ -118,7 +118,6 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
                     chainIcons={destinationNetworkMeta.chainIcons}
                     networkName={destinationNetworkMeta.name}
                     networkNameClassName="font-normal"
-                    expandNearComLabel
                 />
             ),
         },


### PR DESCRIPTION
- Force NEAR and wrap.near metadata to always use `NEAR` for name/symbol in backend. #676 #724
- Show destination network as `near.com` (instead of expanded label) in transfer details #723
- Make payment network icons round in both recipient network select and send-token network displays #711