### PR TITLE
fix: streamline create-treasury onboarding and wallet prompt behavior

### DIFF
--- a/nt-fe/app/(treasury)/app/new/page.tsx
+++ b/nt-fe/app/(treasury)/app/new/page.tsx
@@ -2,20 +2,11 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-    Clock10,
-    Database,
-    Globe,
-    Minus,
-    Plus,
-    Shield,
-    UsersRound,
-    Vote,
-} from "lucide-react";
+import { Clock10, Database, Globe, Shield } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { type ArrayPath, useForm, useFormContext } from "react-hook-form";
+import { useForm, useFormContext } from "react-hook-form";
 import z from "zod";
 import { Alert, AlertDescription } from "@/components/alert";
 import { Button } from "@/components/button";
@@ -23,13 +14,7 @@ import { PageCard } from "@/components/card";
 import { CreationDisabledModal } from "@/components/creation-disabled-modal";
 import { InputBlock } from "@/components/input-block";
 import { LargeInput } from "@/components/large-input";
-import {
-    type Member,
-    MemberInput,
-    buildMemberSchema,
-} from "@/components/member-input";
 import { PageComponentLayout } from "@/components/page-component-layout";
-import { ROLES } from "@/components/role-selector";
 import {
     InlineNextButton,
     type StepProps,
@@ -77,57 +62,35 @@ function buildTreasuryFormSchema(messages: {
     accountMax: string;
     accountChars: string;
     accountTaken: string;
-    rolesRequired: string;
-    duplicateAddress: string;
-    accountId: {
-        minLength: string;
-        maxLength: string;
-        charset: string;
-        doesNotExist: string;
-    };
 }) {
-    return z
-        .object({
-            about: ONBOARDING_ABOUT_SCHEMA,
-            details: z
-                .object({
-                    treasuryName: z
-                        .string()
-                        .min(2, messages.nameMin)
-                        .max(64, messages.nameMax),
-                    accountName: z
-                        .string()
-                        .min(2, messages.accountMin)
-                        .max(64, messages.accountMax)
-                        .regex(/^[a-z0-9-]+$/, messages.accountChars),
-                    paymentThreshold: z.number().min(1).max(100),
-                    governanceThreshold: z.number().min(1).max(100),
-                })
-                .refine(
-                    async (data) => {
-                        if (!data.accountName) return true;
-                        const fullAccountId = `${data.accountName}.sputnik-dao.near`;
-                        const result = await checkHandleUnused(fullAccountId);
-                        return result?.unused === true;
-                    },
-                    {
-                        message: messages.accountTaken,
-                        path: ["accountName"],
-                    },
-                ),
-            isConfidential: z.boolean(),
-            members: buildMemberSchema({
-                rolesRequired: messages.rolesRequired,
-                duplicateAddress: messages.duplicateAddress,
-                accountId: messages.accountId,
-            }),
-        })
-        .refine((data) => {
-            const financialMembers = data.members.filter((m) =>
-                m.roles.includes("financial"),
-            ).length;
-            return data.details.paymentThreshold <= financialMembers;
-        });
+    return z.object({
+        about: ONBOARDING_ABOUT_SCHEMA,
+        details: z
+            .object({
+                treasuryName: z
+                    .string()
+                    .min(2, messages.nameMin)
+                    .max(64, messages.nameMax),
+                accountName: z
+                    .string()
+                    .min(2, messages.accountMin)
+                    .max(64, messages.accountMax)
+                    .regex(/^[a-z0-9-]+$/, messages.accountChars),
+            })
+            .refine(
+                async (data) => {
+                    if (!data.accountName) return true;
+                    const fullAccountId = `${data.accountName}.sputnik-dao.near`;
+                    const result = await checkHandleUnused(fullAccountId);
+                    return result?.unused === true;
+                },
+                {
+                    message: messages.accountTaken,
+                    path: ["accountName"],
+                },
+            ),
+        isConfidential: z.boolean(),
+    });
 }
 
 type TreasuryFormValues = z.infer<ReturnType<typeof buildTreasuryFormSchema>>;
@@ -150,7 +113,7 @@ function createClearErrorsOnChange<T>(
     };
 }
 
-function Step1({ handleNext, handleBack }: StepProps) {
+function TreasuryDetailsStep({ handleNext, handleBack }: StepProps) {
     const tCreate = useTranslations("createTreasury");
     const form = useFormContext<TreasuryFormValues>();
     const [accountNameEdited, setAccountNameEdited] = useState(false);
@@ -265,196 +228,6 @@ function Step1({ handleNext, handleBack }: StepProps) {
     );
 }
 
-function Threshold({
-    title,
-    description,
-    value,
-    onChange,
-    max,
-}: {
-    title: string;
-    description: string;
-    value: number;
-    onChange: (v: number) => void;
-    max: number;
-}) {
-    const tCreate = useTranslations("createTreasury");
-    const canDecrement = value > 1;
-    const canIncrement = value < max;
-
-    return (
-        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-4">
-            <div className="flex flex-col flex-1 min-w-0">
-                <h3 className="font-medium text-sm">{title}</h3>
-                <p className="text-sm text-muted-foreground">{description}</p>
-            </div>
-            <div className="flex items-center gap-4 shrink-0 w-full sm:w-auto justify-start sm:justify-end">
-                <Button
-                    type="button"
-                    variant="secondary"
-                    size="icon-sm"
-                    onClick={() => onChange(value - 1)}
-                    disabled={!canDecrement}
-                    tooltipContent={
-                        canDecrement ? undefined : tCreate("minimumVoteNote")
-                    }
-                >
-                    <Minus className="size-4 text-secondary-foreground" />
-                </Button>
-                <span className="text-sm w-[21px] text-center">
-                    {value}/{max}
-                </span>
-                <Button
-                    type="button"
-                    variant="secondary"
-                    size="icon-sm"
-                    onClick={() => onChange(value + 1)}
-                    disabled={!canIncrement}
-                    tooltipContent={
-                        canIncrement ? undefined : tCreate("votingNote")
-                    }
-                >
-                    <Plus className="size-4 text-secondary-foreground" />
-                </Button>
-            </div>
-        </div>
-    );
-}
-
-function Step2({ handleBack, handleNext }: StepProps) {
-    const tCreate = useTranslations("createTreasury");
-    const form = useFormContext<TreasuryFormValues>();
-    const { accountId } = useNear();
-
-    const handleContinue = async () => {
-        const members = form.getValues("members");
-        const memberFieldsToValidate = members.flatMap((_, index) => {
-            if (index === 0 && !accountId) return [];
-            return [
-                `members.${index}.accountId`,
-                `members.${index}.roles`,
-            ] as const;
-        });
-
-        const isValid =
-            memberFieldsToValidate.length > 0
-                ? await form.trigger(memberFieldsToValidate as any)
-                : true;
-
-        if (!accountId) {
-            form.clearErrors("members.0.accountId");
-        }
-
-        if (isValid && handleNext) {
-            trackEvent("onboarding_step_completed", {
-                step_name: "members",
-                members_count: form.getValues("members").length,
-            });
-            handleNext();
-        }
-    };
-
-    const { members } = form.watch();
-    const financialMembers = members.filter((m: Member) =>
-        m.roles.includes("financial"),
-    ).length;
-    const governanceMembers = members.filter((m: Member) =>
-        m.roles.includes("governance"),
-    ).length;
-
-    useEffect(() => {
-        const currentPayment = form.getValues("details.paymentThreshold");
-        if (currentPayment > financialMembers) {
-            form.setValue(
-                "details.paymentThreshold",
-                Math.max(1, financialMembers),
-            );
-        }
-    }, [financialMembers]);
-
-    useEffect(() => {
-        const currentGovernance = form.getValues("details.governanceThreshold");
-        if (currentGovernance > governanceMembers) {
-            form.setValue(
-                "details.governanceThreshold",
-                Math.max(1, governanceMembers),
-            );
-        }
-    }, [governanceMembers]);
-
-    useEffect(() => {
-        if (!accountId) {
-            form.clearErrors("members.0.accountId");
-        }
-    }, [accountId, form]);
-
-    return (
-        <PageCard>
-            <StepperHeader
-                title={tCreate("addMembers")}
-                handleBack={handleBack}
-            />
-
-            <InfoAlert message={tCreate("addMembersInfo")} />
-
-            <div className="flex flex-col gap-8">
-                <MemberInput
-                    control={form.control}
-                    mode="onboarding"
-                    name={`members` as ArrayPath<TreasuryFormValues>}
-                />
-                <div className="flex flex-col gap-3">
-                    <div className="flex flex-col gap-1">
-                        <h3 className="font-semibold">
-                            {tCreate("votingThreshold")}
-                        </h3>
-                        <p className="text-sm text-muted-foreground">
-                            {tCreate("thresholdDescription")}
-                        </p>
-                    </div>
-
-                    <div className="flex flex-col gap-4">
-                        <FormField
-                            control={form.control}
-                            name="details.paymentThreshold"
-                            render={({ field }) => (
-                                <Threshold
-                                    title={tCreate("financial")}
-                                    description={tCreate(
-                                        "financialDescription",
-                                    )}
-                                    value={field.value}
-                                    onChange={field.onChange}
-                                    max={financialMembers}
-                                />
-                            )}
-                        />
-                        <FormField
-                            control={form.control}
-                            name="details.governanceThreshold"
-                            render={({ field }) => (
-                                <Threshold
-                                    title={tCreate("governance")}
-                                    description={tCreate(
-                                        "governanceDescription",
-                                    )}
-                                    value={field.value}
-                                    onChange={field.onChange}
-                                    max={governanceMembers}
-                                />
-                            )}
-                        />
-                    </div>
-                </div>
-                <InlineNextButton
-                    text={tCreate("continue")}
-                    onClick={handleContinue}
-                />
-            </div>
-        </PageCard>
-    );
-}
-
 export function TreasuryTypePill({
     type,
 }: {
@@ -534,7 +307,7 @@ export function Feature({
     );
 }
 
-function Step3({ handleBack, handleNext }: StepProps) {
+function TreasuryTypeSelectionStep({ handleBack, handleNext }: StepProps) {
     const tCreate = useTranslations("createTreasury");
     const TREASURY_TYPES = useMemo(
         () => [
@@ -670,7 +443,7 @@ function Step3({ handleBack, handleNext }: StepProps) {
     );
 }
 
-function Step4({
+function ReviewTreasuryStep({
     handleBack,
     accountId,
     connectWallet,
@@ -681,39 +454,10 @@ function Step4({
     isConnectingWallet: boolean;
 }) {
     const tCreate = useTranslations("createTreasury");
-    const VISUAL = useMemo(
-        () => [
-            {
-                icon: <UsersRound className="size-5 text-foreground" />,
-                title: tCreate("membersLabel"),
-            },
-            {
-                icon: <Vote className="size-5 text-foreground" />,
-                title: tCreate("financialThreshold"),
-            },
-            {
-                icon: <Vote className="size-5 text-foreground" />,
-                title: tCreate("governanceThreshold"),
-            },
-        ],
-        [tCreate],
-    );
     const form = useFormContext<TreasuryFormValues>();
     const { details } = form.watch();
-    const { members } = form.watch();
     const { isConfidential } = form.watch();
     const [showWalletSelector, setShowWalletSelector] = useState(false);
-
-    const financialMembers = members.filter((m: Member) =>
-        m.roles.includes("financial"),
-    ).length;
-    const governanceMembers = members.filter((m: Member) =>
-        m.roles.includes("governance"),
-    ).length;
-    const financialThreshold = details.paymentThreshold;
-    const governanceThreshold = details.governanceThreshold;
-    const financialThresholdVisual = `${financialThreshold}/${financialMembers}`;
-    const governanceThresholdVisual = `${governanceThreshold}/${governanceMembers}`;
     if (showWalletSelector && !accountId) {
         return (
             <ConnectWalletSelector
@@ -755,27 +499,6 @@ function Step4({
                         />
                     </div>
                 </InputBlock>
-                <div className="grid md:grid-cols-3 grid-cols-1 gap-2">
-                    {[
-                        members.length,
-                        financialThresholdVisual,
-                        governanceThresholdVisual,
-                    ].map((item, index) => (
-                        <InputBlock invalid={false} key={index}>
-                            <div className="flex flex-col px-3.5 py-3 gap-1 items-center justify-center max-md:flex-row max-md:gap-2 max-md:justify-start">
-                                {VISUAL[index].icon}
-                                <div className="flex flex-col items-center gap-0.5 max-md:flex-row max-md:items-baseline max-md:gap-1.5">
-                                    <p className="font-semibold text-xl">
-                                        {item}
-                                    </p>
-                                    <p className="text-xs text-muted-foreground">
-                                        {VISUAL[index].title}
-                                    </p>
-                                </div>
-                            </div>
-                        </InputBlock>
-                    ))}
-                </div>
             </div>
 
             <Alert variant="info">
@@ -790,7 +513,11 @@ function Step4({
             </Alert>
 
             <InlineNextButton
-                text={tCreate("createButton")}
+                text={
+                    accountId
+                        ? tCreate("createButton")
+                        : tCreate("connectWalletCreate")
+                }
                 loading={
                     accountId ? form.formState.isSubmitting : isConnectingWallet
                 }
@@ -812,8 +539,6 @@ export default function NewTreasuryPage() {
     const tValidation = useTranslations("createTreasury.validation");
     const tSteps = useTranslations("createTreasury.steps");
     const tStepTitles = useTranslations("createTreasury.stepTitles");
-    const tMember = useTranslations("memberInput.validation");
-    const tAccountId = useTranslations("accountIdInput");
     const NON_CONFIDENTIAL_STEPS: CreationStep[] = useMemo(
         () => [
             {
@@ -863,7 +588,6 @@ export default function NewTreasuryPage() {
         () => [
             tStepTitles("aboutYou"),
             tStepTitles("details"),
-            tStepTitles("members"),
             tStepTitles("treasuryType"),
             tStepTitles("review"),
         ],
@@ -878,16 +602,8 @@ export default function NewTreasuryPage() {
                 accountMax: tValidation("accountMax"),
                 accountChars: tValidation("accountChars"),
                 accountTaken: tValidation("accountTaken"),
-                rolesRequired: tMember("rolesRequired"),
-                duplicateAddress: tMember("duplicateAddress"),
-                accountId: {
-                    minLength: tAccountId("minLength"),
-                    maxLength: tAccountId("maxLength"),
-                    charset: tAccountId("charset"),
-                    doesNotExist: tAccountId("doesNotExist"),
-                },
             }),
-        [tValidation, tMember, tAccountId],
+        [tValidation],
     );
     const { accountId, connect, isAuthenticating } = useNear();
     const { treasuries } = useTreasury();
@@ -913,25 +629,12 @@ export default function NewTreasuryPage() {
         defaultValues: {
             about: ONBOARDING_ABOUT_DEFAULT_VALUES,
             details: {
-                paymentThreshold: 1,
-                governanceThreshold: 1,
                 treasuryName: "",
                 accountName: "",
             },
             isConfidential: false,
-            members: [
-                {
-                    accountId: "",
-                    roles: ROLES.map((r) => r.id),
-                },
-            ],
         },
     });
-    useEffect(() => {
-        if (accountId) {
-            form.setValue("members.0.accountId", accountId);
-        }
-    }, [accountId]);
 
     const handleStepChange = (nextStep: number) => {
         const previousStep = previousStepRef.current;
@@ -952,25 +655,15 @@ export default function NewTreasuryPage() {
             step_name: "review",
         });
 
-        const governors = data.members
-            .filter((m) => m.roles.includes("governance"))
-            .map((m) => m.accountId);
-        const financiers = data.members
-            .filter((m) => m.roles.includes("financial"))
-            .map((m) => m.accountId);
-        const requestors = data.members
-            .filter((m) => m.roles.includes("requestor"))
-            .map((m) => m.accountId);
-
         const request: CreateTreasuryRequest = {
             name: data.details.treasuryName,
             accountId: `${data.details.accountName}.sputnik-dao.near`,
-            paymentThreshold: data.details.paymentThreshold,
-            governanceThreshold: data.details.governanceThreshold,
-            governors,
+            paymentThreshold: 1,
+            governanceThreshold: 1,
+            governors: [accountId],
             isConfidential: data.isConfidential,
-            financiers,
-            requestors,
+            financiers: [accountId],
+            requestors: [accountId],
         };
 
         const initialSteps = request.isConfidential
@@ -981,6 +674,7 @@ export default function NewTreasuryPage() {
         setProgressError(null);
         setCreatedTreasuryId(null);
         setProgressOpen(true);
+        console.log(request);
 
         try {
             await createTreasuryStream(request, (event) => {
@@ -1045,6 +739,7 @@ export default function NewTreasuryPage() {
                 steps={progressSteps}
                 error={progressError}
                 treasuryId={createdTreasuryId}
+                onClose={() => setProgressOpen(false)}
                 onNavigate={() => {
                     if (createdTreasuryId) {
                         router.push(`/${createdTreasuryId}`);
@@ -1089,11 +784,10 @@ export default function NewTreasuryPage() {
                                               },
                                           },
                                       ]),
-                                { component: Step1 },
-                                { component: Step2 },
-                                { component: Step3 },
+                                { component: TreasuryDetailsStep },
+                                { component: TreasuryTypeSelectionStep },
                                 {
-                                    component: Step4,
+                                    component: ReviewTreasuryStep,
                                     props: {
                                         accountId,
                                         connectWallet: connect,

--- a/nt-fe/components/creation-progress-modal.tsx
+++ b/nt-fe/components/creation-progress-modal.tsx
@@ -23,6 +23,7 @@ interface CreationProgressModalProps {
     error?: string | null;
     treasuryId?: string | null;
     onNavigate: () => void;
+    onClose: () => void;
 }
 
 function StepStatusIcon({ status }: { status: CreationStep["status"] }) {
@@ -58,13 +59,21 @@ export function CreationProgressModal({
     error,
     treasuryId,
     onNavigate,
+    onClose,
 }: CreationProgressModalProps) {
     const t = useTranslations("progressModal");
     const isDone = !!treasuryId;
     const hasError = !!error;
 
     return (
-        <Dialog open={open}>
+        <Dialog
+            open={open}
+            onOpenChange={(nextOpen) => {
+                if (!nextOpen && (hasError || isDone)) {
+                    onClose();
+                }
+            }}
+        >
             <DialogContent className="max-w-md!">
                 <DialogHeader closeButton={hasError || isDone}>
                     <DialogTitle>

--- a/nt-fe/features/onboarding/components/create-treasury-prompt-controller.tsx
+++ b/nt-fe/features/onboarding/components/create-treasury-prompt-controller.tsx
@@ -9,7 +9,20 @@ import { useNear } from "@/stores/near-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
 import { CreateTreasuryPromptModal } from "./create-treasury-prompt-modal";
 
-const MODAL_SUPPRESSED_PATHS = new Set(["/app/new"]);
+function hasDaoLikeSegment(path: string | null | undefined): boolean {
+    if (!path) return false;
+    const normalizedPath = (() => {
+        try {
+            return decodeURIComponent(path);
+        } catch {
+            return path;
+        }
+    })();
+    return normalizedPath
+        .split("/")
+        .filter(Boolean)
+        .some((segment) => segment.includes(".near"));
+}
 
 export function CreateTreasuryPromptController() {
     const router = useRouter();
@@ -20,7 +33,8 @@ export function CreateTreasuryPromptController() {
     const prevIsAuthenticatingRef = useRef(false);
     const lastHandledLoginNonceRef = useRef(0);
     const [loginNonce, setLoginNonce] = useState(0);
-    const { accountId, isInitializing, isAuthenticating } = useNear();
+    const { accountId, isInitializing, isAuthenticating, disconnect } =
+        useNear();
     const createTreasuryPromptOpenRequestId = useOnboardingStore(
         (state) => state.createTreasuryPromptOpenRequestId,
     );
@@ -32,16 +46,16 @@ export function CreateTreasuryPromptController() {
         pathname === "/" ||
         (pathname === "/login" &&
             searchParams.get("context") === "existing_user");
-    const isSuppressedPath = pathname
-        ? MODAL_SUPPRESSED_PATHS.has(pathname)
-        : false;
+    const shouldHideDisconnect =
+        hasDaoLikeSegment(pathname) ||
+        hasDaoLikeSegment(searchParams.get("returnTo"));
     const canOpenPrompt =
         !!accountId &&
         creationAvailable &&
         !isInitializing &&
         !isLoading &&
-        treasuries.length === 0 &&
-        !isSuppressedPath;
+        treasuries.length === 0;
+    const showDisconnectWallet = canOpenPrompt && !shouldHideDisconnect;
 
     useEffect(() => {
         if (!accountId) {
@@ -108,10 +122,15 @@ export function CreateTreasuryPromptController() {
         <CreateTreasuryPromptModal
             open={open}
             source={source}
+            showDisconnectWallet={showDisconnectWallet}
             onOpenChange={handleOpenChange}
             onCreateTreasury={() => {
                 handleOpenChange(false);
                 router.push("/app/new");
+            }}
+            onDisconnectWallet={async () => {
+                await disconnect();
+                handleOpenChange(false);
             }}
         />
     );

--- a/nt-fe/features/onboarding/components/create-treasury-prompt-modal.tsx
+++ b/nt-fe/features/onboarding/components/create-treasury-prompt-modal.tsx
@@ -79,7 +79,7 @@ export function CreateTreasuryPromptModal({
                                 await onDisconnectWallet?.();
                             }}
                         >
-                            {tSignIn("disconnect")} {tSignIn("wallet")}
+                            {tSignIn("disconnectWallet")}
                         </Button>
                     )}
                     {isOnboardingPath ? (

--- a/nt-fe/features/onboarding/components/create-treasury-prompt-modal.tsx
+++ b/nt-fe/features/onboarding/components/create-treasury-prompt-modal.tsx
@@ -16,17 +16,22 @@ import { trackEvent } from "@/lib/analytics";
 interface CreateTreasuryPromptModalProps {
     open: boolean;
     source: "onboarding" | "app";
+    showDisconnectWallet?: boolean;
     onOpenChange: (open: boolean) => void;
     onCreateTreasury: () => void;
+    onDisconnectWallet?: () => Promise<void> | void;
 }
 
 export function CreateTreasuryPromptModal({
     open,
     source,
+    showDisconnectWallet = false,
     onOpenChange,
     onCreateTreasury,
+    onDisconnectWallet,
 }: CreateTreasuryPromptModalProps) {
     const t = useTranslations("onboarding.createPrompt");
+    const tSignIn = useTranslations("signIn");
     const isOnboardingPath = source === "onboarding";
     const descriptionSuffix = isOnboardingPath
         ? t("suffixDemo")
@@ -65,6 +70,18 @@ export function CreateTreasuryPromptModal({
                     >
                         {t("createCta")}
                     </Button>
+                    {showDisconnectWallet && (
+                        <Button
+                            variant="secondary"
+                            className="w-full"
+                            onClick={async () => {
+                                trackClick("disconnect_wallet");
+                                await onDisconnectWallet?.();
+                            }}
+                        >
+                            {tSignIn("disconnect")} {tSignIn("wallet")}
+                        </Button>
+                    )}
                     {isOnboardingPath ? (
                         <Button
                             variant="secondary"

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "sehen Sie sich die Demo an.",
             "suffixExploring": "erkunden Sie weiter.",
             "createCta": "Treasury erstellen",
-            "viewDemo": "Demo ansehen",
+            "viewDemo": "Trezu-Demo erkunden",
             "keepExploring": "Weiter erkunden"
         },
         "infoBox": {

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -77,7 +77,8 @@
         "wallet": "Wallet",
         "termsOfService": "Nutzungsbedingungen",
         "privacyPolicy": "Datenschutzerklärung",
-        "disconnect": "Trennen"
+        "disconnect": "Trennen",
+        "disconnectWallet": "Trennen Wallet"
     },
     "auth": {
         "noWallet": "Verbinden Sie Ihre Wallet",

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -77,7 +77,8 @@
         "wallet": "Wallet",
         "termsOfService": "Terms of Service",
         "privacyPolicy": "Privacy Policy",
-        "disconnect": "Disconnect"
+        "disconnect": "Disconnect",
+        "disconnectWallet": "Disconnect Wallet"
     },
     "auth": {
         "noWallet": "Connect your wallet",

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "check out the demo.",
             "suffixExploring": "keep exploring.",
             "createCta": "Create a Treasury",
-            "viewDemo": "View Demo",
+            "viewDemo": "Explore the Trezu Demo.",
             "keepExploring": "Keep Exploring"
         },
         "infoBox": {

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "mira la demo.",
             "suffixExploring": "sigue explorando.",
             "createCta": "Crear una tesorería",
-            "viewDemo": "Ver demo",
+            "viewDemo": "Explora la demo de Trezu",
             "keepExploring": "Seguir explorando"
         },
         "infoBox": {

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -77,7 +77,8 @@
         "wallet": "Cartera",
         "termsOfService": "Términos del servicio",
         "privacyPolicy": "Política de privacidad",
-        "disconnect": "Desconectar"
+        "disconnect": "Desconectar",
+        "disconnectWallet": "Desconectar Cartera"
     },
     "auth": {
         "noWallet": "Conecta tu cartera",

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "consultez la démo.",
             "suffixExploring": "continuez à explorer.",
             "createCta": "Créer une trésorerie",
-            "viewDemo": "Voir la démo",
+            "viewDemo": "Explorer la démo Trezu",
             "keepExploring": "Continuer à explorer"
         },
         "infoBox": {

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -77,7 +77,8 @@
         "wallet": "Portefeuille",
         "termsOfService": "Conditions d'utilisation",
         "privacyPolicy": "Politique de confidentialité",
-        "disconnect": "Déconnecter"
+        "disconnect": "Déconnecter",
+        "disconnectWallet": "Déconnecter Portefeuille"
     },
     "auth": {
         "noWallet": "Connectez votre portefeuille",

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -77,7 +77,8 @@
         "wallet": "ארנק",
         "termsOfService": "תנאי שימוש",
         "privacyPolicy": "מדיניות פרטיות",
-        "disconnect": "התנתקות"
+        "disconnect": "התנתקות",
+        "disconnectWallet": "התנתקות ארנק"
     },
     "auth": {
         "noWallet": "חבר את הארנק שלך",

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "בדוק את הדמו.",
             "suffixExploring": "המשך לחקור.",
             "createCta": "צור אוצר",
-            "viewDemo": "הצג דמו",
+            "viewDemo": "גלה את דמו Trezu",
             "keepExploring": "המשך לחקור"
         },
         "infoBox": {

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -77,7 +77,8 @@
         "wallet": "Dompet",
         "termsOfService": "Ketentuan Layanan",
         "privacyPolicy": "Kebijakan Privasi",
-        "disconnect": "Putuskan"
+        "disconnect": "Putuskan",
+        "disconnectWallet": "Putuskan Dompet"
     },
     "auth": {
         "noWallet": "Hubungkan dompet Anda",

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "lihat demo.",
             "suffixExploring": "terus menjelajah.",
             "createCta": "Buat Treasury",
-            "viewDemo": "Lihat Demo",
+            "viewDemo": "Jelajahi Demo Trezu",
             "keepExploring": "Terus Menjelajah"
         },
         "infoBox": {

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -77,7 +77,8 @@
         "wallet": "ウォレット",
         "termsOfService": "利用規約",
         "privacyPolicy": "プライバシーポリシー",
-        "disconnect": "切断"
+        "disconnect": "切断",
+        "disconnectWallet": "切断 ウォレット"
     },
     "auth": {
         "noWallet": "ウォレットを接続してください",

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "デモをチェックしてください。",
             "suffixExploring": "引き続き探索してください。",
             "createCta": "トレジャリーを作成",
-            "viewDemo": "デモを見る",
+            "viewDemo": "Trezuデモを探索",
             "keepExploring": "引き続き探索"
         },
         "infoBox": {

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -77,7 +77,8 @@
         "wallet": "지갑",
         "termsOfService": "이용약관",
         "privacyPolicy": "개인정보 처리방침",
-        "disconnect": "연결 해제"
+        "disconnect": "연결 해제",
+        "disconnectWallet": "연결 해제 지갑"
     },
     "auth": {
         "noWallet": "지갑을 연결하세요",

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "데모를 확인하세요.",
             "suffixExploring": "계속 살펴보세요.",
             "createCta": "트레저리 생성",
-            "viewDemo": "데모 보기",
+            "viewDemo": "Trezu 데모 살펴보기",
             "keepExploring": "계속 살펴보기"
         },
         "infoBox": {

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -77,7 +77,8 @@
         "wallet": "Carteira",
         "termsOfService": "Termos de Serviço",
         "privacyPolicy": "Política de Privacidade",
-        "disconnect": "Desconectar"
+        "disconnect": "Desconectar",
+        "disconnectWallet": "Desconectar Carteira"
     },
     "auth": {
         "noWallet": "Conecte sua carteira",

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "veja a demonstração.",
             "suffixExploring": "continue explorando.",
             "createCta": "Criar uma tesouraria",
-            "viewDemo": "Ver demonstração",
+            "viewDemo": "Explore a demonstração da Trezu",
             "keepExploring": "Continuar explorando"
         },
         "infoBox": {

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "demoyu inceleyin.",
             "suffixExploring": "keşfetmeye devam edin.",
             "createCta": "Hazine Oluştur",
-            "viewDemo": "Demoyu Görüntüle",
+            "viewDemo": "Trezu Demosunu Keşfet",
             "keepExploring": "Keşfetmeye Devam Et"
         },
         "infoBox": {

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -77,7 +77,8 @@
         "wallet": "Cüzdan",
         "termsOfService": "Hizmet Şartları",
         "privacyPolicy": "Gizlilik Politikası",
-        "disconnect": "Bağlantıyı Kes"
+        "disconnect": "Bağlantıyı Kes",
+        "disconnectWallet": "Bağlantıyı Kes Cüzdan"
     },
     "auth": {
         "noWallet": "Cüzdanınızı bağlayın",

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "погляньте на демо.",
             "suffixExploring": "продовжуйте досліджувати.",
             "createCta": "Створити скарбницю",
-            "viewDemo": "Переглянути демо",
+            "viewDemo": "Спробувати демо Trezu",
             "keepExploring": "Продовжити досліджувати"
         },
         "infoBox": {

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -77,7 +77,8 @@
         "wallet": "Гаманець",
         "termsOfService": "Умови використання",
         "privacyPolicy": "Політика конфіденційності",
-        "disconnect": "Відключити"
+        "disconnect": "Відключити",
+        "disconnectWallet": "Відключити Гаманець"
     },
     "auth": {
         "noWallet": "Підключіть свій гаманець",

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -77,7 +77,8 @@
         "wallet": "Ví",
         "termsOfService": "Điều khoản dịch vụ",
         "privacyPolicy": "Chính sách bảo mật",
-        "disconnect": "Ngắt kết nối"
+        "disconnect": "Ngắt kết nối",
+        "disconnectWallet": "Ngắt kết nối Ví"
     },
     "auth": {
         "noWallet": "Kết nối ví của bạn",

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "xem demo.",
             "suffixExploring": "tiếp tục khám phá.",
             "createCta": "Tạo một Ngân quỹ",
-            "viewDemo": "Xem Demo",
+            "viewDemo": "Khám phá Trezu Demo",
             "keepExploring": "Tiếp tục khám phá"
         },
         "infoBox": {

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -2117,7 +2117,7 @@
             "suffixDemo": "查看演示。",
             "suffixExploring": "继续探索。",
             "createCta": "创建金库",
-            "viewDemo": "查看演示",
+            "viewDemo": "探索 Trezu 演示",
             "keepExploring": "继续探索"
         },
         "infoBox": {

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -77,7 +77,8 @@
         "wallet": "钱包",
         "termsOfService": "服务条款",
         "privacyPolicy": "隐私政策",
-        "disconnect": "断开连接"
+        "disconnect": "断开连接",
+        "disconnectWallet": "断开连接 钱包"
     },
     "auth": {
         "noWallet": "请连接您的钱包",

--- a/nt-fe/stores/near-store.ts
+++ b/nt-fe/stores/near-store.ts
@@ -92,10 +92,12 @@ interface Vote {
 
 const LOGIN_MESSAGE = "Login to Trezu";
 const LOGIN_RECIPIENT = "Trezu App";
+const LEDGER_WALLET_ID = "ledger";
 
 interface NearStore {
     // Wallet state
     connector: NearConnector | null;
+    connectorExcludeLedger: boolean | null;
     walletAccountId: string | null; // Raw wallet account ID
     isInitializing: boolean;
 
@@ -108,7 +110,9 @@ interface NearStore {
     user: AuthUserInfo | null;
 
     // Wallet actions
-    init: () => Promise<NearConnector | undefined>;
+    init: (options?: {
+        excludeLedger?: boolean;
+    }) => Promise<NearConnector | undefined>;
     connect: (walletId?: string) => Promise<void>;
     disconnect: () => Promise<void>;
 
@@ -143,6 +147,7 @@ const isFullyAuthenticated = (state: NearStore): boolean => {
 export const useNearStore = create<NearStore>((set, get) => ({
     // Wallet state
     connector: null,
+    connectorExcludeLedger: null,
     walletAccountId: null,
     isInitializing: true,
 
@@ -154,12 +159,18 @@ export const useNearStore = create<NearStore>((set, get) => ({
     authError: null,
     user: null,
 
-    init: async () => {
-        const { connector } = get();
+    init: async (options) => {
+        const { connector, connectorExcludeLedger } = get();
+        const requestedExcludeLedger = options?.excludeLedger;
 
-        if (connector) {
+        if (
+            connector &&
+            (requestedExcludeLedger === undefined ||
+                connectorExcludeLedger === requestedExcludeLedger)
+        ) {
             return connector;
         }
+        const shouldExcludeLedger = requestedExcludeLedger ?? true;
 
         let newConnector = null;
 
@@ -178,6 +189,7 @@ export const useNearStore = create<NearStore>((set, get) => ({
                     signDelegateActions: true,
                     signInAndSignMessage: true,
                 },
+                excludedWallets: shouldExcludeLedger ? [LEDGER_WALLET_ID] : [],
             });
         } catch (err) {
             set({ isInitializing: false });
@@ -287,14 +299,20 @@ export const useNearStore = create<NearStore>((set, get) => ({
             },
         );
 
-        set({ connector: newConnector });
+        set({
+            connector: newConnector,
+            connectorExcludeLedger: shouldExcludeLedger,
+        });
         set({ isInitializing: false });
         return newConnector;
     },
 
     connect: async (walletId?: string) => {
-        const { connector, init } = get();
-        const newConnector = connector ?? (await init());
+        const { init } = get();
+        const shouldExcludeLedger = walletId !== LEDGER_WALLET_ID;
+        const newConnector = await init({
+            excludeLedger: shouldExcludeLedger,
+        });
         if (!newConnector) {
             throw new Error("Failed to initialize connector");
         }


### PR DESCRIPTION
#722 
- Removed the **Members Configuration** step from `/app/new` treasury creation flow.
- Updated create button text to be state-aware `Connect Wallet` before connect, `Create Treasury` after connect
- Fixed Creation Progress Modal close button so it actually closes in done/error states.
- Updated “You’re almost set” prompt logic for no-treasury users:
  - supports optional **Disconnect Wallet** action,
- Updated wallet connector init logic to support:
  - hiding Ledger in default NearConnect selector flow,
  - still allowing explicit Ledger connect when selected directly.
- Updated `viewDemo` wording to new “Explore Trezu Demo” phrasing.