### PR TITLE
fix: missing assets in export

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -29,6 +29,7 @@ import { useTreasury } from "@/hooks/use-treasury";
 import { useBalanceChart } from "@/hooks/use-treasury-queries";
 import type { ChartInterval, TreasuryAsset } from "@/lib/api";
 import { availableBalance, totalBalance } from "@/lib/balance";
+import { getBalanceHistoryTokenIds } from "@/lib/balance-history-token-ids";
 import Big from "@/lib/big";
 import {
     getDashboardBalanceView,
@@ -152,26 +153,7 @@ export default function BalanceWithGraph({
 
         for (const token of tokens) {
             const existing = grouped.get(token.symbol);
-
-            // Convert token ID to balance-history format
-            // Intents tokens need "intents.near:" prefix for balance-history API
-            // Staked tokens need "staking:" prefix with pool IDs
-            let tokenIdsForHistory: string[] = [];
-            if (
-                token.residency === "Intents" &&
-                !token.id.startsWith("intents.near:")
-            ) {
-                tokenIdsForHistory = [`intents.near:${token.contractId}`];
-            } else if (
-                token.residency === "Staked" &&
-                "staking" in token.balance
-            ) {
-                tokenIdsForHistory = token.balance.staking.pools.map(
-                    (p) => `staking:${p.poolId}`,
-                );
-            } else {
-                tokenIdsForHistory = [token.contractId ?? token.id];
-            }
+            const tokenIdsForHistory = getBalanceHistoryTokenIds(token);
 
             if (existing) {
                 existing.tokens.push(token);

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx
@@ -65,6 +65,7 @@ import { Download, Loader2 } from "lucide-react";
 import { User } from "@/components/user";
 import { FormattedDate } from "@/components/formatted-date";
 import { CreditsQuotaDisplay } from "@/components/credits-quota-display";
+import { getBalanceHistoryTokenIds } from "@/lib/balance-history-token-ids";
 import {
     useReactTable,
     getCoreRowModel,
@@ -481,17 +482,23 @@ export default function ExportActivityPage() {
             // Add tokenIds if specific assets are selected (excluding "all")
             const specificAssets = selectedAssets.filter((a) => a !== "all");
             if (specificAssets.length > 0) {
-                const tokenIds: string[] = [];
+                const tokenIds = new Set<string>();
                 specificAssets.forEach((assetId) => {
                     const token = aggregatedTokens.find(
-                        (t: any) => t.id === assetId,
+                        (t) => t.id === assetId,
                     );
                     if (token) {
-                        token.networks.forEach((n: any) => tokenIds.push(n.id));
+                        token.networks.forEach((network) => {
+                            for (const tokenId of getBalanceHistoryTokenIds(
+                                network,
+                            )) {
+                                tokenIds.add(tokenId);
+                            }
+                        });
                     }
                 });
-                if (tokenIds.length > 0) {
-                    params.append("tokenIds", tokenIds.join(","));
+                if (tokenIds.size > 0) {
+                    params.append("tokenIds", Array.from(tokenIds).join(","));
                 }
             }
 
@@ -607,9 +614,7 @@ export default function ExportActivityPage() {
         const selectedLabels = selectedAssets
             .filter((assetId) => assetId !== "all")
             .map((assetId) => {
-                const token = aggregatedTokens.find(
-                    (t: any) => t.id === assetId,
-                );
+                const token = aggregatedTokens.find((t) => t.id === assetId);
                 return token?.name || token?.id || assetId;
             });
         if (selectedLabels.length === 1) return selectedLabels[0];

--- a/nt-fe/lib/balance-history-token-ids.ts
+++ b/nt-fe/lib/balance-history-token-ids.ts
@@ -1,0 +1,24 @@
+import type { TreasuryAsset } from "@/lib/api";
+
+const INTENTS_TOKEN_PREFIX = "intents.near:";
+
+export function getBalanceHistoryTokenIds(token: TreasuryAsset): string[] {
+    if (token.residency === "Intents") {
+        const tokenId = token.contractId ?? token.id;
+        if (!tokenId) return [];
+
+        return [
+            tokenId.startsWith(INTENTS_TOKEN_PREFIX)
+                ? tokenId
+                : `${INTENTS_TOKEN_PREFIX}${tokenId}`,
+        ];
+    }
+
+    if (token.residency === "Staked" && token.balance.type === "Staked") {
+        return token.balance.staking.pools.map(
+            (pool) => `staking:${pool.poolId}`,
+        );
+    }
+
+    return [token.contractId ?? token.id].filter(Boolean);
+}


### PR DESCRIPTION
#654 

The fix updates the export asset filter to send the token IDs expected by the balance-history export API.

