### PR TITLE
fix: parse single 3-digit comma group as thousands in bulk payment amounts (#758)

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.test.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { parseAmount } from "./parsing";
+
+const labels = {
+    pleaseRemoveChars: (chars: string) => `Please remove: ${chars}`,
+    amountCannotBeEmpty: "Amount cannot be empty",
+};
+
+describe("parseAmount thousand separators", () => {
+    it("parses a single 3-digit comma group as thousands, not decimal", () => {
+        // Regression for #758: "1,000" must become 1000, not 1.0
+        expect(parseAmount("1,000", labels).amount).toBe("1000");
+        expect(parseAmount("2,500", labels).amount).toBe("2500");
+    });
+
+    it("keeps multi-group thousands separators working", () => {
+        expect(parseAmount("1,000,000", labels).amount).toBe("1000000");
+    });
+
+    it("still treats a non-3-digit comma group as a decimal", () => {
+        expect(parseAmount("10,5", labels).amount).toBe("10.5");
+        expect(parseAmount("10,50", labels).amount).toBe("10.50");
+        expect(parseAmount("1,2345", labels).amount).toBe("1.2345");
+    });
+
+    it("treats a 3-digit group after a leading zero as a decimal", () => {
+        // "0,500" is only meaningful as 0.5, never as 500
+        expect(parseAmount("0,500", labels).amount).toBe("0.500");
+    });
+
+    it("still handles mixed comma+dot formats", () => {
+        expect(parseAmount("1,000.50", labels).amount).toBe("1000.50");
+        expect(parseAmount("1.000,50", labels).amount).toBe("1000.50");
+    });
+});

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.ts
@@ -256,9 +256,7 @@ export function parseAmount(
         // length (1, 2 or 4+ digits) is a decimal separator: "10,5",
         // "10,50", "1,2345".
         const isThousandsGroup =
-            parts.length === 2 &&
-            parts[1].length === 3 &&
-            parts[0] !== "0";
+            parts.length === 2 && parts[1].length === 3 && parts[0] !== "0";
         if (parts.length === 2 && !isThousandsGroup) {
             // Decimal separator: "10,5" or "10,50"
             normalized = normalized.replace(",", ".");

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.ts
@@ -247,13 +247,23 @@ export function parseAmount(
             normalized = normalized.replace(/\./g, "").replace(",", ".");
         }
     } else if (hasComma) {
-        // Only comma: check if it's decimal or thousands separator
+        // Only comma: check if it's a decimal or a thousands separator.
         const parts = normalized.split(",");
-        if (parts.length === 2 && parts[1].length <= 8) {
-            // Likely decimal separator: "10,5" or "10,50"
+        // A single comma group of exactly 3 digits is the canonical
+        // thousands grouping ("1,000" -> 1000), so it must not be treated
+        // as a decimal, unless the integer part is "0" ("0,500" -> 0.5),
+        // which is only meaningful as a decimal. Any other single group
+        // length (1, 2 or 4+ digits) is a decimal separator: "10,5",
+        // "10,50", "1,2345".
+        const isThousandsGroup =
+            parts.length === 2 &&
+            parts[1].length === 3 &&
+            parts[0] !== "0";
+        if (parts.length === 2 && !isThousandsGroup) {
+            // Decimal separator: "10,5" or "10,50"
             normalized = normalized.replace(",", ".");
         } else {
-            // Likely thousands separator: "1,000" or "1,000,000"
+            // Thousands separator: "1,000" or "1,000,000"
             normalized = normalized.replace(/,/g, "");
         }
     }


### PR DESCRIPTION
## Summary

- The Bulk Payment amount parser treated any single comma group of up to 8 digits as a decimal separator, so `1,000` was normalized to `1.000` (1.0) and `2,500` to `2.500` (2.5).
- This silently reduced payment amounts by ~1000x with no validation error. Mixed formats like `1,000.50` parsed correctly, making the bug appear intermittent.

## Changes

- `nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.ts`: In `parseAmount`, a single comma group of exactly 3 digits is now treated as a thousands separator (`1,000` -> 1000), except when the integer part is `0` (`0,500` -> 0.5, only meaningful as a decimal). Groups of 1, 2, or 4+ digits remain decimal separators, and the comma+dot and multi-group paths are unchanged.
- `nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.test.ts`: Added bun:test coverage for the `1,000` / `2,500` regression, multi-group thousands, non-3-digit decimals, the leading-zero decimal case, and mixed comma+dot formats.

Fixes #758