### PR TITLE
fix: use destination network decimals for EXACT_OUTPUT quote amounts

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -486,8 +486,12 @@ function getDestinationAmountDecimalsForExactOutput(
     destinationNetwork: string | undefined,
     amountMode: IntentsAmountMode,
     bridgeAssets: BridgeAsset[],
-): number {
-    if (amountMode !== "recipient" || isNearComNetwork(destinationNetwork)) {
+): number | undefined {
+    if (
+        amountMode !== "recipient" ||
+        !destinationNetwork ||
+        isNearComNetwork(destinationNetwork)
+    ) {
         return token.decimals;
     }
 
@@ -496,7 +500,7 @@ function getDestinationAmountDecimalsForExactOutput(
         (network) => network.id === destinationNetwork,
     );
 
-    return destination?.decimals ?? token.decimals;
+    return destination?.decimals;
 }
 
 function classifyPaymentToken(
@@ -971,17 +975,18 @@ export default function PaymentsPage() {
             const directTransferAmount = Big(data.amount)
                 .mul(Big(10).pow(data.token.decimals))
                 .toFixed();
+            const quoteAmountDecimals =
+                getDestinationAmountDecimalsForExactOutput(
+                    tokenClassification.tokenForIntentsQuote,
+                    data.destinationNetwork,
+                    intentsAmountMode,
+                    bridgeAssets,
+                );
+            if (quoteAmountDecimals === undefined) {
+                throw new Error(tPay("failed1ClickQuote"));
+            }
             const quoteAmount = Big(data.amount)
-                .mul(
-                    Big(10).pow(
-                        getDestinationAmountDecimalsForExactOutput(
-                            tokenClassification.tokenForIntentsQuote,
-                            data.destinationNetwork,
-                            intentsAmountMode,
-                            bridgeAssets,
-                        ),
-                    ),
-                )
+                .mul(Big(10).pow(quoteAmountDecimals))
                 .toFixed();
 
             let description = encodeToMarkdown({ notes: data.memo || "" });

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -477,6 +477,28 @@ type PaymentTokenClassification = {
     tokenForIntentsQuote: Token;
 };
 
+// 1Click expects `amount` in destination-asset base units for EXACT_OUTPUT.
+// Some routes have mixed token decimals across networks (e.g. 18 vs 24), so
+// we resolve decimals from the selected destination network to avoid
+// under/over-scaling the quote request amount.
+function getDestinationAmountDecimalsForExactOutput(
+    token: Token,
+    destinationNetwork: string | undefined,
+    amountMode: IntentsAmountMode,
+    bridgeAssets: BridgeAsset[],
+): number {
+    if (amountMode !== "recipient" || isNearComNetwork(destinationNetwork)) {
+        return token.decimals;
+    }
+
+    const bridgeAsset = findBridgeAssetForToken(bridgeAssets, token);
+    const destination = bridgeAsset?.networks.find(
+        (network) => network.id === destinationNetwork,
+    );
+
+    return destination?.decimals ?? token.decimals;
+}
+
 function classifyPaymentToken(
     token: Token,
     destinationNetwork?: string,
@@ -750,6 +772,16 @@ export default function PaymentsPage() {
     const isViaIntents = isIntentsToken(quoteToken);
 
     const isCrossChainIntentsToken = isIntentsCrossChainToken(watchedToken);
+    const destinationAmountDecimals = useMemo(
+        () =>
+            getDestinationAmountDecimalsForExactOutput(
+                quoteToken,
+                watchedDestinationNetwork,
+                intentsAmountMode,
+                bridgeAssets,
+            ),
+        [bridgeAssets, intentsAmountMode, quoteToken, watchedDestinationNetwork],
+    );
 
     // ── Live quote (drives step-1 fee preview & step-2 review) ───────────────
 
@@ -767,6 +799,7 @@ export default function PaymentsPage() {
         treasuryId,
         token: quoteToken,
         amount: watchedAmount,
+        destinationAmountDecimals,
         address: watchedAddress,
         isConfidential,
         proposalPeriod: policy?.proposal_period,
@@ -930,8 +963,20 @@ export default function PaymentsPage() {
                 ? isIntentsToken(data.token)
                 : !shouldUseDirectTransfer;
 
-            const parsedAmount = Big(data.amount)
+            const directTransferAmount = Big(data.amount)
                 .mul(Big(10).pow(data.token.decimals))
+                .toFixed();
+            const quoteAmount = Big(data.amount)
+                .mul(
+                    Big(10).pow(
+                        getDestinationAmountDecimalsForExactOutput(
+                            tokenClassification.tokenForIntentsQuote,
+                            data.destinationNetwork,
+                            intentsAmountMode,
+                            bridgeAssets,
+                        ),
+                    ),
+                )
                 .toFixed();
 
             let description = encodeToMarkdown({ notes: data.memo || "" });
@@ -952,7 +997,7 @@ export default function PaymentsPage() {
                             treasuryId!,
                             tokenForQuote,
                             trimmedAddress,
-                            parsedAmount,
+                            quoteAmount,
                             isConfidential,
                             policy?.proposal_period,
                             intentsAmountMode,
@@ -1022,7 +1067,7 @@ export default function PaymentsPage() {
                 proposalKind = buildDirectTransferKind(
                     trimmedAddress,
                     data.token,
-                    parsedAmount,
+                    directTransferAmount,
                     isConfidential,
                 );
 

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -780,7 +780,12 @@ export default function PaymentsPage() {
                 intentsAmountMode,
                 bridgeAssets,
             ),
-        [bridgeAssets, intentsAmountMode, quoteToken, watchedDestinationNetwork],
+        [
+            bridgeAssets,
+            intentsAmountMode,
+            quoteToken,
+            watchedDestinationNetwork,
+        ],
     );
 
     // ── Live quote (drives step-1 fee preview & step-2 review) ───────────────

--- a/nt-fe/hooks/use-intents-quote.ts
+++ b/nt-fe/hooks/use-intents-quote.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useDebounce } from "use-debounce";
 import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
+import * as Sentry from "@sentry/nextjs";
 import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 import { getAddressPattern } from "@/lib/address-validation";
 import Big from "@/lib/big";
@@ -177,17 +178,36 @@ export function useIntentsQuote({
     const [debouncedAddress] = useDebounce(address, 300);
     const [debouncedAmount] = useDebounce(amount, 400);
     const [isEnsuring, setIsEnsuring] = useState(false);
-    const effectiveAmountDecimals = destinationAmountDecimals ?? token.decimals;
+    const requiresDestinationAmountDecimals =
+        amountMode === "recipient" &&
+        !!destinationNetwork &&
+        !isNearComNetwork(destinationNetwork);
+    const requestAmountDecimals = requiresDestinationAmountDecimals
+        ? destinationAmountDecimals
+        : token.decimals;
 
     const isRecipientReady =
         !!debouncedAddress && isAddressValidForToken(debouncedAddress, token);
-
-    const parsedAmount = useMemo(() => {
-        if (!debouncedAmount || Number(debouncedAmount) <= 0) return null;
-        return Big(debouncedAmount)
-            .mul(Big(10).pow(effectiveAmountDecimals))
-            .toFixed();
-    }, [debouncedAmount, effectiveAmountDecimals]);
+    const isQuoteReady =
+        isIntents &&
+        !!treasuryId &&
+        isRecipientReady &&
+        !!debouncedAmount &&
+        Number(debouncedAmount) > 0 &&
+        !!proposalPeriod &&
+        !feeErrorMessage;
+    const missingRequiredDecimalsForQuote =
+        isQuoteReady && requestAmountDecimals === undefined;
+    const captureMissingDestinationDecimals = useCallback(
+        (tokenAddress: string) => {
+            Sentry.captureException(
+                new Error(
+                    `Blocked EXACT_OUTPUT quote: missing destination decimals (token=${tokenAddress}, destination=${destinationNetwork ?? "unknown"})`,
+                ),
+            );
+        },
+        [destinationNetwork],
+    );
 
     const {
         data: quote,
@@ -207,7 +227,14 @@ export function useIntentsQuote({
             isPayment,
         ],
         queryFn: async (): Promise<IntentsQuoteResponse | null> => {
-            if (!treasuryId || !parsedAmount) return null;
+            if (!isQuoteReady) return null;
+            if (requestAmountDecimals === undefined) {
+                captureMissingDestinationDecimals(token.address);
+                throw new Error(t("fetchFailed"));
+            }
+            const parsedAmount = Big(debouncedAmount)
+                .mul(Big(10).pow(requestAmountDecimals))
+                .toFixed();
             return getIntentsQuote(
                 buildIntentsQuoteRequest(
                     treasuryId,
@@ -223,13 +250,7 @@ export function useIntentsQuote({
                 false,
             );
         },
-        enabled:
-            isIntents &&
-            !!treasuryId &&
-            isRecipientReady &&
-            !!parsedAmount &&
-            !!proposalPeriod &&
-            !feeErrorMessage,
+        enabled: isQuoteReady,
         refetchOnWindowFocus: false,
         retry: false,
     });
@@ -245,8 +266,12 @@ export function useIntentsQuote({
         if (!amountInRaw || !amountOutRaw) return null;
 
         try {
-            const amountIn = Big(amountInRaw);
-            const amountOut = Big(amountOutRaw);
+            if (requestAmountDecimals === undefined) return null;
+
+            const amountIn = Big(amountInRaw).div(Big(10).pow(token.decimals));
+            const amountOut = Big(amountOutRaw).div(
+                Big(10).pow(requestAmountDecimals),
+            );
 
             if (amountOut.lte(0)) return null;
 
@@ -258,11 +283,9 @@ export function useIntentsQuote({
                 return null;
             }
 
-            const feeAmount = formatBalance(
-                amountIn.minus(amountOut).toFixed(0),
-                token.decimals,
-                token.decimals,
-            );
+            const feeAmount = fee
+                .toFixed(requestAmountDecimals)
+                .replace(/\.?0+$/, "");
 
             return {
                 feeAmount,
@@ -270,11 +293,12 @@ export function useIntentsQuote({
         } catch {
             return null;
         }
-    }, [amountMode, quote, token.decimals]);
+    }, [amountMode, quote, token.decimals, requestAmountDecimals]);
 
     const hasLowAmountQuote = !!lowAmountQuoteDetails;
 
-    const hasError = hasQueryError || hasLowAmountQuote;
+    const hasError =
+        hasQueryError || hasLowAmountQuote || missingRequiredDecimalsForQuote;
 
     const errorMessage = useMemo(() => {
         if (hasLowAmountQuote) {
@@ -287,6 +311,10 @@ export function useIntentsQuote({
             return t("amountTooLow");
         }
 
+        if (missingRequiredDecimalsForQuote) {
+            return t("fetchFailed");
+        }
+
         if (!hasQueryError || !error) return null;
         const msg =
             error instanceof Error
@@ -294,16 +322,17 @@ export function useIntentsQuote({
                 : "Failed to prepare 1Click transfer route";
         return formatErrorMessage(
             msg,
-            effectiveAmountDecimals,
+            requestAmountDecimals as number,
             token.symbol,
             t,
         );
     }, [
         hasLowAmountQuote,
         lowAmountQuoteDetails,
+        missingRequiredDecimalsForQuote,
         hasQueryError,
         error,
-        effectiveAmountDecimals,
+        requestAmountDecimals,
         token.symbol,
         t,
     ]);
@@ -341,6 +370,14 @@ export function useIntentsQuote({
 
             if (feeErrorMessage) return { ok: false };
 
+            if (requestAmountDecimals === undefined) {
+                captureMissingDestinationDecimals(formValues.token.address);
+                return {
+                    ok: false,
+                    error: t("fetchFailed"),
+                };
+            }
+
             if (quote && !isLoading && !isFetching && !isSyncPending) {
                 if (hasLowAmountQuote) {
                     if (lowAmountQuoteDetails) {
@@ -360,7 +397,7 @@ export function useIntentsQuote({
             setIsEnsuring(true);
             try {
                 const immediateParsed = Big(formValues.amount)
-                    .mul(Big(10).pow(effectiveAmountDecimals))
+                    .mul(Big(10).pow(requestAmountDecimals))
                     .toFixed();
 
                 const freshQuote = await getIntentsQuote(
@@ -391,7 +428,7 @@ export function useIntentsQuote({
                     err instanceof Error
                         ? formatErrorMessage(
                               err.message,
-                              effectiveAmountDecimals,
+                              requestAmountDecimals,
                               formValues.token.symbol,
                               t,
                           )
@@ -415,7 +452,8 @@ export function useIntentsQuote({
             destinationNetwork,
             hasLowAmountQuote,
             lowAmountQuoteDetails,
-            effectiveAmountDecimals,
+            requestAmountDecimals,
+            captureMissingDestinationDecimals,
             t,
         ],
     );

--- a/nt-fe/hooks/use-intents-quote.ts
+++ b/nt-fe/hooks/use-intents-quote.ts
@@ -292,7 +292,12 @@ export function useIntentsQuote({
             error instanceof Error
                 ? error.message
                 : "Failed to prepare 1Click transfer route";
-        return formatErrorMessage(msg, effectiveAmountDecimals, token.symbol, t);
+        return formatErrorMessage(
+            msg,
+            effectiveAmountDecimals,
+            token.symbol,
+            t,
+        );
     }, [
         hasLowAmountQuote,
         lowAmountQuoteDetails,

--- a/nt-fe/hooks/use-intents-quote.ts
+++ b/nt-fe/hooks/use-intents-quote.ts
@@ -149,6 +149,7 @@ interface UseIntentsQuoteParams {
     treasuryId: string | undefined;
     token: Token;
     amount: string;
+    destinationAmountDecimals?: number;
     address: string;
     isConfidential: boolean;
     proposalPeriod?: string;
@@ -162,6 +163,7 @@ export function useIntentsQuote({
     treasuryId,
     token,
     amount,
+    destinationAmountDecimals,
     address,
     isConfidential,
     proposalPeriod,
@@ -175,14 +177,17 @@ export function useIntentsQuote({
     const [debouncedAddress] = useDebounce(address, 300);
     const [debouncedAmount] = useDebounce(amount, 400);
     const [isEnsuring, setIsEnsuring] = useState(false);
+    const effectiveAmountDecimals = destinationAmountDecimals ?? token.decimals;
 
     const isRecipientReady =
         !!debouncedAddress && isAddressValidForToken(debouncedAddress, token);
 
     const parsedAmount = useMemo(() => {
         if (!debouncedAmount || Number(debouncedAmount) <= 0) return null;
-        return Big(debouncedAmount).mul(Big(10).pow(token.decimals)).toFixed();
-    }, [debouncedAmount, token.decimals]);
+        return Big(debouncedAmount)
+            .mul(Big(10).pow(effectiveAmountDecimals))
+            .toFixed();
+    }, [debouncedAmount, effectiveAmountDecimals]);
 
     const {
         data: quote,
@@ -287,13 +292,13 @@ export function useIntentsQuote({
             error instanceof Error
                 ? error.message
                 : "Failed to prepare 1Click transfer route";
-        return formatErrorMessage(msg, token.decimals, token.symbol, t);
+        return formatErrorMessage(msg, effectiveAmountDecimals, token.symbol, t);
     }, [
         hasLowAmountQuote,
         lowAmountQuoteDetails,
         hasQueryError,
         error,
-        token.decimals,
+        effectiveAmountDecimals,
         token.symbol,
         t,
     ]);
@@ -350,7 +355,7 @@ export function useIntentsQuote({
             setIsEnsuring(true);
             try {
                 const immediateParsed = Big(formValues.amount)
-                    .mul(Big(10).pow(formValues.token.decimals))
+                    .mul(Big(10).pow(effectiveAmountDecimals))
                     .toFixed();
 
                 const freshQuote = await getIntentsQuote(
@@ -381,7 +386,7 @@ export function useIntentsQuote({
                     err instanceof Error
                         ? formatErrorMessage(
                               err.message,
-                              formValues.token.decimals,
+                              effectiveAmountDecimals,
                               formValues.token.symbol,
                               t,
                           )
@@ -405,6 +410,7 @@ export function useIntentsQuote({
             destinationNetwork,
             hasLowAmountQuote,
             lowAmountQuoteDetails,
+            effectiveAmountDecimals,
             t,
         ],
     );


### PR DESCRIPTION
#756 
We used decimals from the selected token, which gives wrong amounts when the destination token uses a different decimal count, fixed quote amount scaling for `EXACT_OUTPUT` payments by using decimals from the destination network token.

