### PR TITLE
fix: force NEAR network metadata for near and wrap.near

### DIFF
--- a/nt-be/src/constants/intents_chains.rs
+++ b/nt-be/src/constants/intents_chains.rs
@@ -62,7 +62,7 @@ pub static CHAIN_METADATA: Lazy<HashMap<String, ChainMetadata>> = Lazy::new(|| {
     );
     metadata.insert(
         "near".to_string(),
-        ChainMetadata::new("Near Protocol", "near.svg"),
+        ChainMetadata::new("NEAR", "near.svg"),
     );
     metadata.insert("base".to_string(), ChainMetadata::new("Base", "base.svg"));
     metadata.insert(

--- a/nt-be/src/constants/intents_chains.rs
+++ b/nt-be/src/constants/intents_chains.rs
@@ -60,10 +60,7 @@ pub static CHAIN_METADATA: Lazy<HashMap<String, ChainMetadata>> = Lazy::new(|| {
         "eth".to_string(),
         ChainMetadata::new("Ethereum", "ethereum.svg"),
     );
-    metadata.insert(
-        "near".to_string(),
-        ChainMetadata::new("NEAR", "near.svg"),
-    );
+    metadata.insert("near".to_string(), ChainMetadata::new("NEAR", "near.svg"));
     metadata.insert("base".to_string(), ChainMetadata::new("Base", "base.svg"));
     metadata.insert(
         "arbitrum".to_string(),

--- a/nt-be/src/handlers/token/metadata.rs
+++ b/nt-be/src/handlers/token/metadata.rs
@@ -69,7 +69,7 @@ impl TokenMetadata {
             price,
             price_updated_at,
             network: Some("near".to_string()),
-            chain_name: Some("Near Protocol".to_string()),
+            chain_name: Some("NEAR".to_string()),
             chain_icons: get_chain_metadata_by_name("near").map(|m| m.icon),
         }
     }
@@ -92,7 +92,7 @@ impl TokenMetadata {
             price,
             price_updated_at,
             network: Some("near".to_string()),
-            chain_name: Some("Near Protocol".to_string()),
+            chain_name: Some("NEAR".to_string()),
             chain_icons: get_chain_metadata_by_name("near").map(|m| m.icon),
         }
     }
@@ -102,6 +102,8 @@ impl TokenMetadata {
         if is_near_or_wrap_token_id(&self.token_id) {
             self.name = "NEAR".to_string();
             self.symbol = "NEAR".to_string();
+            self.icon = Some(NEAR_ICON.to_string());
+            self.chain_name = Some("NEAR".to_string());
         }
     }
 }


### PR DESCRIPTION
#768 
<img width="1728" height="959" alt="image" src="https://github.com/user-attachments/assets/6163281f-a362-4615-b04a-d77a7b9bdfd5" />
<img width="1728" height="959" alt="image" src="https://github.com/user-attachments/assets/da8d9334-a72a-4d37-bb98-c4bb68c13217" />

On staging, I saw wNEAR had no icon in the counterparties table, so I overrode it with the default NEAR icon.
