### PR TITLE
fix: use transaction source for confidential request dates and links

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -1198,7 +1198,7 @@ export function DepositModal({
                                 <div className="flex gap-4">
                                     {/* QR Code Skeleton */}
                                     <div className="shrink-0">
-                                        <div className="w-32 h-32 bg-background rounded-lg" />
+                                        <div className="size-[88px] bg-background rounded-lg" />
                                     </div>
 
                                     {/* Address Skeleton */}
@@ -1304,17 +1304,12 @@ export function DepositModal({
                                     >
                                         {/* QR Code */}
                                         <div className="shrink-0">
-                                            <div className="w-24 h-24 sm:w-40 sm:h-40 rounded-lg flex items-center justify-center p-2">
+                                            <div className="size-[88px] rounded-lg flex items-center justify-center">
                                                 <QRCode
                                                     value={
                                                         displayDepositInfo.address
                                                     }
-                                                    size={112}
-                                                    style={{
-                                                        height: "auto",
-                                                        maxWidth: "100%",
-                                                        width: "100%",
-                                                    }}
+                                                    size={88}
                                                 />
                                             </div>
                                         </div>

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/deposit/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/deposit/page.tsx
@@ -27,7 +27,7 @@ export default function DepositPage() {
                         prefillNetworkId={initialPrefillRef.current.network}
                     />
                 </div>
-                <div className="flex flex-col max-w-[300px] w-full shrink-0">
+                <div className="flex flex-col md:max-w-[300px] w-full shrink-0">
                     <DepositFaq />
                 </div>
             </div>

--- a/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
@@ -675,6 +675,8 @@ export default function RequestReceiptPage({
     }, [proposalId]);
     const proposalUiKind = proposal ? getProposalUIKind(proposal) : undefined;
     const isBatchPaymentProposal = proposalUiKind === "Batch Payment Request";
+    const isConfidentialRequestProposal =
+        proposalUiKind === "Confidential Request";
     const isReceiptEligibleProposal =
         isReceiptEligibleProposalKind(proposalUiKind);
     const isSingleReceiptProposal = !isBatchPaymentProposal;
@@ -708,6 +710,10 @@ export default function RequestReceiptPage({
     const destinationAmountWithDecimals =
         receiptProposalData?.destinationAmountWithDecimals;
     const isExecutableReceipt = status === "Executed";
+    const shouldUseSwapExecutionDate =
+        isExecutableReceipt &&
+        !!depositAddress &&
+        !isConfidentialRequestProposal;
 
     const { data: transaction, isLoading: isLoadingTransaction } =
         useProposalTransaction(
@@ -719,7 +725,7 @@ export default function RequestReceiptPage({
     const { data: swapStatus, isLoading: isLoadingSwapStatus } = useSwapStatus(
         depositAddress,
         undefined,
-        isExecutableReceipt && !!depositAddress,
+        shouldUseSwapExecutionDate,
     );
     const transactionDate = getProposalExecutedDate(swapStatus, transaction);
     const isExchangeProposal = receiptProposalVariant === "exchange";
@@ -867,8 +873,9 @@ export default function RequestReceiptPage({
     const isTransactionDateLoading =
         isExecutableReceipt &&
         isSingleReceiptProposal &&
-        ((hasDepositAddress && isLoadingSwapStatus) ||
-            (!hasDepositAddress && isLoadingTransaction));
+        (shouldUseSwapExecutionDate
+            ? isLoadingSwapStatus
+            : isLoadingTransaction);
     const isRateLoading = hasDepositAddress
         ? isSingleReceiptProposal && isLoadingQuoteByDepositAddress
         : isLoadingSourceHistoricalPrice ||

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -170,6 +170,7 @@ function ExecutedSection({
 }) {
     const t = useTranslations("proposals.expanded");
     const tStatus = useTranslations("proposals.status");
+    const tCommon = useTranslations("common");
     const formatDate = useFormatDate();
 
     let statusIcon = <StepIcon status="Pending" />;
@@ -201,6 +202,13 @@ function ExecutedSection({
         default:
             statusText = status as string;
     }
+    const displayDateText = (() => {
+        if (date) return formatDate(date);
+        if (status === "Pending" || status === "Expired") {
+            return formatDate(expiresAt);
+        }
+        return tCommon("notAvailable");
+    })();
 
     return (
         <div className="space-y-3 relative z-10">
@@ -212,7 +220,7 @@ function ExecutedSection({
                         {isDateLoading ? (
                             <Skeleton className="h-4 w-36" />
                         ) : (
-                            formatDate(date ?? expiresAt)
+                            displayDateText
                         )}
                     </p>
                 </div>
@@ -287,7 +295,8 @@ export function ProposalSidebar({
     // Whether this proposal used the Intents protocol (has a deposit address)
     const hasDepositAddress = !!depositAddress;
     const shouldUseTransactionDate = isExecuted;
-    const shouldUseSwapDate = isExecuted && hasDepositAddress;
+    const shouldUseSwapDate =
+        isExecuted && hasDepositAddress && !isConfidentialRequestProposal;
 
     // Fetch transaction data for non-intents proposals, or for statuses
     // whose resolved date/link should come from the chain transaction.
@@ -444,8 +453,10 @@ export function ProposalSidebar({
                             </Link>
                         </Button>
                     )}
-                    {/* For intents-routed proposals (exchange or payment), show intents explorer link */}
-                    {isExecuted && hasDepositAddress ? (
+                    {/* For intents-routed non-confidential proposals, show intents explorer link */}
+                    {isExecuted &&
+                    hasDepositAddress &&
+                    !isConfidentialRequestProposal ? (
                         <Link
                             href={`https://explorer.near-intents.org/transactions/${depositAddress}`}
                             target="_blank"


### PR DESCRIPTION
#789 
- Confidential requests were getting a 404 from swap status, so we now use the Nearblocks transaction time and explorer link instead.
- If we can’t find an execution date, we show N/A instead of the wrong expiry date. 
- Made the deposit QR code smaller: suggesed by Olha