### PR TITLE
fix: hide maintenance banner from creation

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/members/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/members/page.tsx
@@ -1209,7 +1209,7 @@ export default function MembersPage() {
 
     return (
         <PageComponentLayout title={t("title")} description={t("description")}>
-            {!isInfoSectionDismissed && (
+            {!isInfoSectionDismissed && canAddMember && (
                 <PageCard className="p-4 gap-3 bg-general-tertiary mb-4">
                     <div className="flex items-start justify-between gap-3">
                         <div className="space-y-1">

--- a/nt-fe/components/page-component-layout.tsx
+++ b/nt-fe/components/page-component-layout.tsx
@@ -20,6 +20,7 @@ interface PageComponentLayoutProps {
     backButton?: boolean | string;
     hideLogin?: boolean;
     hideCollapseButton?: boolean;
+    hideSystemStatusBanner?: boolean;
     transparentHeader?: boolean;
     logo?: ReactNode;
     children: ReactNode;
@@ -31,6 +32,7 @@ export function PageComponentLayout({
     backButton,
     hideCollapseButton,
     hideLogin,
+    hideSystemStatusBanner,
     transparentHeader = false,
     logo,
     children,
@@ -138,7 +140,9 @@ export function PageComponentLayout({
             </header>
 
             <main className="flex-1 overflow-y-auto bg-page-bg p-4">
-                <SystemStatusBanner className="lg:hidden mb-3" />
+                {!hideSystemStatusBanner && (
+                    <SystemStatusBanner className="lg:hidden mb-3" />
+                )}
                 {children}
             </main>
         </div>

--- a/nt-fe/features/onboarding/components/create-treasury-entry.tsx
+++ b/nt-fe/features/onboarding/components/create-treasury-entry.tsx
@@ -676,6 +676,7 @@ export function CreateTreasuryEntry() {
                     title={tPages("title")}
                     description={t("headerDescription")}
                     hideCollapseButton
+                    hideSystemStatusBanner
                     transparentHeader
                 >
                     {showWaitlist
@@ -693,6 +694,7 @@ export function CreateTreasuryEntry() {
             title={tPages("title")}
             hideCollapseButton
             hideLogin
+            hideSystemStatusBanner
             transparentHeader
             logo={unauthHeaderLogo}
         >


### PR DESCRIPTION
- hide maintenance banner from treasury creation form
- hide members permissions guide if user doesn't have permission to add member