### PR TITLE
feat: move storage_deposit handling to backend (#735)

### DIFF
--- a/nt-be/src/handlers/relay/mod.rs
+++ b/nt-be/src/handlers/relay/mod.rs
@@ -1,2 +1,3 @@
 pub mod confidential;
+pub mod storage_deposit;
 pub mod submit;

--- a/nt-be/src/handlers/relay/storage_deposit.rs
+++ b/nt-be/src/handlers/relay/storage_deposit.rs
@@ -1,0 +1,553 @@
+//! Backend-driven NEP-141 `storage_deposit` handling for relayed approvals.
+//!
+//! When an approving vote (`act_proposal` with `VoteApprove`) is relayed, the
+//! backend inspects the on-chain proposal kind, derives which accounts need to
+//! be registered on which token contracts, and performs the `storage_deposit`
+//! calls itself (signed and paid by the sponsor) before the vote executes the
+//! transfer. This removes the extra `storage_deposit` transactions the user
+//! used to sign in the relay flow.
+//!
+//! Derivation uses ONLY the authoritative on-chain proposal kind (fetched via
+//! `get_proposal`) — never the proposal description.
+
+use std::collections::HashSet;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use base64::Engine as _;
+use near_api::{
+    AccountId, NearGas, NearToken, Transaction,
+    types::{
+        Action,
+        transaction::{actions::FunctionCallAction, delegate_action::SignedDelegateAction},
+    },
+};
+use serde_json::Value;
+
+use crate::{
+    AppState,
+    handlers::{
+        proposals::scraper::{fetch_batch_payment_list, fetch_proposal},
+        relay::submit::extract_intents_contract,
+        token::storage_deposit::is_registered::check_storage_deposit,
+    },
+};
+
+/// Standard NEP-141 registration cost (0.00125 NEAR). The contract refunds any
+/// excess, and `registration_only: true` is a no-op when already registered.
+pub const STORAGE_DEPOSIT_AMOUNT: NearToken = NearToken::from_micronear(1250);
+const STORAGE_DEPOSIT_GAS: NearGas = NearGas::from_tgas(30);
+/// Upper bound on registrations performed for a single approval. Bulk payment
+/// lists are capped well under this on the contract side; this is a backstop.
+const MAX_STORAGE_DEPOSITS: usize = 200;
+
+/// A single `(account_to_register, token_contract)` registration target.
+type Target = (AccountId, AccountId);
+
+fn is_native_token(token_id: &str) -> bool {
+    token_id.is_empty() || token_id.eq_ignore_ascii_case("near")
+}
+
+/// Return the proposal id if these `act_proposal` args represent a `VoteApprove`.
+fn approve_id_from_act_proposal_args(args: &Value) -> Option<u64> {
+    if args.get("action").and_then(Value::as_str) == Some("VoteApprove") {
+        args.get("id").and_then(Value::as_u64)
+    } else {
+        None
+    }
+}
+
+/// Collect the proposal ids being approved (`VoteApprove`) in this delegate action.
+pub fn vote_approve_proposal_ids(signed_delegate_action: &SignedDelegateAction) -> Vec<u64> {
+    let mut ids = Vec::new();
+    for action in &signed_delegate_action.delegate_action.actions {
+        if let Action::FunctionCall(function_call) = action.deref()
+            && function_call.method_name == "act_proposal"
+            && let Ok(args) = serde_json::from_slice::<Value>(&function_call.args)
+            && let Some(id) = approve_id_from_act_proposal_args(&args)
+        {
+            ids.push(id);
+        }
+    }
+    ids
+}
+
+/// A bulk payment list whose recipients must be registered on `token`.
+struct BulkList {
+    token: AccountId,
+    list_id: String,
+}
+
+/// Result of classifying a proposal kind: directly-known targets plus any bulk
+/// lists whose recipients still need to be resolved over the network.
+#[derive(Default)]
+struct ClassifiedTargets {
+    direct: Vec<Target>,
+    bulk_lists: Vec<BulkList>,
+}
+
+/// Fetch a proposal by id and derive its storage-deposit targets. Failures to
+/// read the proposal are logged and yield no targets (the vote still proceeds).
+pub async fn derive_targets_for_proposal(
+    state: &Arc<AppState>,
+    treasury_id: &AccountId,
+    proposal_id: u64,
+) -> Vec<Target> {
+    let proposal = match fetch_proposal(&state.network, treasury_id, proposal_id).await {
+        Ok(proposal) => proposal,
+        Err(e) => {
+            log::warn!(
+                "storage_deposit: failed to fetch proposal {} for {}: {}",
+                proposal_id,
+                treasury_id,
+                e
+            );
+            return Vec::new();
+        }
+    };
+
+    let ClassifiedTargets {
+        mut direct,
+        bulk_lists,
+    } = classify_kind(&proposal.kind, &state.bulk_payment_contract_id);
+
+    // Expand each bulk list's recipients via the on-chain list.
+    for BulkList { token, list_id } in bulk_lists {
+        match fetch_batch_payment_list(&state.network, &list_id, &state.bulk_payment_contract_id)
+            .await
+        {
+            Ok(list) => {
+                for payment in list.payments {
+                    // Non-NEAR (cross-chain) recipients can't be NEP-141 registered.
+                    if let Ok(recipient) = payment.recipient.parse::<AccountId>() {
+                        direct.push((recipient, token.clone()));
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "storage_deposit: failed to fetch bulk list {}: {}",
+                    list_id,
+                    e
+                );
+            }
+        }
+    }
+
+    direct
+}
+
+fn decode_action_args(action: &Value) -> Option<Value> {
+    let args_b64 = action.get("args")?.as_str()?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(args_b64)
+        .ok()?;
+    serde_json::from_slice::<Value>(&bytes).ok()
+}
+
+/// Classify a proposal's on-chain `kind` into storage-deposit targets, without
+/// any network access. Bulk recipient lists are returned for later expansion.
+///
+/// Only these shapes register anything (everything else → none):
+/// - `Transfer { token_id, receiver_id }` with a non-native token.
+/// - `FunctionCall` actions `ft_transfer` / `ft_transfer_call` (with a bulk
+///   special case that registers the bulk contract and expands recipients).
+/// - `FunctionCall` action `mt_transfer_call` to the bulk contract when the
+///   intents `token_id` is a `nep141:` asset.
+fn classify_kind(kind: &Value, bulk_contract: &AccountId) -> ClassifiedTargets {
+    let mut out = ClassifiedTargets::default();
+
+    // Sputnik native `Transfer` kind (the main direct-FT-payment path).
+    if let Some(transfer) = kind.get("Transfer") {
+        let token_id = transfer
+            .get("token_id")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let receiver_id = transfer
+            .get("receiver_id")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if !is_native_token(token_id)
+            && let (Ok(account), Ok(token)) =
+                (receiver_id.parse::<AccountId>(), token_id.parse::<AccountId>())
+        {
+            out.direct.push((account, token));
+        }
+        return out;
+    }
+
+    let Some(func_call) = kind.get("FunctionCall") else {
+        return out;
+    };
+    let call_receiver = func_call
+        .get("receiver_id")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let Some(actions) = func_call.get("actions").and_then(Value::as_array) else {
+        return out;
+    };
+
+    for action in actions {
+        let method = action
+            .get("method_name")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        match method {
+            // `ft_transfer` on a token contract → register the recipient on it.
+            "ft_transfer" => {
+                if let Some(args) = decode_action_args(action)
+                    && let Some(recv) = args.get("receiver_id").and_then(Value::as_str)
+                    && let (Ok(account), Ok(token)) =
+                        (recv.parse::<AccountId>(), call_receiver.parse::<AccountId>())
+                {
+                    out.direct.push((account, token));
+                }
+            }
+            // `ft_transfer_call` on a token contract. To the bulk contract →
+            // register the bulk contract + every NEAR recipient; otherwise →
+            // register the call's receiver.
+            "ft_transfer_call" => {
+                let Some(args) = decode_action_args(action) else {
+                    continue;
+                };
+                let Ok(token) = call_receiver.parse::<AccountId>() else {
+                    continue;
+                };
+                let arg_receiver = args
+                    .get("receiver_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if arg_receiver == bulk_contract.as_str() {
+                    out.direct.push((bulk_contract.clone(), token.clone()));
+                    if let Some(list_id) = args.get("msg").and_then(Value::as_str) {
+                        out.bulk_lists.push(BulkList {
+                            token,
+                            list_id: list_id.to_string(),
+                        });
+                    }
+                } else if let Ok(account) = arg_receiver.parse::<AccountId>() {
+                    out.direct.push((account, token));
+                }
+            }
+            // Intents bulk payment: `mt_transfer_call` to the bulk contract on
+            // `intents.near`, where the underlying token is a `nep141:` asset.
+            "mt_transfer_call" => {
+                let Some(args) = decode_action_args(action) else {
+                    continue;
+                };
+                let arg_receiver = args
+                    .get("receiver_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if arg_receiver != bulk_contract.as_str() {
+                    continue;
+                }
+                let token_id_field = args.get("token_id").and_then(Value::as_str).unwrap_or("");
+                let Some(contract) = extract_intents_contract(token_id_field) else {
+                    continue;
+                };
+                let Ok(token) = contract.parse::<AccountId>() else {
+                    continue;
+                };
+                out.direct.push((bulk_contract.clone(), token.clone()));
+                if let Some(list_id) = args.get("msg").and_then(Value::as_str) {
+                    out.bulk_lists.push(BulkList {
+                        token,
+                        list_id: list_id.to_string(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    out
+}
+
+/// Dedupe targets and enforce the per-approval cap.
+fn prepare_targets(targets: Vec<Target>) -> Result<Vec<Target>, String> {
+    let mut seen = HashSet::new();
+    let deduped: Vec<Target> = targets
+        .into_iter()
+        .filter(|(account, token)| seen.insert((account.to_string(), token.to_string())))
+        .collect();
+
+    if deduped.len() > MAX_STORAGE_DEPOSITS {
+        return Err(format!(
+            "Too many storage_deposit registrations required ({} > {})",
+            deduped.len(),
+            MAX_STORAGE_DEPOSITS
+        ));
+    }
+    Ok(deduped)
+}
+
+/// Perform the required registrations concurrently, skipping already-registered
+/// accounts. Returns the number of `storage_deposit` calls actually sent (for
+/// `paid_near` accounting). Errors if a required registration fails.
+pub async fn execute_storage_deposits(
+    state: &Arc<AppState>,
+    targets: Vec<Target>,
+) -> Result<u32, String> {
+    let deduped = prepare_targets(targets)?;
+    if deduped.is_empty() {
+        return Ok(0);
+    }
+
+    let futures = deduped.into_iter().map(|(account, token)| {
+        let state = state.clone();
+        async move { register_one(&state, &account, &token).await }
+    });
+    let results = futures::future::join_all(futures).await;
+
+    let mut count: u32 = 0;
+    for result in results {
+        match result {
+            Ok(true) => count += 1,
+            Ok(false) => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(count)
+}
+
+/// Register a single account on a token contract. Returns `Ok(true)` when a
+/// `storage_deposit` was actually sent, `Ok(false)` when already registered.
+async fn register_one(
+    state: &Arc<AppState>,
+    account_id: &AccountId,
+    token_id: &AccountId,
+) -> Result<bool, String> {
+    match check_storage_deposit(state, account_id.clone(), token_id.clone()).await {
+        Ok(true) => return Ok(false),
+        Ok(false) => {}
+        Err(e) => {
+            // Couldn't verify — attempt anyway; storage_deposit refunds if
+            // the account turns out to be already registered.
+            log::warn!(
+                "storage_deposit: registration check failed for {} on {}: {}",
+                account_id,
+                token_id,
+                e
+            );
+        }
+    }
+
+    let args = serde_json::to_vec(&serde_json::json!({
+        "account_id": account_id,
+        "registration_only": true,
+    }))
+    .map_err(|e| e.to_string())?;
+
+    Transaction::construct(state.signer_id.clone(), token_id.clone())
+        .add_action(Action::FunctionCall(Box::new(FunctionCallAction {
+            method_name: "storage_deposit".to_string(),
+            args,
+            gas: STORAGE_DEPOSIT_GAS,
+            deposit: STORAGE_DEPOSIT_AMOUNT,
+        })))
+        .with_signer(state.signer.clone())
+        .send_to(&state.network)
+        .await
+        .map_err(|e| {
+            format!(
+                "Failed to send storage_deposit for {} on {}: {}",
+                account_id, token_id, e
+            )
+        })?
+        .into_result()
+        .map_err(|e| {
+            format!(
+                "storage_deposit failed for {} on {}: {}",
+                account_id, token_id, e
+            )
+        })?;
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn bulk() -> AccountId {
+        "bulkpayment.near".parse().unwrap()
+    }
+
+    fn acc(s: &str) -> AccountId {
+        s.parse().unwrap()
+    }
+
+    /// Build a FunctionCall action with base64-encoded JSON args.
+    fn fc_action(method: &str, args: serde_json::Value) -> serde_json::Value {
+        let encoded = base64::engine::general_purpose::STANDARD
+            .encode(serde_json::to_vec(&args).unwrap());
+        json!({ "method_name": method, "args": encoded })
+    }
+
+    fn function_call_kind(receiver: &str, actions: Vec<serde_json::Value>) -> serde_json::Value {
+        json!({ "FunctionCall": { "receiver_id": receiver, "actions": actions } })
+    }
+
+    #[test]
+    fn transfer_ft_registers_recipient() {
+        let kind = json!({ "Transfer": { "token_id": "usdc.near", "receiver_id": "alice.near" } });
+        let out = classify_kind(&kind, &bulk());
+        assert_eq!(out.direct, vec![(acc("alice.near"), acc("usdc.near"))]);
+        assert!(out.bulk_lists.is_empty());
+    }
+
+    #[test]
+    fn transfer_native_registers_nothing() {
+        let kind = json!({ "Transfer": { "token_id": "", "receiver_id": "alice.near" } });
+        let out = classify_kind(&kind, &bulk());
+        assert!(out.direct.is_empty());
+
+        let kind = json!({ "Transfer": { "token_id": "near", "receiver_id": "alice.near" } });
+        assert!(classify_kind(&kind, &bulk()).direct.is_empty());
+    }
+
+    #[test]
+    fn ft_transfer_registers_receiver_on_token() {
+        let kind = function_call_kind(
+            "usdc.near",
+            vec![fc_action("ft_transfer", json!({ "receiver_id": "deposit.near", "amount": "5" }))],
+        );
+        let out = classify_kind(&kind, &bulk());
+        assert_eq!(out.direct, vec![(acc("deposit.near"), acc("usdc.near"))]);
+        assert!(out.bulk_lists.is_empty());
+    }
+
+    #[test]
+    fn near_deposit_plus_ft_transfer_only_registers_transfer_receiver() {
+        // Native NEAR via intents/exchange: near_deposit is ignored, ft_transfer covers the deposit address.
+        let kind = function_call_kind(
+            "wrap.near",
+            vec![
+                fc_action("near_deposit", json!({})),
+                fc_action("ft_transfer", json!({ "receiver_id": "1click.near", "amount": "5" })),
+            ],
+        );
+        let out = classify_kind(&kind, &bulk());
+        assert_eq!(out.direct, vec![(acc("1click.near"), acc("wrap.near"))]);
+    }
+
+    #[test]
+    fn ft_transfer_call_non_bulk_registers_receiver() {
+        let kind = function_call_kind(
+            "usdc.near",
+            vec![fc_action(
+                "ft_transfer_call",
+                json!({ "receiver_id": "somecontract.near", "amount": "5", "msg": "x" }),
+            )],
+        );
+        let out = classify_kind(&kind, &bulk());
+        assert_eq!(out.direct, vec![(acc("somecontract.near"), acc("usdc.near"))]);
+        assert!(out.bulk_lists.is_empty());
+    }
+
+    #[test]
+    fn ft_transfer_call_bulk_registers_contract_and_queues_list() {
+        let kind = function_call_kind(
+            "usdc.near",
+            vec![fc_action(
+                "ft_transfer_call",
+                json!({ "receiver_id": "bulkpayment.near", "amount": "5", "msg": "list-7" }),
+            )],
+        );
+        let out = classify_kind(&kind, &bulk());
+        assert_eq!(out.direct, vec![(bulk(), acc("usdc.near"))]);
+        assert_eq!(out.bulk_lists.len(), 1);
+        assert_eq!(out.bulk_lists[0].token, acc("usdc.near"));
+        assert_eq!(out.bulk_lists[0].list_id, "list-7");
+    }
+
+    #[test]
+    fn mt_transfer_call_bulk_nep141_strips_prefix() {
+        let kind = function_call_kind(
+            "intents.near",
+            vec![fc_action(
+                "mt_transfer_call",
+                json!({
+                    "receiver_id": "bulkpayment.near",
+                    "token_id": "nep141:usdt.tether-token.near",
+                    "amount": "5",
+                    "msg": "list-9"
+                }),
+            )],
+        );
+        let out = classify_kind(&kind, &bulk());
+        assert_eq!(out.direct, vec![(bulk(), acc("usdt.tether-token.near"))]);
+        assert_eq!(out.bulk_lists.len(), 1);
+        assert_eq!(out.bulk_lists[0].token, acc("usdt.tether-token.near"));
+        assert_eq!(out.bulk_lists[0].list_id, "list-9");
+    }
+
+    #[test]
+    fn mt_transfer_non_bulk_registers_nothing() {
+        // Plain intents transfer/exchange: no NEP-141 storage_deposit.
+        let kind = function_call_kind(
+            "intents.near",
+            vec![fc_action(
+                "mt_transfer",
+                json!({ "receiver_id": "1click.near", "token_id": "nep141:usdc.near", "amount": "5" }),
+            )],
+        );
+        let out = classify_kind(&kind, &bulk());
+        assert!(out.direct.is_empty());
+        assert!(out.bulk_lists.is_empty());
+    }
+
+    #[test]
+    fn unrelated_methods_register_nothing() {
+        let kind = function_call_kind(
+            "wrap.near",
+            vec![fc_action("near_withdraw", json!({ "amount": "5" }))],
+        );
+        let out = classify_kind(&kind, &bulk());
+        assert!(out.direct.is_empty());
+
+        // approve_list (NEAR bulk) — no FT registration.
+        let kind = function_call_kind(
+            "bulkpayment.near",
+            vec![fc_action("approve_list", json!({ "list_id": "list-1" }))],
+        );
+        assert!(classify_kind(&kind, &bulk()).direct.is_empty());
+    }
+
+    #[test]
+    fn approve_id_parsing() {
+        assert_eq!(
+            approve_id_from_act_proposal_args(&json!({ "id": 12, "action": "VoteApprove" })),
+            Some(12)
+        );
+        assert_eq!(
+            approve_id_from_act_proposal_args(&json!({ "id": 12, "action": "VoteReject" })),
+            None
+        );
+        assert_eq!(
+            approve_id_from_act_proposal_args(&json!({ "action": "VoteApprove" })),
+            None
+        );
+    }
+
+    #[test]
+    fn prepare_targets_dedupes() {
+        let targets = vec![
+            (acc("alice.near"), acc("usdc.near")),
+            (acc("alice.near"), acc("usdc.near")),
+            (acc("bob.near"), acc("usdc.near")),
+        ];
+        let prepared = prepare_targets(targets).unwrap();
+        assert_eq!(prepared.len(), 2);
+    }
+
+    #[test]
+    fn prepare_targets_enforces_cap() {
+        let targets: Vec<Target> = (0..(MAX_STORAGE_DEPOSITS + 1))
+            .map(|i| (acc(&format!("a{i}.near")), acc("usdc.near")))
+            .collect();
+        assert!(prepare_targets(targets).is_err());
+    }
+}

--- a/nt-be/src/handlers/relay/storage_deposit.rs
+++ b/nt-be/src/handlers/relay/storage_deposit.rs
@@ -48,7 +48,7 @@ const MAX_REGISTER_ATTEMPTS: usize = 3;
 const REGISTER_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// A single account that must be registered on a token contract.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct Registration {
     account_id: AccountId,
     token_id: AccountId,
@@ -157,9 +157,10 @@ struct BulkList {
 
 /// Result of classifying a proposal kind: directly-known targets plus any bulk
 /// lists whose recipients still need to be resolved over the network.
+/// Targets are deduplicated via the `HashSet` as they are collected.
 #[derive(Default)]
 struct ClassifiedTargets {
-    direct: Vec<Registration>,
+    direct: HashSet<Registration>,
     bulk_lists: Vec<BulkList>,
 }
 
@@ -169,7 +170,7 @@ pub(crate) async fn derive_targets_for_proposal(
     state: &Arc<AppState>,
     treasury_id: &AccountId,
     proposal_id: u64,
-) -> Vec<Registration> {
+) -> HashSet<Registration> {
     let proposal = match fetch_proposal(&state.network, treasury_id, proposal_id).await {
         Ok(proposal) => proposal,
         Err(e) => {
@@ -179,7 +180,7 @@ pub(crate) async fn derive_targets_for_proposal(
                 treasury_id,
                 e
             );
-            return Vec::new();
+            return HashSet::new();
         }
     };
 
@@ -197,7 +198,7 @@ pub(crate) async fn derive_targets_for_proposal(
                 for payment in list.payments {
                     // Non-NEAR (cross-chain) recipients can't be NEP-141 registered.
                     if let Ok(account_id) = payment.recipient.parse::<AccountId>() {
-                        direct.push(Registration {
+                        direct.insert(Registration {
                             account_id,
                             token_id: token.clone(),
                         });
@@ -236,7 +237,7 @@ fn classify_kind(kind: &serde_json::Value, bulk_contract: &AccountId) -> Classif
     // Sputnik native `Transfer` kind (the main direct-FT-payment path).
     if let Some(transfer) = kind.transfer {
         if !is_native_token(transfer.token_id.as_str()) {
-            out.direct.push(Registration {
+            out.direct.insert(Registration {
                 account_id: transfer.receiver_id,
                 token_id: transfer.token_id,
             });
@@ -253,7 +254,7 @@ fn classify_kind(kind: &serde_json::Value, bulk_contract: &AccountId) -> Classif
             // `ft_transfer` on a token contract → register the recipient on it.
             "ft_transfer" => {
                 if let Some(args) = decode_args::<FtTransferArgs>(&action.args) {
-                    out.direct.push(Registration {
+                    out.direct.insert(Registration {
                         account_id: args.receiver_id,
                         token_id: func_call.receiver_id.clone(),
                     });
@@ -270,7 +271,7 @@ fn classify_kind(kind: &serde_json::Value, bulk_contract: &AccountId) -> Classif
                 if args.receiver_id == *bulk_contract {
                     out.push_bulk(bulk_contract, token_id, args.msg);
                 } else {
-                    out.direct.push(Registration {
+                    out.direct.insert(Registration {
                         account_id: args.receiver_id,
                         token_id,
                     });
@@ -304,7 +305,7 @@ impl ClassifiedTargets {
     /// Register the bulk payment contract on `token` and queue its recipient
     /// list (identified by `list_id`) for expansion.
     fn push_bulk(&mut self, bulk_contract: &AccountId, token: AccountId, list_id: String) {
-        self.direct.push(Registration {
+        self.direct.insert(Registration {
             account_id: bulk_contract.clone(),
             token_id: token.clone(),
         });
@@ -314,37 +315,27 @@ impl ClassifiedTargets {
     }
 }
 
-/// Dedupe targets and enforce the per-approval cap.
-fn prepare_targets(targets: Vec<Registration>) -> Result<Vec<Registration>, String> {
-    let mut seen = HashSet::new();
-    let deduped: Vec<Registration> = targets
-        .into_iter()
-        .filter(|r| seen.insert((r.account_id.to_string(), r.token_id.to_string())))
-        .collect();
-
-    if deduped.len() > MAX_STORAGE_DEPOSITS {
+/// Perform the required registrations concurrently, skipping already-registered
+/// accounts. The targets are already deduplicated (collected into a `HashSet`).
+/// Returns the number of `storage_deposit` calls actually sent (for `paid_near`
+/// accounting). Errors if the per-approval cap is exceeded or a required
+/// registration fails.
+pub(crate) async fn execute_storage_deposits(
+    state: &Arc<AppState>,
+    targets: HashSet<Registration>,
+) -> Result<u32, String> {
+    if targets.is_empty() {
+        return Ok(0);
+    }
+    if targets.len() > MAX_STORAGE_DEPOSITS {
         return Err(format!(
             "Too many storage_deposit registrations required ({} > {})",
-            deduped.len(),
+            targets.len(),
             MAX_STORAGE_DEPOSITS
         ));
     }
-    Ok(deduped)
-}
 
-/// Perform the required registrations concurrently, skipping already-registered
-/// accounts. Returns the number of `storage_deposit` calls actually sent (for
-/// `paid_near` accounting). Errors if a required registration fails.
-pub(crate) async fn execute_storage_deposits(
-    state: &Arc<AppState>,
-    targets: Vec<Registration>,
-) -> Result<u32, String> {
-    let deduped = prepare_targets(targets)?;
-    if deduped.is_empty() {
-        return Ok(0);
-    }
-
-    let futures = deduped.into_iter().map(|registration| {
+    let futures = targets.into_iter().map(|registration| {
         let state = state.clone();
         async move { register_one(&state, &registration).await }
     });
@@ -462,6 +453,10 @@ mod tests {
         }
     }
 
+    fn regs(items: &[(&str, &str)]) -> HashSet<Registration> {
+        items.iter().map(|(a, t)| reg(a, t)).collect()
+    }
+
     /// Build a FunctionCall action with base64-encoded JSON args.
     fn fc_action(method: &str, args: serde_json::Value) -> serde_json::Value {
         let encoded =
@@ -477,7 +472,7 @@ mod tests {
     fn transfer_ft_registers_recipient() {
         let kind = json!({ "Transfer": { "token_id": "usdc.near", "receiver_id": "alice.near" } });
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![reg("alice.near", "usdc.near")]);
+        assert_eq!(out.direct, regs(&[("alice.near", "usdc.near")]));
         assert!(out.bulk_lists.is_empty());
     }
 
@@ -501,7 +496,7 @@ mod tests {
             )],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![reg("deposit.near", "usdc.near")]);
+        assert_eq!(out.direct, regs(&[("deposit.near", "usdc.near")]));
         assert!(out.bulk_lists.is_empty());
     }
 
@@ -519,7 +514,7 @@ mod tests {
             ],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![reg("1click.near", "wrap.near")]);
+        assert_eq!(out.direct, regs(&[("1click.near", "wrap.near")]));
     }
 
     #[test]
@@ -532,7 +527,7 @@ mod tests {
             )],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![reg("somecontract.near", "usdc.near")]);
+        assert_eq!(out.direct, regs(&[("somecontract.near", "usdc.near")]));
         assert!(out.bulk_lists.is_empty());
     }
 
@@ -546,7 +541,7 @@ mod tests {
             )],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![reg("bulkpayment.near", "usdc.near")]);
+        assert_eq!(out.direct, regs(&[("bulkpayment.near", "usdc.near")]));
         assert_eq!(out.bulk_lists.len(), 1);
         assert_eq!(out.bulk_lists[0].token, acc("usdc.near"));
         assert_eq!(out.bulk_lists[0].list_id, "list-7");
@@ -569,7 +564,7 @@ mod tests {
         let out = classify_kind(&kind, &bulk());
         assert_eq!(
             out.direct,
-            vec![reg("bulkpayment.near", "usdt.tether-token.near")]
+            regs(&[("bulkpayment.near", "usdt.tether-token.near")])
         );
         assert_eq!(out.bulk_lists.len(), 1);
         assert_eq!(out.bulk_lists[0].token, acc("usdt.tether-token.near"));
@@ -636,21 +631,16 @@ mod tests {
     }
 
     #[test]
-    fn prepare_targets_dedupes() {
-        let targets = vec![
-            reg("alice.near", "usdc.near"),
-            reg("alice.near", "usdc.near"),
-            reg("bob.near", "usdc.near"),
-        ];
-        let prepared = prepare_targets(targets).unwrap();
-        assert_eq!(prepared.len(), 2);
-    }
-
-    #[test]
-    fn prepare_targets_enforces_cap() {
-        let targets: Vec<Registration> = (0..(MAX_STORAGE_DEPOSITS + 1))
-            .map(|i| reg(&format!("a{i}.near"), "usdc.near"))
-            .collect();
-        assert!(prepare_targets(targets).is_err());
+    fn classify_dedupes_repeated_targets() {
+        // Two identical ft_transfers collapse to a single registration via the HashSet.
+        let transfer = || {
+            fc_action(
+                "ft_transfer",
+                json!({ "receiver_id": "deposit.near", "amount": "5" }),
+            )
+        };
+        let kind = function_call_kind("usdc.near", vec![transfer(), transfer()]);
+        let out = classify_kind(&kind, &bulk());
+        assert_eq!(out.direct, regs(&[("deposit.near", "usdc.near")]));
     }
 }

--- a/nt-be/src/handlers/relay/storage_deposit.rs
+++ b/nt-be/src/handlers/relay/storage_deposit.rs
@@ -318,10 +318,7 @@ impl ClassifiedTargets {
             token_id: token.clone(),
         });
         if !list_id.is_empty() {
-            self.bulk_lists.push(BulkList {
-                token,
-                list_id,
-            });
+            self.bulk_lists.push(BulkList { token, list_id });
         }
     }
 }
@@ -476,8 +473,8 @@ mod tests {
 
     /// Build a FunctionCall action with base64-encoded JSON args.
     fn fc_action(method: &str, args: serde_json::Value) -> serde_json::Value {
-        let encoded = base64::engine::general_purpose::STANDARD
-            .encode(serde_json::to_vec(&args).unwrap());
+        let encoded =
+            base64::engine::general_purpose::STANDARD.encode(serde_json::to_vec(&args).unwrap());
         json!({ "method_name": method, "args": encoded })
     }
 
@@ -507,7 +504,10 @@ mod tests {
     fn ft_transfer_registers_receiver_on_token() {
         let kind = function_call_kind(
             "usdc.near",
-            vec![fc_action("ft_transfer", json!({ "receiver_id": "deposit.near", "amount": "5" }))],
+            vec![fc_action(
+                "ft_transfer",
+                json!({ "receiver_id": "deposit.near", "amount": "5" }),
+            )],
         );
         let out = classify_kind(&kind, &bulk());
         assert_eq!(out.direct, vec![reg("deposit.near", "usdc.near")]);
@@ -521,7 +521,10 @@ mod tests {
             "wrap.near",
             vec![
                 fc_action("near_deposit", json!({})),
-                fc_action("ft_transfer", json!({ "receiver_id": "1click.near", "amount": "5" })),
+                fc_action(
+                    "ft_transfer",
+                    json!({ "receiver_id": "1click.near", "amount": "5" }),
+                ),
             ],
         );
         let out = classify_kind(&kind, &bulk());
@@ -573,7 +576,10 @@ mod tests {
             )],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![reg("bulkpayment.near", "usdt.tether-token.near")]);
+        assert_eq!(
+            out.direct,
+            vec![reg("bulkpayment.near", "usdt.tether-token.near")]
+        );
         assert_eq!(out.bulk_lists.len(), 1);
         assert_eq!(out.bulk_lists[0].token, acc("usdt.tether-token.near"));
         assert_eq!(out.bulk_lists[0].list_id, "list-9");

--- a/nt-be/src/handlers/relay/storage_deposit.rs
+++ b/nt-be/src/handlers/relay/storage_deposit.rs
@@ -68,14 +68,16 @@ struct ProposalKind {
 
 #[derive(Debug, Deserialize)]
 struct TransferKind {
-    #[serde(default)]
-    token_id: String,
-    receiver_id: String,
+    // Native NEAR uses the sentinel token_id "", which is not a valid
+    // AccountId; such transfers fail to deserialize and yield no registration
+    // (correct — native NEAR needs none).
+    token_id: AccountId,
+    receiver_id: AccountId,
 }
 
 #[derive(Debug, Deserialize)]
 struct FunctionCallKind {
-    receiver_id: String,
+    receiver_id: AccountId,
     #[serde(default)]
     actions: Vec<ProposalFunctionCall>,
 }
@@ -90,19 +92,20 @@ struct ProposalFunctionCall {
 
 #[derive(Debug, Deserialize)]
 struct FtTransferArgs {
-    receiver_id: String,
+    receiver_id: AccountId,
 }
 
 #[derive(Debug, Deserialize)]
 struct FtTransferCallArgs {
-    receiver_id: String,
+    receiver_id: AccountId,
     #[serde(default)]
     msg: String,
 }
 
 #[derive(Debug, Deserialize)]
 struct MtTransferCallArgs {
-    receiver_id: String,
+    receiver_id: AccountId,
+    /// Intents asset id, e.g. `nep141:usdc.near` — not a bare AccountId.
     token_id: String,
     #[serde(default)]
     msg: String,
@@ -232,15 +235,10 @@ fn classify_kind(kind: &serde_json::Value, bulk_contract: &AccountId) -> Classif
 
     // Sputnik native `Transfer` kind (the main direct-FT-payment path).
     if let Some(transfer) = kind.transfer {
-        if !is_native_token(&transfer.token_id)
-            && let (Ok(account_id), Ok(token_id)) = (
-                transfer.receiver_id.parse::<AccountId>(),
-                transfer.token_id.parse::<AccountId>(),
-            )
-        {
+        if !is_native_token(transfer.token_id.as_str()) {
             out.direct.push(Registration {
-                account_id,
-                token_id,
+                account_id: transfer.receiver_id,
+                token_id: transfer.token_id,
             });
         }
         return out;
@@ -254,15 +252,10 @@ fn classify_kind(kind: &serde_json::Value, bulk_contract: &AccountId) -> Classif
         match action.method_name.as_str() {
             // `ft_transfer` on a token contract → register the recipient on it.
             "ft_transfer" => {
-                if let Some(args) = decode_args::<FtTransferArgs>(&action.args)
-                    && let (Ok(account_id), Ok(token_id)) = (
-                        args.receiver_id.parse::<AccountId>(),
-                        func_call.receiver_id.parse::<AccountId>(),
-                    )
-                {
+                if let Some(args) = decode_args::<FtTransferArgs>(&action.args) {
                     out.direct.push(Registration {
-                        account_id,
-                        token_id,
+                        account_id: args.receiver_id,
+                        token_id: func_call.receiver_id.clone(),
                     });
                 }
             }
@@ -273,14 +266,12 @@ fn classify_kind(kind: &serde_json::Value, bulk_contract: &AccountId) -> Classif
                 let Some(args) = decode_args::<FtTransferCallArgs>(&action.args) else {
                     continue;
                 };
-                let Ok(token_id) = func_call.receiver_id.parse::<AccountId>() else {
-                    continue;
-                };
-                if args.receiver_id == bulk_contract.as_str() {
+                let token_id = func_call.receiver_id.clone();
+                if args.receiver_id == *bulk_contract {
                     out.push_bulk(bulk_contract, token_id, args.msg);
-                } else if let Ok(account_id) = args.receiver_id.parse::<AccountId>() {
+                } else {
                     out.direct.push(Registration {
-                        account_id,
+                        account_id: args.receiver_id,
                         token_id,
                     });
                 }
@@ -291,7 +282,7 @@ fn classify_kind(kind: &serde_json::Value, bulk_contract: &AccountId) -> Classif
                 let Some(args) = decode_args::<MtTransferCallArgs>(&action.args) else {
                     continue;
                 };
-                if args.receiver_id != bulk_contract.as_str() {
+                if args.receiver_id != *bulk_contract {
                     continue;
                 }
                 let Some(contract) = extract_intents_contract(&args.token_id) else {

--- a/nt-be/src/handlers/relay/storage_deposit.rs
+++ b/nt-be/src/handlers/relay/storage_deposit.rs
@@ -13,6 +13,7 @@
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::Arc;
+use std::time::Duration;
 
 use base64::Engine as _;
 use near_api::{
@@ -22,7 +23,8 @@ use near_api::{
         transaction::{actions::FunctionCallAction, delegate_action::SignedDelegateAction},
     },
 };
-use serde_json::Value;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
 use crate::{
     AppState,
@@ -35,36 +37,108 @@ use crate::{
 
 /// Standard NEP-141 registration cost (0.00125 NEAR). The contract refunds any
 /// excess, and `registration_only: true` is a no-op when already registered.
-pub const STORAGE_DEPOSIT_AMOUNT: NearToken = NearToken::from_micronear(1250);
+pub(crate) const STORAGE_DEPOSIT_AMOUNT: NearToken = NearToken::from_micronear(1250);
 const STORAGE_DEPOSIT_GAS: NearGas = NearGas::from_tgas(30);
 /// Upper bound on registrations performed for a single approval. Bulk payment
 /// lists are capped well under this on the contract side; this is a backstop.
 const MAX_STORAGE_DEPOSITS: usize = 200;
+/// How many times to retry a single `storage_deposit` send before failing the
+/// approval, to ride out transient RPC/network errors.
+const MAX_REGISTER_ATTEMPTS: usize = 3;
+const REGISTER_RETRY_DELAY: Duration = Duration::from_millis(500);
 
-/// A single `(account_to_register, token_contract)` registration target.
-type Target = (AccountId, AccountId);
+/// A single account that must be registered on a token contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Registration {
+    account_id: AccountId,
+    token_id: AccountId,
+}
+
+// ─── Typed views over the on-chain proposal kind / action args ──────────────────
+
+/// Sputnik proposal `kind`. Only the variants that can imply a NEP-141
+/// registration are modelled; everything else deserializes to `None` fields.
+#[derive(Debug, Default, Deserialize)]
+struct ProposalKind {
+    #[serde(rename = "Transfer")]
+    transfer: Option<TransferKind>,
+    #[serde(rename = "FunctionCall")]
+    function_call: Option<FunctionCallKind>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TransferKind {
+    #[serde(default)]
+    token_id: String,
+    receiver_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FunctionCallKind {
+    receiver_id: String,
+    #[serde(default)]
+    actions: Vec<ProposalFunctionCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProposalFunctionCall {
+    method_name: String,
+    /// Base64-encoded JSON args.
+    #[serde(default)]
+    args: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FtTransferArgs {
+    receiver_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FtTransferCallArgs {
+    receiver_id: String,
+    #[serde(default)]
+    msg: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MtTransferCallArgs {
+    receiver_id: String,
+    token_id: String,
+    #[serde(default)]
+    msg: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActProposalArgs {
+    id: u64,
+    action: String,
+}
 
 fn is_native_token(token_id: &str) -> bool {
     token_id.is_empty() || token_id.eq_ignore_ascii_case("near")
 }
 
+/// Decode base64-encoded JSON action args into a typed struct.
+fn decode_args<T: DeserializeOwned>(encoded: &str) -> Option<T> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
 /// Return the proposal id if these `act_proposal` args represent a `VoteApprove`.
-fn approve_id_from_act_proposal_args(args: &Value) -> Option<u64> {
-    if args.get("action").and_then(Value::as_str) == Some("VoteApprove") {
-        args.get("id").and_then(Value::as_u64)
-    } else {
-        None
-    }
+fn approve_proposal_id(args: &ActProposalArgs) -> Option<u64> {
+    (args.action == "VoteApprove").then_some(args.id)
 }
 
 /// Collect the proposal ids being approved (`VoteApprove`) in this delegate action.
-pub fn vote_approve_proposal_ids(signed_delegate_action: &SignedDelegateAction) -> Vec<u64> {
+pub(crate) fn vote_approve_proposal_ids(signed_delegate_action: &SignedDelegateAction) -> Vec<u64> {
     let mut ids = Vec::new();
     for action in &signed_delegate_action.delegate_action.actions {
         if let Action::FunctionCall(function_call) = action.deref()
             && function_call.method_name == "act_proposal"
-            && let Ok(args) = serde_json::from_slice::<Value>(&function_call.args)
-            && let Some(id) = approve_id_from_act_proposal_args(&args)
+            && let Ok(args) = serde_json::from_slice::<ActProposalArgs>(&function_call.args)
+            && let Some(id) = approve_proposal_id(&args)
         {
             ids.push(id);
         }
@@ -82,17 +156,17 @@ struct BulkList {
 /// lists whose recipients still need to be resolved over the network.
 #[derive(Default)]
 struct ClassifiedTargets {
-    direct: Vec<Target>,
+    direct: Vec<Registration>,
     bulk_lists: Vec<BulkList>,
 }
 
 /// Fetch a proposal by id and derive its storage-deposit targets. Failures to
 /// read the proposal are logged and yield no targets (the vote still proceeds).
-pub async fn derive_targets_for_proposal(
+pub(crate) async fn derive_targets_for_proposal(
     state: &Arc<AppState>,
     treasury_id: &AccountId,
     proposal_id: u64,
-) -> Vec<Target> {
+) -> Vec<Registration> {
     let proposal = match fetch_proposal(&state.network, treasury_id, proposal_id).await {
         Ok(proposal) => proposal,
         Err(e) => {
@@ -119,8 +193,11 @@ pub async fn derive_targets_for_proposal(
             Ok(list) => {
                 for payment in list.payments {
                     // Non-NEAR (cross-chain) recipients can't be NEP-141 registered.
-                    if let Ok(recipient) = payment.recipient.parse::<AccountId>() {
-                        direct.push((recipient, token.clone()));
+                    if let Ok(account_id) = payment.recipient.parse::<AccountId>() {
+                        direct.push(Registration {
+                            account_id,
+                            token_id: token.clone(),
+                        });
                     }
                 }
             }
@@ -137,14 +214,6 @@ pub async fn derive_targets_for_proposal(
     direct
 }
 
-fn decode_action_args(action: &Value) -> Option<Value> {
-    let args_b64 = action.get("args")?.as_str()?;
-    let bytes = base64::engine::general_purpose::STANDARD
-        .decode(args_b64)
-        .ok()?;
-    serde_json::from_slice::<Value>(&bytes).ok()
-}
-
 /// Classify a proposal's on-chain `kind` into storage-deposit targets, without
 /// any network access. Bulk recipient lists are returned for later expansion.
 ///
@@ -154,108 +223,84 @@ fn decode_action_args(action: &Value) -> Option<Value> {
 ///   special case that registers the bulk contract and expands recipients).
 /// - `FunctionCall` action `mt_transfer_call` to the bulk contract when the
 ///   intents `token_id` is a `nep141:` asset.
-fn classify_kind(kind: &Value, bulk_contract: &AccountId) -> ClassifiedTargets {
+fn classify_kind(kind: &serde_json::Value, bulk_contract: &AccountId) -> ClassifiedTargets {
     let mut out = ClassifiedTargets::default();
 
+    let Ok(kind) = serde_json::from_value::<ProposalKind>(kind.clone()) else {
+        return out;
+    };
+
     // Sputnik native `Transfer` kind (the main direct-FT-payment path).
-    if let Some(transfer) = kind.get("Transfer") {
-        let token_id = transfer
-            .get("token_id")
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        let receiver_id = transfer
-            .get("receiver_id")
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        if !is_native_token(token_id)
-            && let (Ok(account), Ok(token)) =
-                (receiver_id.parse::<AccountId>(), token_id.parse::<AccountId>())
+    if let Some(transfer) = kind.transfer {
+        if !is_native_token(&transfer.token_id)
+            && let (Ok(account_id), Ok(token_id)) = (
+                transfer.receiver_id.parse::<AccountId>(),
+                transfer.token_id.parse::<AccountId>(),
+            )
         {
-            out.direct.push((account, token));
+            out.direct.push(Registration {
+                account_id,
+                token_id,
+            });
         }
         return out;
     }
 
-    let Some(func_call) = kind.get("FunctionCall") else {
-        return out;
-    };
-    let call_receiver = func_call
-        .get("receiver_id")
-        .and_then(Value::as_str)
-        .unwrap_or("");
-    let Some(actions) = func_call.get("actions").and_then(Value::as_array) else {
+    let Some(func_call) = kind.function_call else {
         return out;
     };
 
-    for action in actions {
-        let method = action
-            .get("method_name")
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        match method {
+    for action in &func_call.actions {
+        match action.method_name.as_str() {
             // `ft_transfer` on a token contract → register the recipient on it.
             "ft_transfer" => {
-                if let Some(args) = decode_action_args(action)
-                    && let Some(recv) = args.get("receiver_id").and_then(Value::as_str)
-                    && let (Ok(account), Ok(token)) =
-                        (recv.parse::<AccountId>(), call_receiver.parse::<AccountId>())
+                if let Some(args) = decode_args::<FtTransferArgs>(&action.args)
+                    && let (Ok(account_id), Ok(token_id)) = (
+                        args.receiver_id.parse::<AccountId>(),
+                        func_call.receiver_id.parse::<AccountId>(),
+                    )
                 {
-                    out.direct.push((account, token));
+                    out.direct.push(Registration {
+                        account_id,
+                        token_id,
+                    });
                 }
             }
             // `ft_transfer_call` on a token contract. To the bulk contract →
             // register the bulk contract + every NEAR recipient; otherwise →
             // register the call's receiver.
             "ft_transfer_call" => {
-                let Some(args) = decode_action_args(action) else {
+                let Some(args) = decode_args::<FtTransferCallArgs>(&action.args) else {
                     continue;
                 };
-                let Ok(token) = call_receiver.parse::<AccountId>() else {
+                let Ok(token_id) = func_call.receiver_id.parse::<AccountId>() else {
                     continue;
                 };
-                let arg_receiver = args
-                    .get("receiver_id")
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                if arg_receiver == bulk_contract.as_str() {
-                    out.direct.push((bulk_contract.clone(), token.clone()));
-                    if let Some(list_id) = args.get("msg").and_then(Value::as_str) {
-                        out.bulk_lists.push(BulkList {
-                            token,
-                            list_id: list_id.to_string(),
-                        });
-                    }
-                } else if let Ok(account) = arg_receiver.parse::<AccountId>() {
-                    out.direct.push((account, token));
+                if args.receiver_id == bulk_contract.as_str() {
+                    out.push_bulk(bulk_contract, token_id, args.msg);
+                } else if let Ok(account_id) = args.receiver_id.parse::<AccountId>() {
+                    out.direct.push(Registration {
+                        account_id,
+                        token_id,
+                    });
                 }
             }
             // Intents bulk payment: `mt_transfer_call` to the bulk contract on
             // `intents.near`, where the underlying token is a `nep141:` asset.
             "mt_transfer_call" => {
-                let Some(args) = decode_action_args(action) else {
+                let Some(args) = decode_args::<MtTransferCallArgs>(&action.args) else {
                     continue;
                 };
-                let arg_receiver = args
-                    .get("receiver_id")
-                    .and_then(Value::as_str)
-                    .unwrap_or("");
-                if arg_receiver != bulk_contract.as_str() {
+                if args.receiver_id != bulk_contract.as_str() {
                     continue;
                 }
-                let token_id_field = args.get("token_id").and_then(Value::as_str).unwrap_or("");
-                let Some(contract) = extract_intents_contract(token_id_field) else {
+                let Some(contract) = extract_intents_contract(&args.token_id) else {
                     continue;
                 };
-                let Ok(token) = contract.parse::<AccountId>() else {
+                let Ok(token_id) = contract.parse::<AccountId>() else {
                     continue;
                 };
-                out.direct.push((bulk_contract.clone(), token.clone()));
-                if let Some(list_id) = args.get("msg").and_then(Value::as_str) {
-                    out.bulk_lists.push(BulkList {
-                        token,
-                        list_id: list_id.to_string(),
-                    });
-                }
+                out.push_bulk(bulk_contract, token_id, args.msg);
             }
             _ => {}
         }
@@ -264,12 +309,29 @@ fn classify_kind(kind: &Value, bulk_contract: &AccountId) -> ClassifiedTargets {
     out
 }
 
+impl ClassifiedTargets {
+    /// Register the bulk payment contract on `token` and queue its recipient
+    /// list (identified by `list_id`) for expansion.
+    fn push_bulk(&mut self, bulk_contract: &AccountId, token: AccountId, list_id: String) {
+        self.direct.push(Registration {
+            account_id: bulk_contract.clone(),
+            token_id: token.clone(),
+        });
+        if !list_id.is_empty() {
+            self.bulk_lists.push(BulkList {
+                token,
+                list_id,
+            });
+        }
+    }
+}
+
 /// Dedupe targets and enforce the per-approval cap.
-fn prepare_targets(targets: Vec<Target>) -> Result<Vec<Target>, String> {
+fn prepare_targets(targets: Vec<Registration>) -> Result<Vec<Registration>, String> {
     let mut seen = HashSet::new();
-    let deduped: Vec<Target> = targets
+    let deduped: Vec<Registration> = targets
         .into_iter()
-        .filter(|(account, token)| seen.insert((account.to_string(), token.to_string())))
+        .filter(|r| seen.insert((r.account_id.to_string(), r.token_id.to_string())))
         .collect();
 
     if deduped.len() > MAX_STORAGE_DEPOSITS {
@@ -285,18 +347,18 @@ fn prepare_targets(targets: Vec<Target>) -> Result<Vec<Target>, String> {
 /// Perform the required registrations concurrently, skipping already-registered
 /// accounts. Returns the number of `storage_deposit` calls actually sent (for
 /// `paid_near` accounting). Errors if a required registration fails.
-pub async fn execute_storage_deposits(
+pub(crate) async fn execute_storage_deposits(
     state: &Arc<AppState>,
-    targets: Vec<Target>,
+    targets: Vec<Registration>,
 ) -> Result<u32, String> {
     let deduped = prepare_targets(targets)?;
     if deduped.is_empty() {
         return Ok(0);
     }
 
-    let futures = deduped.into_iter().map(|(account, token)| {
+    let futures = deduped.into_iter().map(|registration| {
         let state = state.clone();
-        async move { register_one(&state, &account, &token).await }
+        async move { register_one(&state, &registration).await }
     });
     let results = futures::future::join_all(futures).await;
 
@@ -313,11 +375,13 @@ pub async fn execute_storage_deposits(
 
 /// Register a single account on a token contract. Returns `Ok(true)` when a
 /// `storage_deposit` was actually sent, `Ok(false)` when already registered.
-async fn register_one(
-    state: &Arc<AppState>,
-    account_id: &AccountId,
-    token_id: &AccountId,
-) -> Result<bool, String> {
+/// Retries transient send failures up to `MAX_REGISTER_ATTEMPTS` times.
+async fn register_one(state: &Arc<AppState>, registration: &Registration) -> Result<bool, String> {
+    let Registration {
+        account_id,
+        token_id,
+    } = registration;
+
     match check_storage_deposit(state, account_id.clone(), token_id.clone()).await {
         Ok(true) => return Ok(false),
         Ok(false) => {}
@@ -339,6 +403,41 @@ async fn register_one(
     }))
     .map_err(|e| e.to_string())?;
 
+    let mut last_error = String::new();
+    for attempt in 1..=MAX_REGISTER_ATTEMPTS {
+        match send_storage_deposit(state, token_id, args.clone()).await {
+            // storage_deposit is idempotent (registration_only refunds), so a
+            // retry after a partially-applied send is safe.
+            Ok(()) => return Ok(true),
+            Err(e) => {
+                last_error = e;
+                log::warn!(
+                    "storage_deposit attempt {}/{} failed for {} on {}: {}",
+                    attempt,
+                    MAX_REGISTER_ATTEMPTS,
+                    account_id,
+                    token_id,
+                    last_error
+                );
+                if attempt < MAX_REGISTER_ATTEMPTS {
+                    tokio::time::sleep(REGISTER_RETRY_DELAY).await;
+                }
+            }
+        }
+    }
+
+    Err(format!(
+        "storage_deposit failed for {} on {} after {} attempts: {}",
+        account_id, token_id, MAX_REGISTER_ATTEMPTS, last_error
+    ))
+}
+
+/// Send a single sponsor-signed `storage_deposit` transaction.
+async fn send_storage_deposit(
+    state: &Arc<AppState>,
+    token_id: &AccountId,
+    args: Vec<u8>,
+) -> Result<(), String> {
     Transaction::construct(state.signer_id.clone(), token_id.clone())
         .add_action(Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "storage_deposit".to_string(),
@@ -349,21 +448,10 @@ async fn register_one(
         .with_signer(state.signer.clone())
         .send_to(&state.network)
         .await
-        .map_err(|e| {
-            format!(
-                "Failed to send storage_deposit for {} on {}: {}",
-                account_id, token_id, e
-            )
-        })?
+        .map_err(|e| format!("send failed: {}", e))?
         .into_result()
-        .map_err(|e| {
-            format!(
-                "storage_deposit failed for {} on {}: {}",
-                account_id, token_id, e
-            )
-        })?;
-
-    Ok(true)
+        .map_err(|e| format!("execution failed: {}", e))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -377,6 +465,13 @@ mod tests {
 
     fn acc(s: &str) -> AccountId {
         s.parse().unwrap()
+    }
+
+    fn reg(account: &str, token: &str) -> Registration {
+        Registration {
+            account_id: acc(account),
+            token_id: acc(token),
+        }
     }
 
     /// Build a FunctionCall action with base64-encoded JSON args.
@@ -394,7 +489,7 @@ mod tests {
     fn transfer_ft_registers_recipient() {
         let kind = json!({ "Transfer": { "token_id": "usdc.near", "receiver_id": "alice.near" } });
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![(acc("alice.near"), acc("usdc.near"))]);
+        assert_eq!(out.direct, vec![reg("alice.near", "usdc.near")]);
         assert!(out.bulk_lists.is_empty());
     }
 
@@ -415,7 +510,7 @@ mod tests {
             vec![fc_action("ft_transfer", json!({ "receiver_id": "deposit.near", "amount": "5" }))],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![(acc("deposit.near"), acc("usdc.near"))]);
+        assert_eq!(out.direct, vec![reg("deposit.near", "usdc.near")]);
         assert!(out.bulk_lists.is_empty());
     }
 
@@ -430,7 +525,7 @@ mod tests {
             ],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![(acc("1click.near"), acc("wrap.near"))]);
+        assert_eq!(out.direct, vec![reg("1click.near", "wrap.near")]);
     }
 
     #[test]
@@ -443,7 +538,7 @@ mod tests {
             )],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![(acc("somecontract.near"), acc("usdc.near"))]);
+        assert_eq!(out.direct, vec![reg("somecontract.near", "usdc.near")]);
         assert!(out.bulk_lists.is_empty());
     }
 
@@ -457,7 +552,7 @@ mod tests {
             )],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![(bulk(), acc("usdc.near"))]);
+        assert_eq!(out.direct, vec![reg("bulkpayment.near", "usdc.near")]);
         assert_eq!(out.bulk_lists.len(), 1);
         assert_eq!(out.bulk_lists[0].token, acc("usdc.near"));
         assert_eq!(out.bulk_lists[0].list_id, "list-7");
@@ -478,7 +573,7 @@ mod tests {
             )],
         );
         let out = classify_kind(&kind, &bulk());
-        assert_eq!(out.direct, vec![(bulk(), acc("usdt.tether-token.near"))]);
+        assert_eq!(out.direct, vec![reg("bulkpayment.near", "usdt.tether-token.near")]);
         assert_eq!(out.bulk_lists.len(), 1);
         assert_eq!(out.bulk_lists[0].token, acc("usdt.tether-token.near"));
         assert_eq!(out.bulk_lists[0].list_id, "list-9");
@@ -517,17 +612,28 @@ mod tests {
     }
 
     #[test]
+    fn non_payment_kind_registers_nothing() {
+        // Unmodelled proposal kinds (e.g. ChangePolicy) must classify cleanly to none.
+        let kind = json!({ "ChangePolicy": { "policy": {} } });
+        let out = classify_kind(&kind, &bulk());
+        assert!(out.direct.is_empty());
+        assert!(out.bulk_lists.is_empty());
+    }
+
+    #[test]
     fn approve_id_parsing() {
         assert_eq!(
-            approve_id_from_act_proposal_args(&json!({ "id": 12, "action": "VoteApprove" })),
+            approve_proposal_id(&ActProposalArgs {
+                id: 12,
+                action: "VoteApprove".to_string()
+            }),
             Some(12)
         );
         assert_eq!(
-            approve_id_from_act_proposal_args(&json!({ "id": 12, "action": "VoteReject" })),
-            None
-        );
-        assert_eq!(
-            approve_id_from_act_proposal_args(&json!({ "action": "VoteApprove" })),
+            approve_proposal_id(&ActProposalArgs {
+                id: 12,
+                action: "VoteReject".to_string()
+            }),
             None
         );
     }
@@ -535,9 +641,9 @@ mod tests {
     #[test]
     fn prepare_targets_dedupes() {
         let targets = vec![
-            (acc("alice.near"), acc("usdc.near")),
-            (acc("alice.near"), acc("usdc.near")),
-            (acc("bob.near"), acc("usdc.near")),
+            reg("alice.near", "usdc.near"),
+            reg("alice.near", "usdc.near"),
+            reg("bob.near", "usdc.near"),
         ];
         let prepared = prepare_targets(targets).unwrap();
         assert_eq!(prepared.len(), 2);
@@ -545,8 +651,8 @@ mod tests {
 
     #[test]
     fn prepare_targets_enforces_cap() {
-        let targets: Vec<Target> = (0..(MAX_STORAGE_DEPOSITS + 1))
-            .map(|i| (acc(&format!("a{i}.near")), acc("usdc.near")))
+        let targets: Vec<Registration> = (0..(MAX_STORAGE_DEPOSITS + 1))
+            .map(|i| reg(&format!("a{i}.near"), "usdc.near"))
             .collect();
         assert!(prepare_targets(targets).is_err());
     }

--- a/nt-be/src/handlers/relay/submit.rs
+++ b/nt-be/src/handlers/relay/submit.rs
@@ -638,7 +638,7 @@ pub async fn relay_delegate_action(
     // Targets are derived from the authoritative on-chain proposal kind.
     let approved_proposal_ids =
         crate::handlers::relay::storage_deposit::vote_approve_proposal_ids(&signed_delegate_action);
-    let mut storage_deposit_targets = Vec::new();
+    let mut storage_deposit_targets = HashSet::new();
     for proposal_id in approved_proposal_ids {
         storage_deposit_targets.extend(
             crate::handlers::relay::storage_deposit::derive_targets_for_proposal(

--- a/nt-be/src/handlers/relay/submit.rs
+++ b/nt-be/src/handlers/relay/submit.rs
@@ -165,7 +165,7 @@ impl AllowedContractsFetchOutcome {
     }
 }
 
-fn extract_intents_contract(asset_id: &str) -> Option<&str> {
+pub(crate) fn extract_intents_contract(asset_id: &str) -> Option<&str> {
     asset_id.strip_prefix("nep141:").or_else(|| {
         asset_id
             .strip_prefix("nep245:")
@@ -633,6 +633,35 @@ pub async fn relay_delegate_action(
             })?;
     }
 
+    // Step 5b: For approving votes, perform any required NEP-141 storage_deposit
+    // registrations (sponsor-paid) before the act_proposal executes the transfer.
+    // Targets are derived from the authoritative on-chain proposal kind.
+    let approved_proposal_ids =
+        crate::handlers::relay::storage_deposit::vote_approve_proposal_ids(&signed_delegate_action);
+    let mut storage_deposit_targets = Vec::new();
+    for proposal_id in approved_proposal_ids {
+        storage_deposit_targets.extend(
+            crate::handlers::relay::storage_deposit::derive_targets_for_proposal(
+                &state,
+                &request.treasury_id,
+                proposal_id,
+            )
+            .await,
+        );
+    }
+    let storage_deposit_count = if storage_deposit_targets.is_empty() {
+        0
+    } else {
+        crate::handlers::relay::storage_deposit::execute_storage_deposits(
+            &state,
+            storage_deposit_targets,
+        )
+        .await
+        .map_err(|msg| error_response(StatusCode::BAD_REQUEST, msg))?
+    };
+    let storage_deposit_spent = crate::handlers::relay::storage_deposit::STORAGE_DEPOSIT_AMOUNT
+        .saturating_mul(u128::from(storage_deposit_count));
+
     // Step 6: Submit the wrapped delegate action transaction.
     let execution_result = Transaction::construct(state.signer_id.clone(), receiver_id)
         .add_action(Action::Delegate(Box::new(signed_delegate_action)))
@@ -651,7 +680,8 @@ pub async fn relay_delegate_action(
                         storage_cost.saturating_add(deposits)
                     } else {
                         deposits
-                    };
+                    }
+                    .saturating_add(storage_deposit_spent);
                     let near_spent_yocto: BigDecimal = near_spent.as_yoctonear().into();
                     let db_result = sqlx::query_as::<_, (i32,)>(
                         r#"

--- a/nt-be/src/handlers/token/storage_deposit/is_registered.rs
+++ b/nt-be/src/handlers/token/storage_deposit/is_registered.rs
@@ -28,7 +28,7 @@ pub struct StorageDepositResponse {
 }
 
 /// Check storage deposit for a single token
-async fn check_storage_deposit(
+pub(crate) async fn check_storage_deposit(
     state: &Arc<AppState>,
     account_id: AccountId,
     token_id: AccountId,

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx
@@ -829,7 +829,6 @@ export default function ExchangePage() {
                     treasuryId: selectedTreasury,
                     proposal: result.proposal,
                     proposalBond,
-                    additionalTransactions: result.additionalTransactions,
                     proposalType: "swap",
                 });
             }

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/utils/proposal-builder.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/utils/proposal-builder.ts
@@ -1,14 +1,13 @@
-import { IntentsQuoteResponse } from "@/lib/api";
-import { Token } from "@/components/token-input";
-import { isNearChainFtToken } from "@/lib/intents-fee";
+import type { IntentsQuoteResponse } from "@/lib/api";
+import type { Token } from "@/components/token-input";
 import { FT_TRANSFER_GAS, STORAGE_DEPOSIT_GAS } from "@/lib/near-ft-gas";
-import {
-    buildIntentsTransferProposal,
-    buildNep141StorageDepositTx,
-} from "@/lib/near-proposal-builders";
+import { buildIntentsTransferProposal } from "@/lib/near-proposal-builders";
 import { encodeToMarkdown, jsonToBase64 } from "@/lib/utils";
-import { getBatchStorageDepositIsRegistered } from "@/lib/api";
 import { NEAR_NETWORK_ID, WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
+
+// NEP-141 `storage_deposit` registrations are handled by the backend at
+// approval time (see nt-be relay storage_deposit derivation), so these builders
+// only produce the proposal — no extra storage transactions.
 
 interface ProposalBuilderParams {
     proposalData: IntentsQuoteResponse;
@@ -38,19 +37,6 @@ interface ProposalResult {
 
 interface ExchangeProposalResult {
     proposal: ProposalResult;
-    // All additional transactions needed (storage deposits, registrations, etc.)
-    additionalTransactions?: Array<{
-        receiverId: string;
-        actions: Array<{
-            type: "FunctionCall";
-            params: {
-                methodName: string;
-                args: any;
-                gas: string;
-                deposit: string;
-            };
-        }>;
-    }>;
 }
 
 /**
@@ -81,63 +67,13 @@ export function buildProposalDescription(
 }
 
 /**
- * Helper to check if a token is an FT token that requires storage deposit
- */
-function isFTToken(token: Token): boolean {
-    return isNearChainFtToken(token);
-}
-
-/**
- * Helper to normalize additional transactions array
- * Returns undefined if empty, otherwise returns the array
- */
-function normalizeAdditionalTransactions(
-    transactions: ExchangeProposalResult["additionalTransactions"],
-): ExchangeProposalResult["additionalTransactions"] {
-    return transactions && transactions.length > 0 ? transactions : undefined;
-}
-
-/**
  * Builds the proposal structure for native NEAR swaps
- * Checks if treasury is registered on wrap.near and only adds storage deposit if needed
- * Always adds deposit address registration (required for swap execution)
  */
-export async function buildNativeNEARProposal(
+export function buildNativeNEARProposal(
     params: ProposalBuilderParams,
-): Promise<ExchangeProposalResult> {
-    const {
-        proposalData,
-        sellToken,
-        receiveToken,
-        slippageTolerance,
-        treasuryId,
-    } = params;
+): ExchangeProposalResult {
+    const { proposalData, sellToken, receiveToken, slippageTolerance } = params;
     const amountInSmallestUnit = proposalData.quote.amountIn;
-
-    const additionalTransactions = [];
-
-    // Check if treasury is registered on wrap.near
-    const registrations = await getBatchStorageDepositIsRegistered([
-        { accountId: treasuryId, tokenId: WRAP_NEAR_TOKEN_ID },
-    ]);
-
-    const isTreasuryRegistered =
-        registrations.length > 0 && registrations[0].isRegistered;
-
-    // 1. Storage deposit for treasury account on wrap.near (only if not registered)
-    if (!isTreasuryRegistered) {
-        additionalTransactions.push(
-            buildNep141StorageDepositTx(WRAP_NEAR_TOKEN_ID, treasuryId),
-        );
-    }
-
-    // 2. Storage deposit for deposit address on wrap.near (always needed)
-    additionalTransactions.push(
-        buildNep141StorageDepositTx(
-            WRAP_NEAR_TOKEN_ID,
-            proposalData.quote.depositAddress,
-        ),
-    );
 
     return {
         proposal: {
@@ -170,9 +106,6 @@ export async function buildNativeNEARProposal(
                 },
             },
         },
-        additionalTransactions: normalizeAdditionalTransactions(
-            additionalTransactions,
-        ),
     };
 }
 
@@ -180,19 +113,11 @@ export async function buildNativeNEARProposal(
  * Builds the proposal structure for fungible token swaps
  * - For FT tokens (network === "near"): Use ft_transfer on the token contract
  * - For Intents tokens (network !== "near"): Use mt_transfer on intents.near
- * Checks treasury registration on receive token (if FT) and only adds if needed
- * Always adds deposit address registration on sell token (if FT, required for swap execution)
  */
-export async function buildFungibleTokenProposal(
+export function buildFungibleTokenProposal(
     params: ProposalBuilderParams,
-): Promise<ExchangeProposalResult> {
-    const {
-        proposalData,
-        sellToken,
-        receiveToken,
-        slippageTolerance,
-        treasuryId,
-    } = params;
+): ExchangeProposalResult {
+    const { proposalData, sellToken, receiveToken, slippageTolerance } = params;
     const amountInSmallestUnit = proposalData.quote.amountIn;
     const originAsset = sellToken.address;
     const isNearToken =
@@ -200,54 +125,21 @@ export async function buildFungibleTokenProposal(
         !sellToken.address.startsWith("nep141:") &&
         !sellToken.address.startsWith("nep245:");
 
-    const additionalTransactions = [];
-
-    // Check if receive token is FT and needs treasury registration
-    const isReceiveFT = isFTToken(receiveToken);
-    let isTreasuryRegisteredOnReceiveToken = false;
-
-    if (isReceiveFT && receiveToken.address) {
-        const registrations = await getBatchStorageDepositIsRegistered([
-            {
-                accountId: treasuryId,
-                tokenId: receiveToken.address,
-            },
-        ]);
-        isTreasuryRegisteredOnReceiveToken =
-            registrations[0]?.isRegistered || false;
-    }
+    const description = buildProposalDescription(
+        proposalData,
+        sellToken,
+        receiveToken,
+        slippageTolerance,
+    );
 
     if (isNearToken) {
-        // For NEAR FT tokens: always add deposit address registration on sell token
-        additionalTransactions.push(
-            buildNep141StorageDepositTx(
-                sellToken.address,
-                proposalData.quote.depositAddress,
-            ),
-        );
-
-        // Add treasury registration on receive token only if not registered and it's FT
-        if (
-            isReceiveFT &&
-            receiveToken.address &&
-            !isTreasuryRegisteredOnReceiveToken
-        ) {
-            additionalTransactions.push(
-                buildNep141StorageDepositTx(receiveToken.address, treasuryId),
-            );
-        }
-
+        // For NEAR FT tokens: ft_transfer on the token contract directly.
         return {
             proposal: {
-                description: buildProposalDescription(
-                    proposalData,
-                    sellToken,
-                    receiveToken,
-                    slippageTolerance,
-                ),
+                description,
                 kind: {
                     FunctionCall: {
-                        receiver_id: sellToken.address, // Call the token contract directly
+                        receiver_id: sellToken.address,
                         actions: [
                             {
                                 method_name: "ft_transfer",
@@ -263,75 +155,31 @@ export async function buildFungibleTokenProposal(
                     },
                 },
             },
-            additionalTransactions: normalizeAdditionalTransactions(
-                additionalTransactions,
-            ),
-        };
-    } else {
-        // For intents tokens: no deposit address registration needed
-        // Only add treasury registration on receive token if not registered and it's FT
-        if (
-            isReceiveFT &&
-            receiveToken.address &&
-            !isTreasuryRegisteredOnReceiveToken
-        ) {
-            additionalTransactions.push(
-                buildNep141StorageDepositTx(receiveToken.address, treasuryId),
-            );
-        }
-
-        return {
-            proposal: {
-                description: buildProposalDescription(
-                    proposalData,
-                    sellToken,
-                    receiveToken,
-                    slippageTolerance,
-                ),
-                kind: buildIntentsTransferProposal(
-                    originAsset,
-                    proposalData.quote.depositAddress,
-                    amountInSmallestUnit,
-                ),
-            },
-            additionalTransactions: normalizeAdditionalTransactions(
-                additionalTransactions,
-            ),
         };
     }
+
+    // For intents tokens: mt_transfer on intents.near.
+    return {
+        proposal: {
+            description,
+            kind: buildIntentsTransferProposal(
+                originAsset,
+                proposalData.quote.depositAddress,
+                amountInSmallestUnit,
+            ),
+        },
+    };
 }
 
 /**
  * Builds a proposal for depositing native NEAR to get wNEAR (FT NEAR)
  * This wraps native NEAR into wNEAR on wrap.near contract
  */
-export async function buildNEARDepositProposal(
+export function buildNEARDepositProposal(
     params: ProposalBuilderParams,
-): Promise<ExchangeProposalResult> {
-    const {
-        proposalData,
-        sellToken,
-        receiveToken,
-        slippageTolerance,
-        treasuryId,
-    } = params;
+): ExchangeProposalResult {
+    const { proposalData, sellToken, receiveToken, slippageTolerance } = params;
     const amountInSmallestUnit = proposalData.quote.amountIn;
-
-    // Check if treasury is registered on wrap.near
-    const registrations = await getBatchStorageDepositIsRegistered([
-        { accountId: treasuryId, tokenId: WRAP_NEAR_TOKEN_ID },
-    ]);
-    const isTreasuryRegistered =
-        registrations.length > 0 && registrations[0].isRegistered;
-
-    const additionalTransactions = [];
-
-    // Only add storage deposit if not registered
-    if (!isTreasuryRegistered) {
-        additionalTransactions.push(
-            buildNep141StorageDepositTx(WRAP_NEAR_TOKEN_ID, treasuryId),
-        );
-    }
 
     return {
         proposal: {
@@ -355,9 +203,6 @@ export async function buildNEARDepositProposal(
                 },
             },
         },
-        additionalTransactions: normalizeAdditionalTransactions(
-            additionalTransactions,
-        ),
     };
 }
 

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
@@ -13,10 +13,8 @@ import { default_near_token } from "@/constants/token";
 import { useTreasury } from "@/hooks/use-treasury";
 import { useTreasuryPolicy } from "@/hooks/use-treasury-queries";
 import { trackEvent } from "@/lib/analytics";
-import { getBatchStorageDepositIsRegistered } from "@/lib/api";
 import Big from "@/lib/big";
 import {
-    BULK_PAYMENT_CONTRACT_ID,
     buildApproveListProposal,
     generateListId,
     submitPaymentList,
@@ -35,7 +33,6 @@ import {
     buildBulkPaymentFormSchema,
     type EditPaymentFormValues,
 } from "./schemas";
-import { needsStorageDepositCheck } from "./utils";
 
 export default function BulkPaymentPage() {
     const t = useTranslations("pages.payments");
@@ -242,75 +239,8 @@ export default function BulkPaymentPage() {
                 proposalBond,
             });
 
-            // Build storage deposit transactions
-            const additionalTransactions: any[] = [];
-            if (needsStorageDepositCheck(selectedToken)) {
-                const gas = "30000000000000";
-                const depositInYocto = Big(0.00125)
-                    .mul(Big(10).pow(24))
-                    .toFixed();
-
-                // Check if bulk payment contract is registered
-                const bulkPaymentContractRegistration =
-                    await getBatchStorageDepositIsRegistered([
-                        {
-                            accountId: BULK_PAYMENT_CONTRACT_ID,
-                            tokenId: selectedToken.address,
-                        },
-                    ]);
-
-                const isBulkPaymentContractRegistered =
-                    bulkPaymentContractRegistration.length > 0 &&
-                    bulkPaymentContractRegistration[0].isRegistered;
-
-                // Add storage deposit for bulk payment contract if needed
-                if (!isBulkPaymentContractRegistered) {
-                    additionalTransactions.push({
-                        receiverId: selectedToken.address,
-                        actions: [
-                            {
-                                type: "FunctionCall",
-                                params: {
-                                    methodName: "storage_deposit",
-                                    args: {
-                                        account_id: BULK_PAYMENT_CONTRACT_ID,
-                                        registration_only: true,
-                                    } as any,
-                                    gas,
-                                    deposit: depositInYocto,
-                                },
-                            } as any,
-                        ],
-                    });
-                }
-
-                // Add storage deposits for unregistered recipients
-                const unregisteredRecipients = paymentData.filter(
-                    (payment) =>
-                        payment.isRegistered === false &&
-                        !payment.validationError,
-                );
-
-                for (const payment of unregisteredRecipients) {
-                    additionalTransactions.push({
-                        receiverId: selectedToken.address,
-                        actions: [
-                            {
-                                type: "FunctionCall",
-                                params: {
-                                    methodName: "storage_deposit",
-                                    args: {
-                                        account_id: payment.recipient,
-                                        registration_only: true,
-                                    } as any,
-                                    gas,
-                                    deposit: depositInYocto,
-                                },
-                            } as any,
-                        ],
-                    });
-                }
-            }
+            // NEP-141 storage_deposit registrations (bulk contract + recipients)
+            // are handled by the backend at approval time.
 
             // Submit payment list to backend first.
             const submitResult = await submitPaymentList({
@@ -361,7 +291,6 @@ export default function BulkPaymentPage() {
                         kind: proposal.args.proposal.kind,
                     },
                     proposalBond,
-                    additionalTransactions,
                     proposalType: "payment",
                 },
                 false,

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -78,7 +78,6 @@ import {
 import { FunctionCallKind, TransferKind } from "@/lib/proposals-api";
 import {
     buildDirectTransferKind,
-    buildDirectFtStorageDepositTxs,
     buildNativeNEARIntentsProposal,
     buildNearFtIntentsProposal,
 } from "./utils/proposal-builder";
@@ -991,9 +990,6 @@ export default function PaymentsPage() {
 
             let description = encodeToMarkdown({ notes: data.memo || "" });
             let proposalKind: FunctionCallKind | TransferKind;
-            let additionalTransactions:
-                | Array<{ receiverId: string; actions: any[] }>
-                | undefined;
 
             if (shouldUseIntents) {
                 const tokenForQuote = tokenClassification.tokenForIntentsQuote;
@@ -1047,7 +1043,6 @@ export default function PaymentsPage() {
                     description = buildIntentTransferDescription(data, quote);
                     const { depositAddress, amountIn } = quote.quote;
 
-                    let result;
                     if (isIntentsToken(data.token)) {
                         proposalKind = buildIntentsTransferProposal(
                             data.token.address,
@@ -1055,21 +1050,16 @@ export default function PaymentsPage() {
                             amountIn,
                         );
                     } else if (isNearNativeToken) {
-                        result = await buildNativeNEARIntentsProposal({
-                            treasuryId: treasuryId!,
+                        proposalKind = buildNativeNEARIntentsProposal(
                             depositAddress,
                             amountIn,
-                        });
-                        proposalKind = result.kind;
-                        additionalTransactions = result.additionalTransactions;
+                        );
                     } else {
-                        result = await buildNearFtIntentsProposal({
-                            tokenAddress: data.token.address,
+                        proposalKind = buildNearFtIntentsProposal(
+                            data.token.address,
                             depositAddress,
                             amountIn,
-                        });
-                        proposalKind = result.kind;
-                        additionalTransactions = result.additionalTransactions;
+                        );
                     }
                 }
             } else {
@@ -1080,16 +1070,6 @@ export default function PaymentsPage() {
                     directTransferAmount,
                     isConfidential,
                 );
-
-                if (isNearFtToken) {
-                    const storageTxs = await buildDirectFtStorageDepositTxs(
-                        trimmedAddress,
-                        data.token.address,
-                    );
-                    if (storageTxs.length > 0) {
-                        additionalTransactions = storageTxs;
-                    }
-                }
             }
 
             await createProposal(tPay("paymentSubmitted"), {
@@ -1099,7 +1079,6 @@ export default function PaymentsPage() {
                     kind: proposalKind!,
                 },
                 proposalBond,
-                additionalTransactions,
                 proposalType: "payment",
                 addressBookPayment: isAddressBookRecipientSelected,
             })

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -44,7 +44,11 @@ import { generateIntent, getIntentsQuote } from "@/lib/api";
 import type { IntentsQuoteResponse } from "@/lib/api";
 import Big from "@/lib/big";
 import { getBlockchainType } from "@/lib/blockchain-utils";
-import { buildIntentsTransferProposal } from "@/lib/near-proposal-builders";
+import {
+    buildIntentsTransferProposal,
+    buildNativeNearIntentsKind,
+    buildNearFtIntentsKind,
+} from "@/lib/near-proposal-builders";
 import {
     isEthImplicitNearAddress,
     isValidNearAddressFormat,
@@ -76,11 +80,7 @@ import {
     isNearChainNativeToken,
 } from "@/lib/intents-fee";
 import { FunctionCallKind, TransferKind } from "@/lib/proposals-api";
-import {
-    buildDirectTransferKind,
-    buildNativeNEARIntentsProposal,
-    buildNearFtIntentsProposal,
-} from "./utils/proposal-builder";
+import { buildDirectTransferKind } from "./utils/proposal-builder";
 
 function buildPaymentFormSchema(messages: {
     recipientMin: string;
@@ -1050,12 +1050,12 @@ export default function PaymentsPage() {
                             amountIn,
                         );
                     } else if (isNearNativeToken) {
-                        proposalKind = buildNativeNEARIntentsProposal(
+                        proposalKind = buildNativeNearIntentsKind(
                             depositAddress,
                             amountIn,
                         );
                     } else {
-                        proposalKind = buildNearFtIntentsProposal(
+                        proposalKind = buildNearFtIntentsKind(
                             data.token.address,
                             depositAddress,
                             amountIn,

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/utils/proposal-builder.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/utils/proposal-builder.ts
@@ -1,26 +1,16 @@
-import {
-    getBatchStorageDepositIsRegistered,
-    getStorageDepositIsRegistered,
-} from "@/lib/api";
 import type { FunctionCallKind, TransferKind } from "@/lib/proposals-api";
 import type { Token } from "@/components/token-input";
 import { default_near_token } from "@/constants/token";
-import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 import {
-    type AdditionalTx,
     buildNativeNearIntentsKind,
     buildNearFtIntentsKind,
-    buildNep141StorageDepositTx,
 } from "@/lib/near-proposal-builders";
 
-// ─── Shared types ─────────────────────────────────────────────────────────────
-
-export type ProposalResult = {
-    kind: FunctionCallKind | TransferKind;
-    additionalTransactions?: AdditionalTx[];
-};
-
 // ─── Proposal builders ────────────────────────────────────────────────────────
+//
+// NEP-141 `storage_deposit` registrations are handled by the backend at
+// approval time (see nt-be relay storage_deposit derivation), so these builders
+// only produce the proposal kind — no extra storage transactions.
 
 /**
  * Builds a Transfer kind for a direct NEAR or NEAR FT payment.
@@ -44,82 +34,25 @@ export function buildDirectTransferKind(
 }
 
 /**
- * Returns storage deposit txs needed for a direct NEAR FT transfer.
- * Empty array if the recipient is already registered on the token contract.
- */
-export async function buildDirectFtStorageDepositTxs(
-    recipient: string,
-    tokenAddress: string,
-): Promise<AdditionalTx[]> {
-    const isRegistered = await getStorageDepositIsRegistered(
-        recipient,
-        tokenAddress,
-    );
-    return isRegistered
-        ? []
-        : [buildNep141StorageDepositTx(tokenAddress, recipient)];
-}
-
-/**
- * Builds the proposal for native NEAR routed through Intents:
+ * Builds the proposal kind for native NEAR routed through Intents:
  *   1. near_deposit on wrap.near (wraps NEAR → wNEAR)
  *   2. ft_transfer on wrap.near to the 1Click deposit address
- * Also registers the treasury and deposit address on wrap.near if needed.
  */
-export async function buildNativeNEARIntentsProposal(params: {
-    treasuryId: string;
-    depositAddress: string;
-    amountIn: string;
-}): Promise<ProposalResult> {
-    const { treasuryId, depositAddress, amountIn } = params;
-
-    const registrations = await getBatchStorageDepositIsRegistered([
-        { accountId: treasuryId, tokenId: WRAP_NEAR_TOKEN_ID },
-        { accountId: depositAddress, tokenId: WRAP_NEAR_TOKEN_ID },
-    ]);
-
-    const additionalTransactions: AdditionalTx[] = [];
-    if (!registrations[0]?.isRegistered) {
-        additionalTransactions.push(
-            buildNep141StorageDepositTx(WRAP_NEAR_TOKEN_ID, treasuryId),
-        );
-    }
-    if (!registrations[1]?.isRegistered) {
-        additionalTransactions.push(
-            buildNep141StorageDepositTx(WRAP_NEAR_TOKEN_ID, depositAddress),
-        );
-    }
-
-    return {
-        kind: buildNativeNearIntentsKind(depositAddress, amountIn),
-        additionalTransactions:
-            additionalTransactions.length > 0
-                ? additionalTransactions
-                : undefined,
-    };
+export function buildNativeNEARIntentsProposal(
+    depositAddress: string,
+    amountIn: string,
+): FunctionCallKind {
+    return buildNativeNearIntentsKind(depositAddress, amountIn);
 }
 
 /**
- * Builds the proposal for a NEAR FT routed through Intents:
+ * Builds the proposal kind for a NEAR FT routed through Intents:
  *   ft_transfer on the token contract to the 1Click deposit address.
- * Also registers the deposit address on the token contract if needed.
  */
-export async function buildNearFtIntentsProposal(params: {
-    tokenAddress: string;
-    depositAddress: string;
-    amountIn: string;
-}): Promise<ProposalResult> {
-    const { tokenAddress, depositAddress, amountIn } = params;
-
-    const isDepositRegistered = await getStorageDepositIsRegistered(
-        depositAddress,
-        tokenAddress,
-    );
-
-    return {
-        kind: buildNearFtIntentsKind(tokenAddress, depositAddress, amountIn),
-        additionalTransactions: isDepositRegistered
-            ? undefined
-            : [buildNep141StorageDepositTx(tokenAddress, depositAddress)],
-    };
+export function buildNearFtIntentsProposal(
+    tokenAddress: string,
+    depositAddress: string,
+    amountIn: string,
+): FunctionCallKind {
+    return buildNearFtIntentsKind(tokenAddress, depositAddress, amountIn);
 }

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/utils/proposal-builder.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/utils/proposal-builder.ts
@@ -1,16 +1,13 @@
-import type { FunctionCallKind, TransferKind } from "@/lib/proposals-api";
+import type { TransferKind } from "@/lib/proposals-api";
 import type { Token } from "@/components/token-input";
 import { default_near_token } from "@/constants/token";
-import {
-    buildNativeNearIntentsKind,
-    buildNearFtIntentsKind,
-} from "@/lib/near-proposal-builders";
 
 // ─── Proposal builders ────────────────────────────────────────────────────────
 //
 // NEP-141 `storage_deposit` registrations are handled by the backend at
-// approval time (see nt-be relay storage_deposit derivation), so these builders
-// only produce the proposal kind — no extra storage transactions.
+// approval time (see nt-be relay storage_deposit derivation), so this builder
+// only produces the proposal kind — no extra storage transactions. The Intents
+// kinds are built directly via the `*Kind` helpers in @/lib/near-proposal-builders.
 
 /**
  * Builds a Transfer kind for a direct NEAR or NEAR FT payment.
@@ -31,28 +28,4 @@ export function buildDirectTransferKind(
             msg: null,
         },
     };
-}
-
-/**
- * Builds the proposal kind for native NEAR routed through Intents:
- *   1. near_deposit on wrap.near (wraps NEAR → wNEAR)
- *   2. ft_transfer on wrap.near to the 1Click deposit address
- */
-export function buildNativeNEARIntentsProposal(
-    depositAddress: string,
-    amountIn: string,
-): FunctionCallKind {
-    return buildNativeNearIntentsKind(depositAddress, amountIn);
-}
-
-/**
- * Builds the proposal kind for a NEAR FT routed through Intents:
- *   ft_transfer on the token contract to the 1Click deposit address.
- */
-export function buildNearFtIntentsProposal(
-    tokenAddress: string,
-    depositAddress: string,
-    amountIn: string,
-): FunctionCallKind {
-    return buildNearFtIntentsKind(tokenAddress, depositAddress, amountIn);
 }

--- a/nt-fe/lib/near-proposal-builders.ts
+++ b/nt-fe/lib/near-proposal-builders.ts
@@ -1,49 +1,7 @@
 import type { FunctionCallKind } from "@/lib/proposals-api";
-import {
-    FT_TRANSFER_GAS,
-    STORAGE_DEPOSIT_AMOUNT,
-    STORAGE_DEPOSIT_GAS,
-} from "@/lib/near-ft-gas";
+import { FT_TRANSFER_GAS, STORAGE_DEPOSIT_GAS } from "@/lib/near-ft-gas";
 import { jsonToBase64 } from "@/lib/utils";
 import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
-
-type FunctionCallTxAction = {
-    type: "FunctionCall";
-    params: {
-        methodName: string;
-        args: Record<string, unknown>;
-        gas: string;
-        deposit: string;
-    };
-};
-
-export type AdditionalTx = {
-    receiverId: string;
-    actions: FunctionCallTxAction[];
-};
-
-export function buildNep141StorageDepositTx(
-    receiverId: string,
-    accountId: string,
-): AdditionalTx {
-    return {
-        receiverId,
-        actions: [
-            {
-                type: "FunctionCall",
-                params: {
-                    methodName: "storage_deposit",
-                    args: {
-                        account_id: accountId,
-                        registration_only: true,
-                    },
-                    gas: STORAGE_DEPOSIT_GAS,
-                    deposit: STORAGE_DEPOSIT_AMOUNT,
-                },
-            },
-        ],
-    };
-}
 
 export function buildIntentsTransferProposal(
     tokenAddress: string,


### PR DESCRIPTION
#735

## Problem

Required NEP-141 `storage_deposit` registrations were built on the frontend and signed by the user alongside the proposal in one `signDelegateActions` call. This:
- surfaced extra `storage_deposit` transactions in the signing flow (friction),
- paid the deposit from the treasury sponsor and yet bother user to sign the transaction they don't need to sign (friction),
- triggered the **NEAR Mobile nonce-increment bug** (multiple delegate actions per signature).

## Change

Storage deposits are now performed by the **backend, sponsor-paid, at approval time**, derived from the authoritative on-chain proposal — never the description.

**Backend** (`nt-be`)
- New `handlers/relay/storage_deposit.rs`:
  - `vote_approve_proposal_ids` — collects `VoteApprove` ids from the relayed delegate action.
  - `classify_kind` / `derive_targets_for_proposal` — `get_proposal(id)` → maps the proposal kind to `(account, token)` targets: Sputnik `Transfer`-FT recipient; `ft_transfer` receiver; `ft_transfer_call`/`mt_transfer_call` to the bulk contract → bulk contract + every NEAR recipient (via `view_list`, `nep141:` prefix stripped through the reused `extract_intents_contract`). Everything else → none.
  - `execute_storage_deposits` — dedupe, cap (≤200), skip already-registered (`check_storage_deposit`), send `storage_deposit` concurrently.
- `submit.rs` — runs the above before submitting an approving vote; folds spend into `paid_near`; no extra gas credit. `w_execute_signed` / non-vote paths untouched.
- 12 unit tests for the derivation + cap.

**Frontend** (`nt-fe`)
- Removed all `storage_deposit` construction from payments/exchange/bulk builders and pages; dropped `additionalTransactions` from `createProposal`; removed `buildNep141StorageDepositTx`. A proposal is now a **single delegate action**.

## Out of scope

Swap **receive-token** (`tokenOut`) treasury registration is intentionally not handled — it lives only in the proposal description, not in the on-chain action.

## Verification
- `cargo build` ✅; `cargo test relay::storage_deposit` → 12 passed ✅ (run against a local Postgres + migrations).
- Biome 2.2.0 on changed files: no new errors.
- E2E not run (needs sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)