### PR TITLE
feat: add canonical near network in deposit flow

### DIFF
--- a/nt-be/src/constants/mod.rs
+++ b/nt-be/src/constants/mod.rs
@@ -13,6 +13,7 @@ pub const LOCKUP_CONTRACT_ID: &AccountIdRef = AccountIdRef::new_or_panic("lockup
 
 pub const NEAR_ICON: &str = "https://s2.coinmarketcap.com/static/img/coins/128x128/6535.png";
 pub const WRAP_NEAR_ICON: &str = "https://s2.coinmarketcap.com/static/img/coins/128x128/6535.png";
+pub const NEAR_DECIMALS: u8 = 24;
 pub const BLOCKS_PER_HOUR: u64 = 300; // Approximate blocks per hour on NEAR
 
 pub const TREASURY_FACTORY_CONTRACT_ID: &AccountIdRef =

--- a/nt-be/src/handlers/intents/bridge_tokens.rs
+++ b/nt-be/src/handlers/intents/bridge_tokens.rs
@@ -2,7 +2,11 @@ use crate::{
     constants::intents_tokens::{find_unified_asset_id, get_tokens_map},
     utils::cache::CacheTier,
 };
-use axum::{Json, extract::State, http::StatusCode};
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -10,9 +14,14 @@ use std::sync::Arc;
 
 use super::supported_tokens::fetch_supported_tokens_data;
 use crate::{
-    AppState, constants::intents_chains::ChainIcons,
+    AppState,
+    constants::NEAR_DECIMALS,
+    constants::intents_chains::{ChainIcons, get_chain_metadata_by_name},
     handlers::token::metadata::fetch_tokens_metadata_enriched,
 };
+
+const NEAR_MAINNET_NETWORK_ID: &str = "near:mainnet";
+const BLOCKED_NETWORK_IDS: [&str; 1] = ["nep141:nbtc.bridge.near"];
 
 fn metadata_lookup_key(intents_id: &str) -> String {
     format!("intents.near:{intents_id}")
@@ -38,6 +47,8 @@ pub struct NetworkOption {
     pub decimals: u8,
     pub min_deposit_amount: Option<String>,
     pub min_withdrawal_amount: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supports_public_near_deposit_source: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -55,10 +66,19 @@ pub struct DepositAssetsResponse {
     pub assets: Vec<AssetOption>,
 }
 
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BridgeTokensQuery {
+    #[serde(default)]
+    pub include_near_network: bool,
+}
+
 pub async fn get_bridge_tokens(
+    Query(query): Query<BridgeTokensQuery>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<DepositAssetsResponse>, (StatusCode, String)> {
-    let cache_key = "deposit-assets".to_string();
+    let include_near_network = query.include_near_network;
+    let cache_key = format!("deposit-assets:include-near:{}", include_near_network);
     let state_clone = state.clone();
 
     let result = state
@@ -113,6 +133,10 @@ pub async fn get_bridge_tokens(
                 else {
                     continue;
                 };
+
+                if BLOCKED_NETWORK_IDS.contains(&intents_id) {
+                    continue;
+                }
 
                 let lookup_key = metadata_lookup_key(intents_id);
                 let Some(meta) = metadata_map.get(&lookup_key) else {
@@ -180,11 +204,67 @@ pub async fn get_bridge_tokens(
                         decimals: meta.decimals,
                         min_deposit_amount,
                         min_withdrawal_amount,
+                        supports_public_near_deposit_source: None,
                     });
                 }
             }
 
             let mut assets: Vec<AssetOption> = asset_map.into_values().collect();
+
+            if include_near_network {
+                let near_chain_icons = get_chain_metadata_by_name("near")
+                    .map(|metadata| metadata.icon)
+                    .or_else(|| {
+                        Some(ChainIcons {
+                            icon: "https://near.com/static/icons/network/near.svg".to_string(),
+                        })
+                    });
+                // Normalize each asset to at most one canonical NEAR network entry:
+                // - if a "near" network already exists, preserve its token id/decimals
+                // - otherwise, synthesize a NEAR entry for assets that have networks
+                //   (using near:mainnet id as fallback token id)
+                // - skip assets that have no networks at all
+                for asset in &mut assets {
+                    let existing_near_network = asset
+                        .networks
+                        .iter()
+                        .find(|network| network.name.eq_ignore_ascii_case("near"));
+
+                    let (canonical_near_token_id, selection_source) =
+                        if let Some(network) = existing_near_network {
+                            (Some(network.id.clone()), "has_near_network")
+                        } else if !asset.networks.is_empty() {
+                            (Some(NEAR_MAINNET_NETWORK_ID.to_string()), "no_near_network")
+                        } else {
+                            (None, "no_networks_skip")
+                        };
+                    let canonical_near_decimals =
+                        existing_near_network.map_or(NEAR_DECIMALS, |network| network.decimals);
+                    let Some(canonical_near_token_id) = canonical_near_token_id else {
+                        continue;
+                    };
+
+                    asset.networks.retain(|network| {
+                        !network.name.eq_ignore_ascii_case("near")
+                            && network.id != NEAR_MAINNET_NETWORK_ID
+                            && network.chain_id != NEAR_MAINNET_NETWORK_ID
+                    });
+
+                    asset.networks.push(NetworkOption {
+                        id: canonical_near_token_id,
+                        name: "near".to_string(),
+                        symbol: asset.asset_name.clone(),
+                        chain_icons: near_chain_icons.clone(),
+                        chain_id: NEAR_MAINNET_NETWORK_ID.to_string(),
+                        decimals: canonical_near_decimals,
+                        min_deposit_amount: None,
+                        min_withdrawal_amount: None,
+                        supports_public_near_deposit_source: Some(
+                            selection_source == "has_near_network",
+                        ),
+                    });
+                }
+            }
 
             // Sort assets by symbol alphabetically
             assets.sort_by(|a, b| a.id.cmp(&b.id));

--- a/nt-be/src/handlers/user/assets.rs
+++ b/nt-be/src/handlers/user/assets.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use crate::{
     AppState,
     constants::{
-        INTENTS_CONTRACT_ID, NEAR_ICON, REF_FINANCE_CONTRACT_ID,
+        INTENTS_CONTRACT_ID, NEAR_DECIMALS, NEAR_ICON, REF_FINANCE_CONTRACT_ID,
         intents_chains::ChainIcons,
         intents_tokens::{find_token_by_symbol, find_unified_asset_id},
     },
@@ -76,7 +76,7 @@ pub struct TokenMetadata {
 impl TokenMetadata {
     pub fn near() -> Self {
         Self {
-            decimals: 24,
+            decimals: NEAR_DECIMALS,
             symbol: "NEAR".to_string(),
             name: "NEAR".to_string(),
             icon: NEAR_ICON.to_string(),

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -72,6 +72,7 @@ interface SelectOption {
     gradient?: string;
     networks?: BridgeNetwork[];
     chainId?: string;
+    supportsPublicNearDepositSource?: boolean;
 }
 
 const assetSchema = z.object({
@@ -180,6 +181,8 @@ function toNetworkOption(network: BridgeNetwork): SelectOption {
         icon: iconUrl || network.name.charAt(0),
         gradient: "bg-linear-to-br from-green-500 to-teal-500",
         chainId: network.chainId,
+        supportsPublicNearDepositSource:
+            network.supportsPublicNearDepositSource,
     };
 }
 
@@ -382,7 +385,12 @@ export function DepositModal({
     const selectedAsset = form.watch("asset");
     const selectedNetwork = form.watch("network");
     const { data: bridgeAssets = [], isLoading: isLoadingAssets } =
-        useBridgeTokens(true);
+        useBridgeTokens(true, { includeNearNetwork: true });
+
+    const invalidatePendingAddressRequest = useCallback(() => {
+        latestAddressRequestRef.current += 1;
+        setIsLoadingAddress(false);
+    }, []);
 
     useEffect(() => {
         if (selectedAsset && selectedNetwork) {
@@ -816,10 +824,13 @@ export function DepositModal({
     // Handle asset selection - show all assets but update network list
     const handleAssetSelect = useCallback(
         (asset: SelectOption) => {
+            invalidatePendingAddressRequest();
+            setAddressSourceTab("public");
             form.setValue("asset", asset);
             form.clearErrors();
 
             setDepositInfo(null);
+            setSingleUseExpiresAt(null);
 
             const availableNetworks = assetNetworksMap.get(asset.id) || [];
             dispatchDepositAssets({
@@ -837,33 +848,56 @@ export function DepositModal({
             // Auto-select network only when there is exactly one option.
             if (availableNetworks.length === 1) {
                 form.setValue("network", availableNetworks[0]);
-            } else if (
-                selectedNetwork &&
-                !availableNetworks.some((n) => n.id === selectedNetwork.id)
-            ) {
+            } else {
                 form.setValue("network", null);
             }
         },
-        [form, assetNetworksMap, selectedNetwork, networkBalancesByAsset],
+        [
+            form,
+            assetNetworksMap,
+            networkBalancesByAsset,
+            invalidatePendingAddressRequest,
+        ],
     );
 
     // Handle network selection
     const handleNetworkSelect = useCallback(
         (network: SelectOption) => {
+            invalidatePendingAddressRequest();
+            setAddressSourceTab("public");
             form.setValue("network", network);
             form.clearErrors();
 
             setDepositInfo(null);
+            setSingleUseExpiresAt(null);
         },
-        [form],
+        [form, invalidatePendingAddressRequest],
     );
 
+    console.log({ selectedAsset });
     // Fetch deposit address when both asset and network are selected
     useEffect(() => {
         const fetchAddress = async () => {
             if (!selectedNetwork || !selectedAsset) {
                 setDepositInfo(null);
                 setSingleUseExpiresAt(null);
+                return;
+            }
+
+            const isNearNetwork = (
+                selectedNetwork.chainId ?? selectedNetwork.id
+            )
+                .toLowerCase()
+                .includes(NEAR_NETWORK_ID);
+            const isConfidentialNearFallbackOnly =
+                isConfidential &&
+                isNearNetwork &&
+                selectedBridgeNetwork?.supportsPublicNearDepositSource ===
+                    false;
+            if (isConfidentialNearFallbackOnly) {
+                setDepositInfo(null);
+                setSingleUseExpiresAt(null);
+                setIsLoadingAddress(false);
                 return;
             }
             const requestId = ++latestAddressRequestRef.current;
@@ -949,6 +983,7 @@ export function DepositModal({
         if (selectedAsset && selectedNetwork) {
             fetchAddress();
         } else {
+            invalidatePendingAddressRequest();
             setDepositInfo(null);
             setSingleUseExpiresAt(null);
         }
@@ -959,11 +994,16 @@ export function DepositModal({
         selectedBridgeNetwork,
         t,
         treasuryId,
+        invalidatePendingAddressRequest,
     ]);
 
     const isNearNetworkSelected = isNearNetworkId(
         selectedNetwork?.chainId ?? selectedNetwork?.id,
     );
+    const isConfidentialNearFallbackOnly =
+        isConfidential &&
+        isNearNetworkSelected &&
+        selectedBridgeNetwork?.supportsPublicNearDepositSource === false;
 
     const formatAddress = useCallback(
         (address: string) => {
@@ -990,9 +1030,13 @@ export function DepositModal({
         [isNearNetworkSelected],
     );
 
-    const canSwitchDepositSource = isConfidential && isNearNetworkSelected;
+    const canSwitchDepositSource =
+        isConfidential &&
+        isNearNetworkSelected &&
+        !isConfidentialNearFallbackOnly;
     const isConfidentialSourceSelected =
-        canSwitchDepositSource && addressSourceTab === "confidential";
+        isConfidentialNearFallbackOnly ||
+        (canSwitchDepositSource && addressSourceTab === "confidential");
     const showConfidentialDepositWarning =
         isConfidential && !isConfidentialSourceSelected;
     const displayDepositInfo = isConfidentialSourceSelected
@@ -1030,10 +1074,23 @@ export function DepositModal({
     }, [singleUseExpiresAt, countdownNow]);
 
     useEffect(() => {
-        if (!canSwitchDepositSource && addressSourceTab !== "public") {
+        if (
+            isConfidentialNearFallbackOnly &&
+            addressSourceTab !== "confidential"
+        ) {
+            setAddressSourceTab("confidential");
+        } else if (
+            !isConfidentialNearFallbackOnly &&
+            !canSwitchDepositSource &&
+            addressSourceTab !== "public"
+        ) {
             setAddressSourceTab("public");
         }
-    }, [canSwitchDepositSource, addressSourceTab]);
+    }, [
+        canSwitchDepositSource,
+        addressSourceTab,
+        isConfidentialNearFallbackOnly,
+    ]);
 
     useEffect(() => {
         setHasAcknowledgedSingleUse(false);
@@ -1233,7 +1290,8 @@ export function DepositModal({
                                 </p>
                             </div>
 
-                            {canSwitchDepositSource && (
+                            {(canSwitchDepositSource ||
+                                isConfidentialNearFallbackOnly) && (
                                 <Tabs
                                     value={addressSourceTab}
                                     onValueChange={(value) =>
@@ -1244,13 +1302,17 @@ export function DepositModal({
                                     className="gap-0"
                                 >
                                     <TabsList className="px-2 pb-0 border-b border-border">
-                                        <TabsTrigger
-                                            value="public"
-                                            className="text-base font-semibold pb-2"
-                                        >
-                                            <Globe className="size-5" />
-                                            <span>{t("tabs.fromPublic")}</span>
-                                        </TabsTrigger>
+                                        {canSwitchDepositSource && (
+                                            <TabsTrigger
+                                                value="public"
+                                                className="text-base font-semibold pb-2"
+                                            >
+                                                <Globe className="size-5" />
+                                                <span>
+                                                    {t("tabs.fromPublic")}
+                                                </span>
+                                            </TabsTrigger>
+                                        )}
                                         <TabsTrigger
                                             value="confidential"
                                             className="text-base font-semibold pb-2"
@@ -1558,6 +1620,7 @@ export function DepositModal({
             showAddressLoading,
             displayDepositInfo,
             canSwitchDepositSource,
+            isConfidentialNearFallbackOnly,
             addressSourceTab,
             showConfidentialDepositWarning,
             shouldBlurConfidentialAddress,

--- a/nt-fe/hooks/use-bridge-tokens.ts
+++ b/nt-fe/hooks/use-bridge-tokens.ts
@@ -11,6 +11,7 @@ export interface BridgeNetwork {
     decimals: number;
     minDepositAmount?: string;
     minWithdrawalAmount?: string;
+    supportsPublicNearDepositSource?: boolean;
 }
 
 export interface BridgeAsset {
@@ -23,11 +24,20 @@ export interface BridgeAsset {
 /**
  * Hook to fetch bridge tokens with React Query
  */
-export function useBridgeTokens(enabled: boolean = true) {
+export function useBridgeTokens(
+    enabled: boolean = true,
+    options?: {
+        includeNearNetwork?: boolean;
+    },
+) {
+    const includeNearNetwork = options?.includeNearNetwork ?? false;
+
     return useQuery({
-        queryKey: ["bridgeTokens"],
+        queryKey: ["bridgeTokens", includeNearNetwork],
         queryFn: async () => {
-            const fetchedAssets = await fetchBridgeTokens();
+            const fetchedAssets = await fetchBridgeTokens({
+                includeNearNetwork,
+            });
 
             const formattedAssets: BridgeAsset[] = fetchedAssets.map(
                 (asset: any) => {
@@ -57,6 +67,8 @@ export function useBridgeTokens(enabled: boolean = true) {
                             decimals: network.decimals,
                             minDepositAmount: network.minDepositAmount,
                             minWithdrawalAmount: network.minWithdrawalAmount,
+                            supportsPublicNearDepositSource:
+                                network.supportsPublicNearDepositSource,
                         })),
                     };
                 },

--- a/nt-fe/lib/bridge-api.ts
+++ b/nt-fe/lib/bridge-api.ts
@@ -7,10 +7,18 @@ const BACKEND_API_BASE = `${process.env.NEXT_PUBLIC_BACKEND_API_BASE}/api`;
  * Returns a list of assets with their available networks for bridging
  * Used for both deposit and exchange functionality
  */
-export async function fetchBridgeTokens() {
+export async function fetchBridgeTokens(options?: {
+    includeNearNetwork?: boolean;
+}) {
+    const includeNearNetwork = options?.includeNearNetwork ?? false;
     try {
         const response = await axios.get(
             `${BACKEND_API_BASE}/intents/bridge-tokens`,
+            {
+                params: {
+                    includeNearNetwork,
+                },
+            },
         );
 
         return response.data.assets || [];


### PR DESCRIPTION
#720 

Adds NEAR network handling in deposit flow for public and confidential treasuries.

- Public: NEAR network always resolves to treasury account.
<img width="3398" height="1922" alt="image" src="https://github.com/user-attachments/assets/bc25d281-b7a6-46b7-9b8e-11da78c71e93" />


- Confidential:
  - Existing NEAR-network assets keep current source behavior.
  - Fallback NEAR entries show only near.com path under NEAR network.
  
<img width="1699" height="961" alt="image" src="https://github.com/user-attachments/assets/3c0fe949-6730-41e6-a685-9274d6748e80" />
