### PR TITLE
fix: require explicit recipient network selection

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
@@ -70,6 +70,7 @@ interface PaymentFormSectionProps<
     /** Hide recipient network selector (e.g. bulk payments). Default false. */
     hideRecipientNetwork?: boolean;
     bridgeAssets?: BridgeAsset[];
+    isBridgeAssetsLoading?: boolean;
 }
 
 export function PaymentFormSection<
@@ -93,6 +94,7 @@ export function PaymentFormSection<
     destinationNetworkNameFieldName,
     hideRecipientNetwork = false,
     bridgeAssets = [],
+    isBridgeAssetsLoading = false,
 }: PaymentFormSectionProps<TFieldValues, TTokenPath>) {
     const t = useTranslations("paymentFormSection");
     const tRecipientNetwork = useTranslations("recipientNetworkSelect");
@@ -452,6 +454,7 @@ export function PaymentFormSection<
                             }}
                             bridgeAssets={bridgeAssets}
                             token={token}
+                            isBridgeAssetsLoading={isBridgeAssetsLoading}
                         />
                     )}
                 />

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -43,6 +43,7 @@ interface RecipientNetworkSelectProps {
      */
     recipient: string;
     bridgeAssets: BridgeAsset[];
+    isBridgeAssetsLoading?: boolean;
     sectionRules: SectionRule<RecipientNetworkRuleOption>[];
     /**
      * Fires when the user picks a network. Carries the raw network name so
@@ -116,6 +117,7 @@ export function RecipientNetworkSelect({
     token,
     recipient,
     bridgeAssets,
+    isBridgeAssetsLoading = false,
     sectionRules,
     onNetworkChange,
 }: RecipientNetworkSelectProps) {
@@ -209,7 +211,8 @@ export function RecipientNetworkSelect({
     }, [enrichedOptions, sectionRules]);
 
     const hasCompatibleNetwork = compatibleOptions.length > 0;
-    const isDisabled = !recipient || !hasCompatibleNetwork;
+    const isDisabled =
+        !recipient || isBridgeAssetsLoading || !hasCompatibleNetwork;
 
     // Clear the selection when the address no longer matches it (e.g. user
     // edited the address into a different chain's format).

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -220,20 +220,8 @@ export function RecipientNetworkSelect({
         onChange("");
     }, [value, availableOptions, compatibleOptions, onChange]);
 
-    // Auto-pick when there's exactly one compatible network and nothing's
-    // selected (or the selection no longer matches). Skips when the user
-    // already chose a still-compatible network.
-    useEffect(() => {
-        if (compatibleOptions.length !== 1) return;
-        const only = compatibleOptions[0];
-        if (value === only.id) return;
-        if (value && compatibleOptions.some((o) => o.id === value)) return;
-        const timeoutId = window.setTimeout(() => {
-            onChange(only.id);
-            onNetworkChange?.(only);
-        }, 150);
-        return () => window.clearTimeout(timeoutId);
-    }, [compatibleOptions, value, onChange, onNetworkChange]);
+    // Intentionally do not auto-select a network from recipient input.
+    // Users must explicitly confirm recipient network to avoid surprise picks.
     const placeholderText = !recipient
         ? t("enterAddressFirst")
         : !hasCompatibleNetwork

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -220,8 +220,6 @@ export function RecipientNetworkSelect({
         onChange("");
     }, [value, availableOptions, compatibleOptions, onChange]);
 
-    // Intentionally do not auto-select a network from recipient input.
-    // Users must explicitly confirm recipient network to avoid surprise picks.
     const placeholderText = !recipient
         ? t("enterAddressFirst")
         : !hasCompatibleNetwork

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -125,6 +125,7 @@ interface Step1Props extends StepProps {
     onMaxSet?: (maxAmount: string) => void;
     onAddressBookSelectionChange?: (isFromAddressBook: boolean) => void;
     bridgeAssets?: BridgeAsset[];
+    isBridgeAssetsLoading?: boolean;
 }
 
 function Step1({
@@ -138,6 +139,7 @@ function Step1({
     onMaxSet,
     onAddressBookSelectionChange,
     bridgeAssets = [],
+    isBridgeAssetsLoading = false,
 }: Step1Props) {
     const tPay = useTranslations("payments");
     const form = useFormContext<PaymentFormValues>();
@@ -244,6 +246,7 @@ function Step1({
                 onMaxSet={onMaxSet}
                 onAddressBookSelectionChange={onAddressBookSelectionChange}
                 bridgeAssets={bridgeAssets}
+                isBridgeAssetsLoading={isBridgeAssetsLoading}
             />
         </PageCard>
     );
@@ -694,9 +697,11 @@ export default function PaymentsPage() {
         () => preferredNetworks.join(","),
         [preferredNetworks],
     );
-    const { data: bridgeAssets = [] } = useBridgeTokens(
-        preferredNetworks.length > 0,
-    );
+    const {
+        data: bridgeAssets = [],
+        isLoading: isBridgeAssetsLoading,
+        isFetching: isBridgeAssetsFetching,
+    } = useBridgeTokens(true);
 
     const defaultToken = useMemo(() => {
         const fallbackToken = default_near_token(isConfidential);
@@ -1227,6 +1232,8 @@ export default function PaymentsPage() {
                     onAddressBookSelectionChange:
                         setIsAddressBookRecipientSelected,
                     bridgeAssets,
+                    isBridgeAssetsLoading:
+                        isBridgeAssetsLoading || isBridgeAssetsFetching,
                 },
             },
             {
@@ -1256,6 +1263,8 @@ export default function PaymentsPage() {
             isLoadingLiveQuote,
             isFetchingLiveQuote,
             bridgeAssets,
+            isBridgeAssetsLoading,
+            isBridgeAssetsFetching,
             quoteContextKey,
         ],
     );


### PR DESCRIPTION

This PR fixes 3 issues in Payments network selection:

1) We did not handle loading state for bridge assets.
    While assets were still loading, the network list showed only near.com, which looked wrong.

2) Bridge assets were not fetched in some prefilled-token flows.
If the token selector was never opened, bridge assets sometimes did not load, so users did not see full network options.

3) Recipient network was auto-selected when there was only one compatible option.
This was removed, so users now choose the recipient network manually.


https://github.com/user-attachments/assets/ddd4c9ed-d184-4364-b985-dc540e1fdcf6

