### PR TITLE
Fix confidential receipt pricing 

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
@@ -60,7 +60,10 @@ import {
     formatUserDate,
     cn,
 } from "@/lib/utils";
-import { recordReceiptMetric } from "@/lib/proposals-api";
+import {
+    recordReceiptMetric,
+    type SwapQuoteResponse,
+} from "@/lib/proposals-api";
 import type { BatchPaymentRequestData } from "@/features/proposals/types/index";
 import { LANDING_PAGE } from "@/constants/config";
 
@@ -760,18 +763,40 @@ export default function RequestReceiptPage({
             ? transactionDate.toISOString()
             : null;
     const shouldLoadHistoricalPrices =
+        isSingleReceiptProposal && !hasDepositAddress && !!executedAtIso;
+    const shouldFetchQuoteByDepositAddress =
         isSingleReceiptProposal &&
-        isExecutableReceipt &&
-        !hasDepositAddress &&
-        !!executedAtIso;
+        !!depositAddress &&
+        !isConfidentialRequestProposal;
     const {
         data: quoteByDepositAddress,
         isLoading: isLoadingQuoteByDepositAddress,
     } = useQuoteByDepositAddress(
         depositAddress,
         undefined,
-        isSingleReceiptProposal && isExecutableReceipt && !!depositAddress,
+        shouldFetchQuoteByDepositAddress,
     );
+    const confidentialQuote = useMemo<SwapQuoteResponse | null>(() => {
+        if (!isConfidentialRequestProposal) {
+            return null;
+        }
+
+        const quote =
+            proposal?.confidential_metadata?.quote_metadata?.quote ?? null;
+        if (!quote) {
+            return null;
+        }
+
+        return {
+            amountInFormatted: quote.amountInFormatted ?? null,
+            amountOutFormatted: quote.amountOutFormatted ?? null,
+            amountInUsd: quote.amountInUsd ?? null,
+            amountOutUsd: quote.amountOutUsd ?? null,
+        };
+    }, [isConfidentialRequestProposal, proposal?.confidential_metadata]);
+    const effectiveQuote = isConfidentialRequestProposal
+        ? confidentialQuote
+        : quoteByDepositAddress;
     const {
         data: sourceHistoricalPrice,
         isLoading: isLoadingSourceHistoricalPrice,
@@ -860,7 +885,7 @@ export default function RequestReceiptPage({
             buildReceiptAmountModel({
                 isExchangeReceipt: isExchangeProposal,
                 hasDepositAddress,
-                quote: isSingleReceiptProposal ? quoteByDepositAddress : null,
+                quote: isSingleReceiptProposal ? effectiveQuote : null,
                 sourceToken: {
                     amountDecimal: sourceAmountDecimal,
                     amountDisplay:
@@ -879,7 +904,7 @@ export default function RequestReceiptPage({
             }),
         [
             isExchangeProposal,
-            quoteByDepositAddress,
+            effectiveQuote,
             sourceAmountDecimal,
             destinationAmountWithDecimals,
             hasDepositAddress,
@@ -898,7 +923,9 @@ export default function RequestReceiptPage({
             ? isLoadingSwapStatus
             : isLoadingTransaction);
     const isRateLoading = hasDepositAddress
-        ? isSingleReceiptProposal && isLoadingQuoteByDepositAddress
+        ? isSingleReceiptProposal &&
+          !isConfidentialRequestProposal &&
+          isLoadingQuoteByDepositAddress
         : isLoadingSourceHistoricalPrice ||
           (isExchangeProposal && isLoadingDestinationHistoricalPrice);
     const executedTimeValue = transactionDate

--- a/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/utils/receipt-models.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/utils/receipt-models.ts
@@ -33,6 +33,16 @@ function toAsyncValue<T>(value: T | null, isLoading: boolean): AsyncValue<T> {
     return { value, isLoading };
 }
 
+function toDisplayRoundedUsd(value?: string | null): number | null {
+    if (!value) return null;
+
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return null;
+    if (Math.abs(parsed) < 0.01) return parsed;
+
+    return Number(parsed.toFixed(2));
+}
+
 export function buildReceiptAmountModel({
     isExchangeReceipt,
     hasDepositAddress,
@@ -63,6 +73,7 @@ export function buildReceiptAmountModel({
         quote?.amountOutFormatted ?? destinationToken.amountDecimal ?? "0";
     const sourceAmountValue = Number(sourceAmountRaw);
     const destinationAmountValue = Number(destinationAmountRaw);
+    const displayedSourceAmountUsd = toDisplayRoundedUsd(quote?.amountInUsd);
     const sourceAmountDisplay = isExchangeReceipt
         ? (quote?.amountInFormatted ?? sourceToken.amountDisplay)
         : sourceToken.amountDisplay;
@@ -71,11 +82,13 @@ export function buildReceiptAmountModel({
         formatTokenDisplayAmount(destinationToken.amountDecimal || "0");
 
     const sourceUnitPriceUsd =
-        sourceAmountValue > 0 && Number(quote?.amountInUsd) > 0
-            ? Number(quote?.amountInUsd) / sourceAmountValue
-            : hasDepositAddress
-              ? sourceToken.tokenPrice
-              : sourceToken.historicalPriceUsd;
+        sourceAmountValue > 0 &&
+        displayedSourceAmountUsd != null &&
+        displayedSourceAmountUsd > 0
+            ? displayedSourceAmountUsd / sourceAmountValue
+            : !hasDepositAddress
+              ? sourceToken.historicalPriceUsd
+              : null;
 
     const sourceAmountUsd = quote?.amountInUsd
         ? formatCurrencyWithSubCent(Number(quote.amountInUsd))
@@ -83,15 +96,11 @@ export function buildReceiptAmountModel({
           ? formatCurrencyWithSubCent(
                 Number(sourceToken.amountDecimal) * sourceUnitPriceUsd,
             )
-          : hasDepositAddress && sourceToken.tokenPrice != null
-            ? formatCurrencyWithSubCent(
-                  Number(sourceToken.amountDecimal) * sourceToken.tokenPrice,
-              )
-            : null;
+          : null;
 
-    const destinationUnitPriceUsd = hasDepositAddress
-        ? destinationToken.tokenPrice
-        : destinationToken.historicalPriceUsd;
+    const destinationUnitPriceUsd = !hasDepositAddress
+        ? destinationToken.historicalPriceUsd
+        : null;
     const destinationAmountUsd = quote?.amountOutUsd
         ? formatCurrencyWithSubCent(Number(quote.amountOutUsd))
         : !hasDepositAddress && destinationUnitPriceUsd != null
@@ -99,14 +108,7 @@ export function buildReceiptAmountModel({
                 Number(destinationToken.amountDecimal ?? "0") *
                     destinationUnitPriceUsd,
             )
-          : hasDepositAddress &&
-              destinationToken.tokenPrice != null &&
-              quote?.amountOutFormatted
-            ? formatCurrencyWithSubCent(
-                  Number(quote.amountOutFormatted) *
-                      destinationToken.tokenPrice,
-              )
-            : sourceAmountUsd;
+          : sourceAmountUsd;
     const destinationPerSourceRate =
         sourceAmountValue > 0 && destinationAmountValue > 0
             ? destinationAmountValue / sourceAmountValue

--- a/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/utils/receipt-models.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/utils/receipt-models.ts
@@ -33,16 +33,6 @@ function toAsyncValue<T>(value: T | null, isLoading: boolean): AsyncValue<T> {
     return { value, isLoading };
 }
 
-function toDisplayRoundedUsd(value?: string | null): number | null {
-    if (!value) return null;
-
-    const parsed = Number(value);
-    if (!Number.isFinite(parsed)) return null;
-    if (Math.abs(parsed) < 0.01) return parsed;
-
-    return Number(parsed.toFixed(2));
-}
-
 export function buildReceiptAmountModel({
     isExchangeReceipt,
     hasDepositAddress,
@@ -73,7 +63,9 @@ export function buildReceiptAmountModel({
         quote?.amountOutFormatted ?? destinationToken.amountDecimal ?? "0";
     const sourceAmountValue = Number(sourceAmountRaw);
     const destinationAmountValue = Number(destinationAmountRaw);
-    const displayedSourceAmountUsd = toDisplayRoundedUsd(quote?.amountInUsd);
+    const quoteSourceAmountUsd = quote?.amountInUsd
+        ? Number(quote.amountInUsd)
+        : null;
     const sourceAmountDisplay = isExchangeReceipt
         ? (quote?.amountInFormatted ?? sourceToken.amountDisplay)
         : sourceToken.amountDisplay;
@@ -83,9 +75,9 @@ export function buildReceiptAmountModel({
 
     const sourceUnitPriceUsd =
         sourceAmountValue > 0 &&
-        displayedSourceAmountUsd != null &&
-        displayedSourceAmountUsd > 0
-            ? displayedSourceAmountUsd / sourceAmountValue
+        quoteSourceAmountUsd != null &&
+        quoteSourceAmountUsd > 0
+            ? quoteSourceAmountUsd / sourceAmountValue
             : !hasDepositAddress
               ? sourceToken.historicalPriceUsd
               : null;

--- a/nt-fe/features/proposals/components/proposals-table.tsx
+++ b/nt-fe/features/proposals/components/proposals-table.tsx
@@ -681,7 +681,7 @@ export function ProposalsTable({
                 </ScrollArea>
 
                 {onPageChange && totalPages > 1 && (
-                    <div className="p-3">
+                    <div className="p-3 pb-0">
                         <Pagination
                             pageIndex={pageIndex}
                             totalPages={totalPages}

--- a/nt-fe/features/proposals/components/proposals-table.tsx
+++ b/nt-fe/features/proposals/components/proposals-table.tsx
@@ -485,8 +485,12 @@ export function ProposalsTable({
 
     const totalPages = Math.ceil(total / pageSize);
     const tableRows = table.getRowModel().rows;
+    const lastRowId =
+        tableRows.length > 0 ? tableRows[tableRows.length - 1].id : null;
     const isLastRowExpanded =
         tableRows.length > 0 && tableRows[tableRows.length - 1].getIsExpanded();
+    const shouldApplyContainerBottomPadding =
+        tableRows.length > 1 && (Boolean(onPageChange) || !isLastRowExpanded);
     const selectedCount = table.getFilteredSelectedRowModel().rows.length;
     const selectedProposals = table
         .getFilteredSelectedRowModel()
@@ -513,7 +517,12 @@ export function ProposalsTable({
 
     return (
         <>
-            <div className="flex flex-col pb-3">
+            <div
+                className={cn(
+                    "flex flex-col",
+                    shouldApplyContainerBottomPadding && "pb-3",
+                )}
+            >
                 {selectedCount > 0 && (
                     <div className="flex md:text-base text-sm items-center justify-between py-3.5 px-5 border-b">
                         <span className="font-semibold">
@@ -611,7 +620,12 @@ export function ProposalsTable({
                                                 colSpan={
                                                     row.getVisibleCells().length
                                                 }
-                                                className="p-4 bg-general-tertiary"
+                                                className={cn(
+                                                    "p-4 bg-general-tertiary",
+                                                    !shouldApplyContainerBottomPadding &&
+                                                        row.id === lastRowId &&
+                                                        "rounded-b-xl",
+                                                )}
                                             >
                                                 <ExpandedView
                                                     proposal={row.original}
@@ -667,7 +681,7 @@ export function ProposalsTable({
                 </ScrollArea>
 
                 {onPageChange && totalPages > 1 && (
-                    <div className={cn("pr-2", isLastRowExpanded && "pt-3")}>
+                    <div className="p-3">
                         <Pagination
                             pageIndex={pageIndex}
                             totalPages={totalPages}


### PR DESCRIPTION
#923 
- Fixed receipt pricing for confidential requests to use stored DB quote metadata.
- Removed live/current token price fallback for deposit-address flows; now shows N/A when quote USD is missing.
- Minor UI changes with requests table

<img width="1504" height="1420" alt="image" src="https://github.com/user-attachments/assets/37315d24-6349-41c0-b835-62d6700e6507" />
<img width="779" height="720" alt="image" src="https://github.com/user-attachments/assets/42a5a751-1305-4e16-b35d-904372671684" />
<img width="753" height="772" alt="image" src="https://github.com/user-attachments/assets/0a70afaf-3cd1-4575-bff2-61271228a647" />


Note: USD values are currently displayed with 2 decimal places. Because of rounding, the unit rate and total may look slightly inconsistent in some cases (e.g., 1 NEAR = $2.67 while 0.10 NEAR = $0.27). Should we keep 2 decimals or increase precision (e.g., up to 4 decimals) for better consistency?