### PR TITLE
fix: NEAR transfer token/network display

### DIFF
--- a/nt-be/src/handlers/balance_changes/history.rs
+++ b/nt-be/src/handlers/balance_changes/history.rs
@@ -1707,7 +1707,7 @@ pub async fn get_recent_activity(
 
     if !activity_token_ids.is_empty() {
         let chain_metadata_map =
-            fetch_tokens_with_fallback(&state, &activity_token_ids, true).await;
+            fetch_tokens_with_fallback(&state, &activity_token_ids, true, false).await;
         for change in &mut enriched_changes {
             if let Some(ref mut metadata) = change.token_metadata
                 && let Some(chain_meta) = chain_metadata_map.get(&change.token_id)
@@ -1838,7 +1838,7 @@ pub async fn get_recent_activity(
 
     if !swap_token_ids_vec.is_empty() {
         let swap_metadata_with_chain =
-            fetch_tokens_with_fallback(&state, &swap_token_ids_vec, true).await;
+            fetch_tokens_with_fallback(&state, &swap_token_ids_vec, true, false).await;
         // Override the metadata_map with chain-enriched versions
         metadata_map.extend(swap_metadata_with_chain);
     }

--- a/nt-be/src/handlers/intents/bridge_tokens.rs
+++ b/nt-be/src/handlers/intents/bridge_tokens.rs
@@ -123,7 +123,8 @@ pub async fn get_bridge_tokens(
                 .collect();
 
             // Step 4: Batch fetch token metadata using the unified metadata function
-            let metadata_map = fetch_tokens_metadata_enriched(&state_clone, &metadata_ids).await;
+            let metadata_map =
+                fetch_tokens_metadata_enriched(&state_clone, &metadata_ids, false).await;
 
             // Step 5: Group by unified_asset_id
             let mut asset_map: HashMap<String, AssetOption> = HashMap::new();

--- a/nt-be/src/handlers/notifications/telegram_dispatcher.rs
+++ b/nt-be/src/handlers/notifications/telegram_dispatcher.rs
@@ -69,7 +69,8 @@ pub async fn run_telegram_dispatch_cycle(
     }
     token_ids_to_fetch.sort();
     token_ids_to_fetch.dedup();
-    let token_metadata_map = fetch_tokens_metadata_enriched(state, &token_ids_to_fetch).await;
+    let token_metadata_map =
+        fetch_tokens_metadata_enriched(state, &token_ids_to_fetch, false).await;
 
     let mut sent = 0usize;
 

--- a/nt-be/src/handlers/token/metadata.rs
+++ b/nt-be/src/handlers/token/metadata.rs
@@ -28,6 +28,10 @@ use crate::{
 pub struct TokenMetadataQuery {
     #[serde(alias = "token_id")]
     pub token_id: String,
+    /// When true, NearBlocks is used as a final fallback for NEAR FT metadata
+    /// even when chain metadata enrichment is enabled.
+    #[serde(default)]
+    pub near_ft: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -593,7 +597,7 @@ pub async fn fetch_tokens_metadata(
     state: &Arc<AppState>,
     token_ids: &[String],
 ) -> Result<Vec<TokenMetadata>, (StatusCode, String)> {
-    let map = fetch_tokens_with_fallback(state, token_ids, true).await;
+    let map = fetch_tokens_with_fallback(state, token_ids, true, false).await;
     let mut out = Vec::new();
     let mut seen = HashSet::new();
     for token_id in token_ids {
@@ -611,10 +615,15 @@ pub async fn fetch_tokens_metadata(
 ///
 /// When `include_chain_metadata` is false, NearBlocks may be used as a final
 /// asset-metadata fallback (no reliable cross-chain network derivation).
+///
+/// `allow_nearblocks` explicitly enables the NearBlocks fallback regardless of
+/// `include_chain_metadata`. Use this when the caller knows the token is a
+/// native NEAR FT (e.g. via the `nearFt` query param).
 pub async fn fetch_tokens_with_fallback(
     state: &Arc<AppState>,
     token_ids: &[String],
     include_chain_metadata: bool,
+    allow_nearblocks: bool,
 ) -> HashMap<String, TokenMetadata> {
     if token_ids.is_empty() {
         return HashMap::new();
@@ -743,9 +752,10 @@ pub async fn fetch_tokens_with_fallback(
             }
         }
 
-        // 5) NearBlocks (asset metadata only; skip when chain metadata is required)
+        // 5) NearBlocks (asset metadata only; skip when chain metadata is required
+        // unless the caller explicitly opted in via allow_nearblocks)
         if metadata.is_none()
-            && !include_chain_metadata
+            && (!include_chain_metadata || allow_nearblocks)
             && let Some(nearblocks_api_key) = state.env_vars.nearblocks_api_key.as_ref()
             && let Some(nearblocks_candidate) = nearblocks_lookup_candidate(&candidates.all)
         {
@@ -801,9 +811,10 @@ pub async fn fetch_tokens_with_fallback(
 pub async fn fetch_tokens_metadata_enriched(
     state: &Arc<AppState>,
     token_ids: &[String],
+    allow_nearblocks: bool,
 ) -> HashMap<String, TokenMetadata> {
     // Extension users expect full enrichment including chain metadata.
-    let mut result = fetch_tokens_with_fallback(state, token_ids, true).await;
+    let mut result = fetch_tokens_with_fallback(state, token_ids, true, allow_nearblocks).await;
     if result.is_empty() {
         return result;
     }
@@ -831,7 +842,12 @@ pub async fn get_token_metadata(
     State(state): State<Arc<AppState>>,
     Query(mut params): Query<TokenMetadataQuery>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, String)> {
-    let cache_key = format!("token-metadata:{}", params.token_id);
+    let near_ft = params.near_ft.unwrap_or(false);
+    let cache_key = if near_ft {
+        format!("token-metadata:{}:nearft", params.token_id)
+    } else {
+        format!("token-metadata:{}", params.token_id)
+    };
     let state_clone = state.clone();
 
     state
@@ -845,7 +861,8 @@ pub async fn get_token_metadata(
 
             // Fetch token metadata using the reusable function
             let tokens =
-                fetch_tokens_metadata_enriched(&state_clone, &[params.token_id.clone()]).await;
+                fetch_tokens_metadata_enriched(&state_clone, &[params.token_id.clone()], near_ft)
+                    .await;
 
             let wrap_metadata = tokens.get(&params.token_id).ok_or_else(|| {
                 (

--- a/nt-be/src/handlers/token/popular_assets.rs
+++ b/nt-be/src/handlers/token/popular_assets.rs
@@ -39,7 +39,7 @@ pub async fn get_popular_assets_by_activity(
         }
     }
 
-    let metadata_map = fetch_tokens_metadata_enriched(&state, &token_ids).await;
+    let metadata_map = fetch_tokens_metadata_enriched(&state, &token_ids, false).await;
     let data: Vec<TokenMetadata> = token_ids
         .iter()
         .filter_map(|token_id| metadata_map.get(token_id).cloned())

--- a/nt-be/src/handlers/user/assets.rs
+++ b/nt-be/src/handlers/user/assets.rs
@@ -555,7 +555,7 @@ pub async fn compute_user_assets(
     token_ids_to_fetch.push("near".to_string());
 
     let metadata_map = if !token_ids_to_fetch.is_empty() {
-        fetch_tokens_metadata_enriched(state, &token_ids_to_fetch).await
+        fetch_tokens_metadata_enriched(state, &token_ids_to_fetch, false).await
     } else {
         HashMap::new()
     };

--- a/nt-be/src/routes/balance_changes.rs
+++ b/nt-be/src/routes/balance_changes.rs
@@ -167,7 +167,8 @@ pub async fn get_balance_changes_internal(
 
                 // Fetch metadata to get decimals using the helper function
                 let metadata_map: std::collections::HashMap<String, TokenMetadata> =
-                    fetch_tokens_with_fallback(state, std::slice::from_ref(token_id), false).await;
+                    fetch_tokens_with_fallback(state, std::slice::from_ref(token_id), false, false)
+                        .await;
                 let metadata = metadata_map.get(token_id);
 
                 let decimals = metadata.map(|m| m.decimals).unwrap_or(24); // Default to NEAR decimals
@@ -342,6 +343,7 @@ pub async fn get_balance_changes_internal(
             state,
             &token_ids,
             params.include_chain_metadata.unwrap_or(false),
+            false,
         )
         .await;
 

--- a/nt-be/src/services/public_dashboard.rs
+++ b/nt-be/src/services/public_dashboard.rs
@@ -472,7 +472,8 @@ pub async fn load_latest_public_dashboard_snapshot(
         .map(|t| t.contract_id.clone().unwrap_or_else(|| t.token_id.clone()))
         .collect();
     let metadata =
-        crate::handlers::token::metadata::fetch_tokens_metadata_enriched(state, &lookup_ids).await;
+        crate::handlers::token::metadata::fetch_tokens_metadata_enriched(state, &lookup_ids, false)
+            .await;
 
     // Build NEAR metadata once and reuse for all NEAR variants, mirroring assets.rs.
     let near_meta = {

--- a/nt-fe/components/member-input.tsx
+++ b/nt-fe/components/member-input.tsx
@@ -238,7 +238,7 @@ export function MemberInput<
                                 }
                                 render={({ fieldState }) =>
                                     fieldState.error ? (
-                                        <FormMessage />
+                                        <FormMessage className="text-sm mb-3" />
                                     ) : (
                                         <p className="text-muted-foreground text-xs invisible">
                                             Invisible

--- a/nt-fe/features/onboarding/components/onboarding-progress.tsx
+++ b/nt-fe/features/onboarding/components/onboarding-progress.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
@@ -49,10 +49,12 @@ function SemiCircleProgress({
     current: number;
     total: number;
 }) {
+    const id = useId();
     const progress = total > 0 ? Math.min(Math.max(current / total, 0), 1) : 0;
     const hasProgress = progress > 0;
-    const arcLength = 440; // 2 * PI * 70 (approx circumference)
-    const dashArray = 220; // Half circle
+    const progressMaskWidth = 165 * progress;
+    const progressMaskId = `${id}-progress-mask`;
+    const arcClipPathId = `${id}-arc-clip`;
 
     return (
         <div className="relative flex items-center justify-center w-[165px] h-[111px]">
@@ -64,18 +66,15 @@ function SemiCircleProgress({
                 xmlns="http://www.w3.org/2000/svg"
             >
                 <defs>
-                    <mask id="progress-mask">
-                        <circle
-                            cx="82.5"
-                            cy="88.8"
-                            r="70"
-                            fill="none"
-                            stroke="white"
-                            strokeWidth="120"
-                            strokeDasharray={`${dashArray} ${arcLength - dashArray}`}
-                            strokeDashoffset={dashArray * (1 - progress)}
-                            transform="rotate(180 82.5 88.8)"
-                            className="transition-[stroke-dashoffset] duration-1000 ease-in-out"
+                    <mask id={progressMaskId}>
+                        <rect width="165" height="111" fill="black" />
+                        <rect
+                            x="0"
+                            y="0"
+                            width={progressMaskWidth}
+                            height="111"
+                            fill="white"
+                            className="transition-[width] duration-1000 ease-in-out"
                         />
                     </mask>
                     <linearGradient
@@ -89,7 +88,7 @@ function SemiCircleProgress({
                         <stop offset="0.89%" stopColor="#48ACEF" />
                         <stop offset="66.39%" stopColor="#A8DCFF" />
                     </linearGradient>
-                    <clipPath id="svg-draw">
+                    <clipPath id={arcClipPathId}>
                         <path d={PROGRESS_ARC_PATH} />
                     </clipPath>
                 </defs>
@@ -102,10 +101,10 @@ function SemiCircleProgress({
                 />
                 {hasProgress ? (
                     <path
-                        clipPath="url(#svg-draw)"
+                        clipPath={`url(#${arcClipPathId})`}
                         d={PROGRESS_ARC_PATH}
                         fill="url(#progress-gradient)"
-                        mask="url(#progress-mask)"
+                        mask={`url(#${progressMaskId})`}
                     />
                 ) : null}
             </svg>

--- a/nt-fe/features/proposals/components/amount.tsx
+++ b/nt-fe/features/proposals/components/amount.tsx
@@ -29,6 +29,8 @@ interface AmountProps {
     textOnly?: boolean;
     iconSize?: "sm" | "md" | "lg";
     usdTextOverride?: string | null;
+    /** Enable NearBlocks FT metadata fallback for native NEAR tokens */
+    nearFt?: boolean;
 }
 
 function resolveAmountNetworkLabel({
@@ -85,6 +87,7 @@ export function Amount({
     network,
     iconSize = "lg",
     usdTextOverride = null,
+    nearFt,
 }: AmountProps) {
     const tCommon = useTranslations("common");
     const tAmount = useTranslations("amount");
@@ -93,7 +96,8 @@ export function Amount({
     const effectiveShowUSDValue =
         !!usdTextOverride ||
         (showUSDValue && (requestDisplayContext?.showUSDValue ?? true));
-    const { data: tokenData, isLoading } = useToken(tokenId);
+    const tokenOpts = nearFt ? { nearFt: true } : undefined;
+    const { data: tokenData, isLoading } = useToken(tokenId, tokenOpts);
     const rawAmountValue = amount
         ? formatBalance(amount, tokenData?.decimals || 24)
         : amountWithDecimals || "0";

--- a/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/transfer-expanded.tsx
@@ -31,7 +31,10 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
     const tIntents = useTranslations("intentsQuote");
     const requestDisplayContext = useRequestDisplayContext();
     const isExecuted = requestDisplayContext?.isExecuted ?? false;
-    const { data: tokenData } = useToken(data.tokenId);
+    const { data: tokenData } = useToken(
+        data.tokenId,
+        data.nearFt ? { nearFt: true } : undefined,
+    );
     const tokenChainName = tokenData?.network || NEAR_NETWORK_ID;
     const isNearComDestination = isNearComPaymentRoute(data);
 
@@ -127,6 +130,7 @@ export function TransferExpanded({ data }: TransferExpandedProps) {
                     tokenId={data.tokenId}
                     showNetworkTooltip
                     usdTextOverride={amountUsdOverride}
+                    nearFt={data.nearFt}
                 />
             ),
         },

--- a/nt-fe/features/proposals/components/transaction-cell/token-cell.tsx
+++ b/nt-fe/features/proposals/components/transaction-cell/token-cell.tsx
@@ -34,6 +34,7 @@ export function TokenCell({
     const tCommon = useTranslations("common");
     const { isConfidential } = useTreasury();
     const effectivePrefix = prefix ?? t("toPrefix");
+    const nearFt = "nearFt" in data ? data.nearFt : undefined;
     const title = (
         <Amount
             amount={data.amount}
@@ -43,6 +44,7 @@ export function TokenCell({
             expandNearComLabel={"destinationAssetId" in data}
             iconSize="sm"
             textOnly={textOnly}
+            nearFt={nearFt}
         />
     );
     const { data: profile } = useProfile(data.receiver);

--- a/nt-fe/features/proposals/types/index.ts
+++ b/nt-fe/features/proposals/types/index.ts
@@ -60,6 +60,8 @@ export interface PaymentRequestData {
     destinationAssetId?: string;
     /** Optional quote-provided USD value for display */
     quoteAmountInUsd?: string;
+    /** True for plain Transfer proposals — enables NearBlocks FT metadata fallback */
+    nearFt?: boolean;
 }
 
 export interface FunctionCallAction {

--- a/nt-fe/features/proposals/utils/proposal-extractors.ts
+++ b/nt-fe/features/proposals/utils/proposal-extractors.ts
@@ -166,7 +166,10 @@ export function extractPaymentRequestData(
         proposal.description,
     );
 
+    let isTransferKind = false;
+
     if ("Transfer" in proposal.kind) {
+        isTransferKind = true;
         const transfer = proposal.kind.Transfer;
         const normalizedTokenId = transfer.token_id?.trim();
         tokenId =
@@ -218,8 +221,14 @@ export function extractPaymentRequestData(
         proposal.description,
     );
 
-    // Plain native NEAR transfers without 1Click metadata should resolve to
-    // NEAR network (not near.com route) in destination display.
+    // Transfer proposals are always on-chain NEAR; set explicit destination
+    // network so request details do not depend on token metadata.
+    if (!destinationAssetId && isTransferKind && !depositAddress) {
+        destinationAssetId = NEAR_NETWORK_ID;
+    }
+
+    // Non-Transfer native NEAR payments without 1Click metadata also resolve
+    // to NEAR network in destination display.
     if (!destinationAssetId && tokenId === NEAR_NETWORK_ID && !depositAddress) {
         destinationAssetId = NEAR_NETWORK_ID;
     }
@@ -233,6 +242,7 @@ export function extractPaymentRequestData(
         quoteSignature,
         networkFee,
         destinationAssetId,
+        nearFt: isTransferKind || undefined,
     };
 }
 

--- a/nt-fe/hooks/use-treasury-queries.ts
+++ b/nt-fe/hooks/use-treasury-queries.ts
@@ -170,10 +170,13 @@ export function useBatchStorageDepositIsRegistered(
  * Fetches from backend which enriches data from bridge and external price APIs
  * Supports both NEAR and cross-chain tokens
  */
-export function useToken(tokenId: string | null | undefined) {
+export function useToken(
+    tokenId: string | null | undefined,
+    options?: { nearFt?: boolean },
+) {
     return useQuery({
-        queryKey: ["tokenMetadata", tokenId],
-        queryFn: () => getTokenMetadata(tokenId!),
+        queryKey: ["tokenMetadata", tokenId, options?.nearFt ?? false],
+        queryFn: () => getTokenMetadata(tokenId!, options),
         enabled: !!tokenId,
         staleTime: 1000 * 60 * 5, // 5 minutes (token metadata and price)
     });

--- a/nt-fe/lib/api.ts
+++ b/nt-fe/lib/api.ts
@@ -587,6 +587,7 @@ interface PopularAssetsByActivityResponse {
  */
 export async function getTokenMetadata(
     tokenId: string,
+    options?: { nearFt?: boolean },
 ): Promise<TokenMetadata | null> {
     if (!tokenId) return null;
     let token = tokenId;
@@ -605,7 +606,10 @@ export async function getTokenMetadata(
         const url = `${BACKEND_API_BASE}/token/metadata`;
 
         const response = await axios.get<TokenMetadata>(url, {
-            params: { tokenId: token },
+            params: {
+                tokenId: token,
+                ...(options?.nearFt ? { nearFt: true } : {}),
+            },
         });
 
         return response.data;


### PR DESCRIPTION
#925 

Added a new `nearFt` parameter to the token metadata API.
NearBlocks does not return chain/origin metadata, so we now call NearBlocks only in safe cases:
- when chain metadata is not required, or
- when we already know the token is on NEAR (for example, Transfer proposals).

<img width="1699" height="964" alt="image" src="https://github.com/user-attachments/assets/6fc2da27-b960-41ab-a3f0-8e67ef972e43" />




- Also fixed animation with onboarding progress bar