### PR TITLE
feat: add custom NEAR FT whitelist with NearBlocks metadata fallback

### DIFF
--- a/nt-be/src/constants/mod.rs
+++ b/nt-be/src/constants/mod.rs
@@ -3,6 +3,7 @@ use near_api::NearToken;
 
 pub mod intents_chains;
 pub mod intents_tokens;
+pub mod near_ft_whitelist;
 
 pub const REF_FINANCE_CONTRACT_ID: &AccountIdRef =
     AccountIdRef::new_or_panic("v2.ref-finance.near");

--- a/nt-be/src/constants/near_ft_whitelist.rs
+++ b/nt-be/src/constants/near_ft_whitelist.rs
@@ -1,0 +1,14 @@
+/// Custom whitelist of NEAR FT contracts that should always appear in treasury
+/// assets when the account holds a positive balance — even if they are not listed
+/// on Ref Finance or other aggregators.
+///
+/// These are native NEAR FTs so NearBlocks can resolve their
+/// metadata and we can display them in the dashboard.
+pub const NEAR_FT_WHITELIST: &[&str] = &["nexus.nexusdev.near"];
+
+/// Returns true if the given contract ID is in our custom NEAR FT whitelist.
+pub fn is_whitelisted_near_ft(contract_id: &str) -> bool {
+    NEAR_FT_WHITELIST
+        .iter()
+        .any(|&id| id.eq_ignore_ascii_case(contract_id))
+}

--- a/nt-be/src/handlers/user/assets.rs
+++ b/nt-be/src/handlers/user/assets.rs
@@ -538,10 +538,10 @@ pub async fn compute_user_assets(
             if ref_token_ids.contains(contract_id) {
                 continue;
             }
-            if let Some(balance) = balance_map.get(contract_id) {
-                if *balance != U128::from(0) {
-                    ref_tokens_with_balances.push((contract_id.to_string(), balance.clone()));
-                }
+            if let Some(balance) = balance_map.get(contract_id)
+                && *balance != U128::from(0)
+            {
+                ref_tokens_with_balances.push((contract_id.to_string(), balance.clone()));
             }
         }
 

--- a/nt-be/src/handlers/user/assets.rs
+++ b/nt-be/src/handlers/user/assets.rs
@@ -23,6 +23,7 @@ use crate::{
         INTENTS_CONTRACT_ID, NEAR_DECIMALS, NEAR_ICON, REF_FINANCE_CONTRACT_ID,
         intents_chains::ChainIcons,
         intents_tokens::{find_token_by_symbol, find_unified_asset_id},
+        near_ft_whitelist::NEAR_FT_WHITELIST,
     },
     handlers::intents::confidential::balances::fetch_confidential_balances,
     handlers::token::{TokenMetadata as TokenMetadataResponse, fetch_tokens_metadata_enriched},
@@ -438,7 +439,7 @@ pub async fn compute_user_assets(
     // Regular treasuries: FT whitelist, public intents, NEAR, lockups, staking, FT lockups.
 
     let intents_balances: Vec<(String, String)>;
-    let ref_tokens_with_balances: Vec<(String, U128)>;
+    let mut ref_tokens_with_balances: Vec<(String, U128)>;
     let near_balance: Option<TokenBalanceResponse>;
     let lockup_balance: Option<LockupBalance>;
     let staking_balance: Option<StakingBalance>;
@@ -515,6 +516,8 @@ pub async fn compute_user_assets(
         });
 
         let balance_map = build_balance_map(&user_balances);
+        let ref_token_ids: HashSet<String> = whitelist_set.iter().cloned().collect();
+
         ref_tokens_with_balances = whitelist_set
             .into_iter()
             .filter_map(|token_id| {
@@ -530,6 +533,18 @@ pub async fn compute_user_assets(
             })
             .collect();
 
+        // Add custom-whitelisted NEAR FT tokens that have balance but aren't in Ref
+        for &contract_id in NEAR_FT_WHITELIST {
+            if ref_token_ids.contains(contract_id) {
+                continue;
+            }
+            if let Some(balance) = balance_map.get(contract_id) {
+                if *balance != U128::from(0) {
+                    ref_tokens_with_balances.push((contract_id.to_string(), balance.clone()));
+                }
+            }
+        }
+
         near_balance = Some(near_bal);
         lockup_balance = lockup_bal;
         staking_balance = staking_bal;
@@ -538,27 +553,41 @@ pub async fn compute_user_assets(
 
     // ── Fetch metadata (shared path) ────────────────────────────────────
 
-    let mut token_ids_to_fetch: Vec<String> = ref_tokens_with_balances
+    // Ref whitelist tokens + intents + lockup + NEAR (no NearBlocks)
+    let mut ref_token_ids: Vec<String> = ref_tokens_with_balances
         .iter()
+        .filter(|(id, _)| !NEAR_FT_WHITELIST.contains(&id.as_str()))
         .map(|(id, _)| id.clone())
         .collect();
-    token_ids_to_fetch.extend(
+    ref_token_ids.extend(
         intents_balances
             .iter()
             .map(|(id, _)| format!("intents.near:{}", id)),
     );
-    token_ids_to_fetch.extend(
+    ref_token_ids.extend(
         ft_lockup_positions
             .iter()
             .map(|p| p.token_account_id.clone()),
     );
-    token_ids_to_fetch.push("near".to_string());
+    ref_token_ids.push("near".to_string());
 
-    let metadata_map = if !token_ids_to_fetch.is_empty() {
-        fetch_tokens_metadata_enriched(state, &token_ids_to_fetch, false).await
+    // Custom whitelist tokens (with NearBlocks fallback)
+    let custom_token_ids: Vec<String> = ref_tokens_with_balances
+        .iter()
+        .filter(|(id, _)| NEAR_FT_WHITELIST.contains(&id.as_str()))
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    let mut metadata_map = if !ref_token_ids.is_empty() {
+        fetch_tokens_metadata_enriched(state, &ref_token_ids, false).await
     } else {
         HashMap::new()
     };
+
+    if !custom_token_ids.is_empty() {
+        let custom_meta = fetch_tokens_metadata_enriched(state, &custom_token_ids, true).await;
+        metadata_map.extend(custom_meta);
+    }
 
     // ── Build SimplifiedToken list ──────────────────────────────────────
 
@@ -567,7 +596,7 @@ pub async fn compute_user_assets(
         TokenMetadataResponse::create_near_metadata(None, None)
     });
 
-    // REF Finance FT tokens (non-confidential only)
+    // FT tokens from Ref whitelist + custom whitelist (non-confidential only)
     let mut all_simplified_tokens: Vec<(SimplifiedToken, U128)> = ref_tokens_with_balances
         .into_iter()
         .filter_map(|(token_id, balance)| {

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -13,7 +13,7 @@ import {
     getNetworkDisplayCaseClass,
     getLocalizedNetworkDisplayName,
 } from "@/lib/intents-network";
-import { NEAR_COM_ICON } from "@/constants/token";
+import { NEAR_COM_ICON, NEAR_CHAIN_ICONS } from "@/constants/token";
 import type { BridgeAsset } from "@/hooks/use-bridge-tokens";
 import { useTreasury } from "@/hooks/use-treasury";
 import { isValidAddress } from "@/lib/address-validation";
@@ -147,23 +147,39 @@ export function RecipientNetworkSelect({
     );
 
     const tokenNetworkOptions = useMemo((): RecipientNetworkOption[] => {
-        if (!bridgeAssetMatch) return [];
+        if (bridgeAssetMatch) {
+            return bridgeAssetMatch.networks.map((network) => {
+                const iconUrl = network.chainIcons
+                    ? network.chainIcons.icon
+                    : "";
+                return {
+                    id: network.id,
+                    name: getNetworkDisplayName(network.name),
+                    description:
+                        isConfidential &&
+                        getBlockchainType(network.name) === NEAR_NETWORK_ID
+                            ? t("nearDescription")
+                            : undefined,
+                    icon: iconUrl,
+                    networkName: network.name,
+                };
+            });
+        }
 
-        return bridgeAssetMatch.networks.map((network) => {
-            const iconUrl = network.chainIcons ? network.chainIcons.icon : "";
-            return {
-                id: network.id,
-                name: getNetworkDisplayName(network.name),
-                description:
-                    isConfidential &&
-                    getBlockchainType(network.name) === NEAR_NETWORK_ID
-                        ? t("nearDescription")
-                        : undefined,
-                icon: iconUrl,
-                networkName: network.name,
-            };
-        });
-    }, [bridgeAssetMatch, isConfidential, t]);
+        // Native NEAR FTs can be transferred on NEAR network
+        if (token?.residency === "Ft") {
+            return [
+                {
+                    id: NEAR_NETWORK_ID,
+                    name: getNetworkDisplayName(NEAR_NETWORK_ID),
+                    icon: NEAR_CHAIN_ICONS.icon,
+                    networkName: NEAR_NETWORK_ID,
+                },
+            ];
+        }
+
+        return [];
+    }, [bridgeAssetMatch, isConfidential, t, token]);
 
     const availableOptions = useMemo(
         () => [nearComOption, ...tokenNetworkOptions],

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -1063,24 +1063,24 @@ export default function PaymentsPage() {
             const directTransferAmount = Big(data.amount)
                 .mul(Big(10).pow(data.token.decimals))
                 .toFixed();
-            const quoteAmountDecimals =
-                getDestinationAmountDecimalsForExactOutput(
-                    tokenClassification.tokenForIntentsQuote,
-                    data.destinationNetwork,
-                    intentsAmountMode,
-                    bridgeAssets,
-                );
-            if (quoteAmountDecimals === undefined) {
-                throw new Error(tPay("failed1ClickQuote"));
-            }
-            const quoteAmount = Big(data.amount)
-                .mul(Big(10).pow(quoteAmountDecimals))
-                .toFixed();
 
             let description = encodeToMarkdown({ notes: data.memo || "" });
             let proposalKind: FunctionCallKind | TransferKind;
 
             if (shouldUseIntents) {
+                const quoteAmountDecimals =
+                    getDestinationAmountDecimalsForExactOutput(
+                        tokenClassification.tokenForIntentsQuote,
+                        data.destinationNetwork,
+                        intentsAmountMode,
+                        bridgeAssets,
+                    );
+                if (quoteAmountDecimals === undefined) {
+                    throw new Error(tPay("failed1ClickQuote"));
+                }
+                const quoteAmount = Big(data.amount)
+                    .mul(Big(10).pow(quoteAmountDecimals))
+                    .toFixed();
                 const tokenForQuote = tokenClassification.tokenForIntentsQuote;
 
                 // Use the cached quote from the live hook; fall back to a


### PR DESCRIPTION
#924 
Custom whitelisted NEAR FT tokens are now visible in Assets when the treasury has a balance.
Users can also use these tokens for payments on the NEAR network.
<img width="981" height="432" alt="image" src="https://github.com/user-attachments/assets/5b9cd9f5-90d8-404f-a47f-3ff4180460ab" />
