### PR TITLE
chore: fixed missing block error in staking gap

### DIFF
--- a/nt-be/src/handlers/balance_changes/account_monitor.rs
+++ b/nt-be/src/handlers/balance_changes/account_monitor.rs
@@ -250,7 +250,7 @@ pub async fn run_maintenance_cycle(
 
                 match fill_gaps_with_hints(
                     &app_state.db_pool,
-                    &app_state.network,
+                    &app_state.archival_network,
                     account_id,
                     token_id,
                     up_to_block,
@@ -399,7 +399,7 @@ pub async fn run_maintenance_cycle(
             if !app_state.env_vars.disable_staking_rewards {
                 match track_and_fill_staking_rewards(
                     &app_state.db_pool,
-                    &app_state.network,
+                    &app_state.archival_network,
                     account_id,
                     up_to_block,
                 )

--- a/nt-be/src/handlers/balance_changes/balance/mod.rs
+++ b/nt-be/src/handlers/balance_changes/balance/mod.rs
@@ -90,7 +90,9 @@ pub async fn get_balance_at_block_with_fallback(
             }
             Err(e) => {
                 let err_str = e.to_string();
-                if (err_str.contains("422") || err_str.contains("UnknownBlock"))
+                if (err_str.contains("422")
+                    || err_str.contains("UnknownBlock")
+                    || err_str.contains("GarbageCollectedBlock"))
                     && offset < max_block_retries
                 {
                     tracing::debug!(

--- a/nt-be/src/handlers/balance_changes/balance/staking.rs
+++ b/nt-be/src/handlers/balance_changes/balance/staking.rs
@@ -126,6 +126,7 @@ pub async fn get_staking_balance_at_block(
                 // Check for various error conditions
                 if err_str.contains("422")
                     || err_str.contains("UnknownBlock")
+                    || err_str.contains("GarbageCollectedBlock")
                     || err_str.contains("MethodNotFound")
                     || err_str.contains("doesn't exist")
                 {

--- a/nt-be/src/handlers/balance_changes/binary_search.rs
+++ b/nt-be/src/handlers/balance_changes/binary_search.rs
@@ -70,7 +70,10 @@ pub async fn find_balance_change_block(
                 Ok(b) => b,
                 Err(e) => {
                     let err_str = e.to_string();
-                    if err_str.contains("UnknownBlock") || err_str.contains("422") {
+                    if err_str.contains("UnknownBlock")
+                        || err_str.contains("422")
+                        || err_str.contains("GarbageCollectedBlock")
+                    {
                         // Block was never produced (skipped block height) — skip it
                         tracing::debug!(
                             "Block {} not available during binary search, skipping",


### PR DESCRIPTION
#961 

- Switched to the archival node for block lookups. Previously, we were using the standard network, which caused some blocks to be missed and resulted in this error occurring frequently.

- Added error handling for cases where a block is missed.
