### PR TITLE
feat: add onboarding analytics events for accurate PostHog funnel

### DIFF
--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -8,105 +8,131 @@ Naming is mixed today (`snake_case` and `kebab-case`) due to legacy events. New 
 
 ---
 
-## Onboarding & Login (Current)
+## Onboarding Funnel (PostHog)
+
+Recommended sequential funnel for new-user onboarding:
+
+1. `onboarding_landed`
+2. `onboarding_login_completed` _(optional — users already logged in may skip this step)_
+3. `treasury-created`
+
+Track returning users separately with `onboarding_existing_treasury_redirect` (not part of the funnel).
+
+Break down step 1 by `page` (`"/"` vs `"/create"`).
+
+`/login` is in-app login, not onboarding — it fires `wallet_connection_completed` only.
+
+---
+
+## Onboarding & Login
+
+### `onboarding_landed`
+
+User enters the onboarding flow on `/` or `/create`. Not fired when a logged-in user with an existing treasury is auto-redirected to their dashboard.
+
+| Property           | Type    | Description                                      |
+| ------------------ | ------- | ------------------------------------------------ |
+| `page`             | string  | `"/"` or `"/create"`                             |
+| `is_authenticated` | boolean | Whether user already had a session at entry time |
+
+**Source:** [nt-fe/features/onboarding/components/create-treasury-entry.tsx](../nt-fe/features/onboarding/components/create-treasury-entry.tsx)
+
+---
+
+### `onboarding_existing_treasury_redirect`
+
+Logged-in user with at least one treasury landed on `/` or `/create` and is redirected to their treasury (not a new onboarding start).
+
+| Property      | Type   | Description               |
+| ------------- | ------ | ------------------------- |
+| `entry_page`  | string | `"/"` or `"/create"`      |
+| `treasury_id` | string | Treasury ID redirected to |
+
+**Source:** [nt-fe/features/onboarding/components/create-treasury-entry.tsx](../nt-fe/features/onboarding/components/create-treasury-entry.tsx)
+
+---
+
+### `onboarding_login_completed`
+
+User completed wallet login during onboarding (`/` or `/create`). Not fired for `/login` or other in-app login surfaces.
+
+| Property     | Type   | Description          |
+| ------------ | ------ | -------------------- |
+| `page`       | string | `"/"` or `"/create"` |
+| `account_id` | string | NEAR account ID      |
+
+**Source:** [nt-fe/stores/near-store.ts](../nt-fe/stores/near-store.ts) — only when `connect()` is called with an `onboardingPage` argument from [create-treasury-entry.tsx](../nt-fe/features/onboarding/components/create-treasury-entry.tsx)
+
+---
 
 ### `onboarding_wallet_option_clicked`
 
-User clicks a wallet option in the current shared wallet selector.
+User clicks a wallet option in the shared wallet selector. Does **not** fire when the user clicks the NEAR wallet group card (opens sub-picker only); fires when a specific wallet is chosen.
 
-
-| Property       | Type    | Description |
-| -------------- | ------- | ----------- |
-| `wallet_id`    | string  | Wallet key (e.g. `near`, `ledger`) |
-| `is_supported` | boolean | Whether wallet is currently supported |
-| `source`       | string  | UI surface (e.g. `"/login"`) |
-| `connect_flow` | string  | `"onboarding"` or `"within_treasury"` |
-
+| Property       | Type    | Description                                      |
+| -------------- | ------- | ------------------------------------------------ |
+| `wallet_id`    | string  | Wallet key (e.g. `ledger`, `meteor-wallet`)      |
+| `is_supported` | boolean | Whether wallet is currently supported            |
+| `source`       | string  | UI surface (e.g. `"/"`, `"/create"`, `"/login"`) |
+| `connect_flow` | string  | `"onboarding"` or `"within_treasury"`            |
 
 **Source:** [nt-fe/components/connect-wallet-selector.tsx](../nt-fe/components/connect-wallet-selector.tsx)
 
 ---
 
-### `wallet_connection_completed`
+### `wallet-selected`
 
-Wallet auth flow successfully completed.
-
-
-| Property     | Type   | Description |
-| ------------ | ------ | ----------- |
-| `source`     | string | Current values: `"resolve-auth"` or `"terms-accepted"` |
-| `account_id` | string | NEAR account ID when available |
-
-
-**Source:** [nt-fe/stores/near-store.ts](../nt-fe/stores/near-store.ts)
-
----
-
-### `wallet-selected` *(legacy, still emitted)*
-
-Wallet selected in connector callbacks.
-
+Wallet selected in the connector during login.
 
 | Property      | Type   | Description         |
 | ------------- | ------ | ------------------- |
 | `wallet_id`   | string | Wallet manifest ID  |
 | `wallet_name` | string | Wallet display name |
 
+**Source:** [nt-fe/stores/near-store.ts](../nt-fe/stores/near-store.ts)
+
+---
+
+### `wallet_connection_completed`
+
+Wallet auth flow successfully completed. Fired for all login surfaces (onboarding, `/login`, etc.).
+
+| Property     | Type   | Description                            |
+| ------------ | ------ | -------------------------------------- |
+| `source`     | string | `"resolve-auth"` or `"terms-accepted"` |
+| `account_id` | string | NEAR account ID when available         |
 
 **Source:** [nt-fe/stores/near-store.ts](../nt-fe/stores/near-store.ts)
 
 ---
 
-### `existing_user_treasury_opened`
+### `treasury-created`
 
-Login flow identified at least one treasury and navigates to it.
+Treasury creation stream completed successfully.
 
+| Property      | Type   | Description     |
+| ------------- | ------ | --------------- |
+| `treasury_id` | string | New treasury ID |
 
-| Property      | Type   | Description |
-| ------------- | ------ | ----------- |
-| `source`      | string | `"/login"` |
-| `treasury_id` | string | Existing treasury ID selected for redirect |
-
-
-**Source:** [nt-fe/app/(treasury)/login/page.tsx](../nt-fe/app/(treasury)/login/page.tsx)
+**Source:** [nt-fe/features/onboarding/components/create-treasury-entry.tsx](../nt-fe/features/onboarding/components/create-treasury-entry.tsx)
 
 ---
 
-### `survey shown` *(PostHog-only)*
+### `onboarding-completed`
 
-Onboarding survey is shown.
+Fired alongside `treasury-created` when a new treasury is created.
 
+| Property      | Type   | Description     |
+| ------------- | ------ | --------------- |
+| `treasury_id` | string | New treasury ID |
 
-| Property      | Type   | Description |
-| ------------- | ------ | ----------- |
-| `$survey_id`  | string | PostHog survey ID |
-
-
-**Source:** [nt-fe/features/onboarding/components/onboarding-questions-step.tsx](../nt-fe/features/onboarding/components/onboarding-questions-step.tsx)
-
----
-
-### `survey sent` *(PostHog-only)*
-
-Onboarding survey progress/completion payload is sent on Continue/Skip.
-
-
-| Property                    | Type           | Description |
-| --------------------------- | -------------- | ----------- |
-| `$survey_id`                | string         | PostHog survey ID |
-| `$survey_submission_id`     | string         | Stable submission ID for session flow |
-| `$survey_completed`         | boolean        | True when last question is completed |
-| `$survey_response_<id>`     | string/string[]| Per-question response |
-| `$set`                      | object         | User properties set on completion |
-
-
-**Source:** [nt-fe/features/onboarding/components/onboarding-questions-step.tsx](../nt-fe/features/onboarding/components/onboarding-questions-step.tsx)
+**Source:** [nt-fe/features/onboarding/components/create-treasury-entry.tsx](../nt-fe/features/onboarding/components/create-treasury-entry.tsx)
 
 ---
 
 ## Legacy / Deprecated (Onboarding)
 
-These are retained only for historical references and may still exist in old PostHog data/actions.
+These may still exist in old PostHog data but are no longer emitted:
 
 - `treasury-creation-step-1-completed`
 - `treasury-creation-step-2-completed`
@@ -116,10 +142,13 @@ These are retained only for historical references and may still exist in old Pos
 - `onboarding_path_selected`
 - `onboarding_cta_clicked`
 - `onboarding_step_completed`
-- `onboarding-completed`
-- `treasury-created`
 - `create-treasury-prompt-shown`
 - `waitlist-submitted`
+- `existing_user_treasury_opened`
+- `survey shown` _(PostHog-only)_
+- `survey sent` _(PostHog-only)_
+
+---
 
 ## Treasury Settings
 
@@ -127,13 +156,11 @@ These are retained only for historical references and may still exist in old Pos
 
 User saves changes to treasury general settings.
 
-
 | Property      | Type   | Description |
 | ------------- | ------ | ----------- |
 | `treasury_id` | string | Treasury ID |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/settings/components/general-tab.tsx](../nt-fe/app/(treasury)/[treasuryId]/settings/components/general-tab.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/settings/components/general-tab.tsx](<../nt-fe/app/(treasury)/[treasuryId]/settings/components/general-tab.tsx>)
 
 ---
 
@@ -143,13 +170,11 @@ User saves changes to treasury general settings.
 
 User opens the add member modal.
 
-
 | Property      | Type   | Description |
 | ------------- | ------ | ----------- |
 | `treasury_id` | string | Treasury ID |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx>)
 
 ---
 
@@ -157,13 +182,11 @@ User opens the add member modal.
 
 User clicks "Review" in the add member flow, triggering validation.
 
-
 | Property      | Type   | Description |
 | ------------- | ------ | ----------- |
 | `treasury_id` | string | Treasury ID |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx>)
 
 ---
 
@@ -171,14 +194,12 @@ User clicks "Review" in the add member flow, triggering validation.
 
 User successfully submits new member(s) for addition.
 
-
 | Property        | Type   | Description                   |
 | --------------- | ------ | ----------------------------- |
 | `treasury_id`   | string | Treasury ID                   |
 | `members_count` | number | Number of members being added |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx>)
 
 ---
 
@@ -186,13 +207,11 @@ User successfully submits new member(s) for addition.
 
 User clicks "Review" in the edit member flow.
 
-
 | Property      | Type   | Description |
 | ------------- | ------ | ----------- |
 | `treasury_id` | string | Treasury ID |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx>)
 
 ---
 
@@ -200,14 +219,12 @@ User clicks "Review" in the edit member flow.
 
 User successfully submits member role edits.
 
-
 | Property        | Type   | Description                    |
 | --------------- | ------ | ------------------------------ |
 | `treasury_id`   | string | Treasury ID                    |
 | `members_count` | number | Number of members being edited |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx>)
 
 ---
 
@@ -215,14 +232,12 @@ User successfully submits member role edits.
 
 User successfully submits member removal.
 
-
 | Property        | Type   | Description                     |
 | --------------- | ------ | ------------------------------- |
 | `treasury_id`   | string | Treasury ID                     |
 | `members_count` | number | Number of members being removed |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/members/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/members/page.tsx>)
 
 ---
 
@@ -232,15 +247,13 @@ User successfully submits member removal.
 
 User submits a single payment request.
 
-
 | Property       | Type          | Description                        |
 | -------------- | ------------- | ---------------------------------- |
 | `treasury_id`  | string        | Treasury ID                        |
 | `token_symbol` | string        | Token symbol (e.g. `NEAR`, `USDC`) |
 | `amount`       | string/number | Payment amount                     |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx>)
 
 ---
 
@@ -248,14 +261,12 @@ User submits a single payment request.
 
 User clicks the bulk payments button on the payments page.
 
-
 | Property      | Type   | Description       |
 | ------------- | ------ | ----------------- |
 | `source`      | string | `"payments_page"` |
 | `treasury_id` | string | Treasury ID       |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx>)
 
 ---
 
@@ -263,15 +274,13 @@ User clicks the bulk payments button on the payments page.
 
 User reaches the review step in the bulk payment flow.
 
+| Property           | Type   | Description                  |
+| ------------------ | ------ | ---------------------------- | ------------- | --------------- |
+| `source`           | string | `"upload_continue"`          | `"edit_save"` | `"edit_cancel"` |
+| `treasury_id`      | string | Treasury ID                  |
+| `recipients_count` | number | Number of payment recipients |
 
-| Property           | Type   | Description                                           |
-| ------------------ | ------ | ----------------------------------------------------- |
-| `source`           | string | `"upload_continue"` | `"edit_save"` | `"edit_cancel"` |
-| `treasury_id`      | string | Treasury ID                                           |
-| `recipients_count` | number | Number of payment recipients                          |
-
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx>)
 
 ---
 
@@ -279,14 +288,12 @@ User reaches the review step in the bulk payment flow.
 
 User clicks submit on the bulk payments review step.
 
-
 | Property      | Type   | Description                   |
 | ------------- | ------ | ----------------------------- |
 | `source`      | string | `"bulk_payments_review_step"` |
 | `treasury_id` | string | Treasury ID                   |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx](../nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx](<../nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx>)
 
 ---
 
@@ -294,15 +301,13 @@ User clicks submit on the bulk payments review step.
 
 Bulk payment batch is successfully submitted on-chain.
 
-
 | Property           | Type   | Description                       |
 | ------------------ | ------ | --------------------------------- |
 | `treasury_id`      | string | Treasury ID                       |
 | `token_symbol`     | string | Token symbol                      |
 | `recipients_count` | number | Number of recipients in the batch |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx>)
 
 ---
 
@@ -312,15 +317,13 @@ Bulk payment batch is successfully submitted on-chain.
 
 User submits a token swap proposal.
 
-
 | Property               | Type   | Description          |
 | ---------------------- | ------ | -------------------- |
 | `treasury_id`          | string | Treasury ID          |
 | `sell_token_symbol`    | string | Token being sold     |
 | `receive_token_symbol` | string | Token being received |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/exchange/page.tsx>)
 
 ---
 
@@ -330,14 +333,12 @@ User submits a token swap proposal.
 
 User opens a request/proposal detail page.
 
-
 | Property      | Type   | Description |
 | ------------- | ------ | ----------- |
 | `proposal_id` | string | Proposal ID |
 | `treasury_id` | string | Treasury ID |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/requests/[id]/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/requests/[id]/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/requests/[id]/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/requests/[id]/page.tsx>)
 
 ---
 
@@ -345,13 +346,11 @@ User opens a request/proposal detail page.
 
 User submits a vote on one or more proposals.
 
-
 | Property          | Type   | Description                               |
 | ----------------- | ------ | ----------------------------------------- |
 | `vote`            | string | Vote value (e.g. `"approve"`, `"reject"`) |
 | `proposals_count` | number | Number of proposals voted on              |
 | `treasury_id`     | string | Treasury ID                               |
-
 
 **Source:** [nt-fe/stores/near-store.ts](../nt-fe/stores/near-store.ts)
 
@@ -363,7 +362,6 @@ User submits a vote on one or more proposals.
 
 User selects both an asset and a network in the deposit modal.
 
-
 | Property       | Type   | Description                   |
 | -------------- | ------ | ----------------------------- |
 | `treasury_id`  | string | Treasury ID                   |
@@ -372,8 +370,7 @@ User selects both an asset and a network in the deposit modal.
 | `network_id`   | string | Selected network ID           |
 | `network_name` | string | Selected network display name |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx](../nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx](<../nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx>)
 
 ---
 
@@ -383,12 +380,10 @@ User selects both an asset and a network in the deposit modal.
 
 User clicks the export button (CSV/report download shortcut).
 
-
 | Property      | Type   | Description       |
 | ------------- | ------ | ----------------- |
 | `source`      | string | `"export_button"` |
 | `treasury_id` | string | Treasury ID       |
-
 
 **Source:** [nt-fe/components/export-button.tsx](../nt-fe/components/export-button.tsx)
 
@@ -398,16 +393,12 @@ User clicks the export button (CSV/report download shortcut).
 
 User clicks "Generate" on the full export page.
 
-
 | Property        | Type   | Description                     |
 | --------------- | ------ | ------------------------------- |
 | `source`        | string | `"dashboard_export_page"`       |
 | `treasury_id`   | string | Treasury ID                     |
 | `document_type` | string | Type of document being exported |
 
-
-**Source:** [nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx](../nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx)
+**Source:** [nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx](<../nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx>)
 
 ---
-
-

--- a/nt-fe/features/onboarding/components/create-treasury-entry.tsx
+++ b/nt-fe/features/onboarding/components/create-treasury-entry.tsx
@@ -169,6 +169,7 @@ export function TreasuryOnboardingPage({
     const [isWaitlistSubmitted, setIsWaitlistSubmitted] = useState(false);
     const [showWaitlist, setShowWaitlist] = useState(false);
     const pendingAutoCreateRef = useRef(false);
+    const hasTrackedOnboardingEntry = useRef(false);
     const waitlistCardClassName =
         "mx-auto h-[516px] w-full max-w-[600px] items-center justify-center gap-5 overflow-hidden rounded-xl border border-border bg-card p-4";
     const waitlistSubtextClassName =
@@ -201,6 +202,34 @@ export function TreasuryOnboardingPage({
         pathname,
         preferredTreasuryId,
         router,
+        shouldKeepUserOnCreatePage,
+    ]);
+
+    useEffect(() => {
+        if (isInitializing || isLoading || hasTrackedOnboardingEntry.current) {
+            return;
+        }
+
+        hasTrackedOnboardingEntry.current = true;
+
+        if (!shouldKeepUserOnCreatePage && accountId && preferredTreasuryId) {
+            trackEvent("onboarding_existing_treasury_redirect", {
+                entry_page: pathname,
+                treasury_id: preferredTreasuryId,
+            });
+            return;
+        }
+
+        trackEvent("onboarding_landed", {
+            page: pathname,
+            is_authenticated: !!accountId,
+        });
+    }, [
+        accountId,
+        isInitializing,
+        isLoading,
+        pathname,
+        preferredTreasuryId,
         shouldKeepUserOnCreatePage,
     ]);
 
@@ -363,11 +392,9 @@ export function TreasuryOnboardingPage({
                     );
                     setCreatedTreasuryId(treasuryId);
                     trackEvent("treasury-created", {
-                        source: "/",
                         treasury_id: treasuryId,
                     });
                     trackEvent("onboarding-completed", {
-                        source: "/",
                         treasury_id: treasuryId,
                     });
                     queryClient.invalidateQueries({
@@ -637,7 +664,7 @@ export function TreasuryOnboardingPage({
                 }
                 onConnectSupported={async (walletId?: string) => {
                     if (authError) clearError();
-                    await connect(walletId);
+                    await connect(walletId, isCreateRoute ? "/create" : "/");
                 }}
             />
         </div>

--- a/nt-fe/stores/near-store.ts
+++ b/nt-fe/stores/near-store.ts
@@ -157,7 +157,10 @@ interface NearStore {
     init: (options?: {
         targetWalletId?: string;
     }) => Promise<NearConnector | undefined>;
-    connect: (walletId?: string) => Promise<void>;
+    connect: (
+        walletId?: string,
+        onboardingPage?: "/" | "/create",
+    ) => Promise<void>;
     disconnect: () => Promise<void>;
 
     // Auth actions
@@ -289,7 +292,7 @@ export const useNearStore = create<NearStore>((set, get) => ({
         return newConnector;
     },
 
-    connect: async (walletId?: string) => {
+    connect: async (walletId?: string, onboardingPage?: "/" | "/create") => {
         const { init } = get();
         const newConnector = await init({ targetWalletId: walletId });
         if (!newConnector) {
@@ -364,6 +367,12 @@ export const useNearStore = create<NearStore>((set, get) => ({
                 source: "resolve-auth",
                 account_id: loginResponse.accountId,
             });
+            if (onboardingPage) {
+                trackEvent("onboarding_login_completed", {
+                    page: onboardingPage,
+                    account_id: loginResponse.accountId,
+                });
+            }
         } catch (error) {
             console.error("Authentication failed:", error);
             set({


### PR DESCRIPTION
Adds custom PostHog events for the onboarding flow so we can measure real new-user conversion, not just pageviews.

Previously, `$pageview` on `/` included returning users who were immediately redirected to their treasury, and login timing didn’t match the actual flow (`/` → login → `/create` → create). The funnel was misleading.

## What changed

- **`onboarding_landed`** — fires when someone actually starts onboarding (not when bounced to an existing treasury)
- **`onboarding_existing_treasury_redirect`** — tracks returning users separately so they don’t pollute the funnel
- **`onboarding_login_completed`** — fires only for wallet login during onboarding (`/` or `/create`), not `/login`
- Updated **`docs/ANALYTICS_EVENTS.md`** with the new funnel and removed obsolete events

## PostHog funnel

`onboarding_landed` → `onboarding_login_completed` → `treasury-created`