### PR TITLE
fix: make creation idempotent, resumable, and auto-retrying

### DIFF
--- a/nt-be/src/app_state.rs
+++ b/nt-be/src/app_state.rs
@@ -16,6 +16,48 @@ use crate::{
     },
 };
 
+/// Per-endpoint RPC retries before near-api fails over to the next endpoint
+/// (near-api's default is 5). Bumped so transient RPC hiccups are absorbed
+/// before giving up on an endpoint.
+///
+/// NOTE: near-api only fails over on retryable errors (HTTP 408/429/5xx from a
+/// reachable server); hard connection errors and client timeouts are treated as
+/// `Critical` and abort immediately without failover. Timeout/connection
+/// resilience therefore comes from the multiple endpoints.
+const RPC_ENDPOINT_RETRIES: u8 = 7;
+
+/// Build the default mainnet RPC endpoints with provider-level failover.
+///
+/// FastNEAR (authenticated) is primary; public providers act as fallbacks so a
+/// single degraded provider can't stall signing/read flows.
+fn default_mainnet_endpoints(fastnear_api_key: &str) -> Vec<RPCEndpoint> {
+    vec![
+        RPCEndpoint::new("https://rpc.mainnet.fastnear.com/".parse().unwrap())
+            .with_api_key(fastnear_api_key.to_string())
+            .with_retries(RPC_ENDPOINT_RETRIES),
+        // Open fallbacks (no API key).
+        RPCEndpoint::new("https://rpc.mainnet.near.org".parse().unwrap())
+            .with_retries(RPC_ENDPOINT_RETRIES),
+        RPCEndpoint::new("https://free.rpc.fastnear.com".parse().unwrap())
+            .with_retries(RPC_ENDPOINT_RETRIES),
+    ]
+}
+
+/// Build the default mainnet archival RPC endpoints with provider-level failover.
+fn default_mainnet_archival_endpoints(fastnear_api_key: &str) -> Vec<RPCEndpoint> {
+    vec![
+        RPCEndpoint::new(
+            "https://archival-rpc.mainnet.fastnear.com/"
+                .parse()
+                .unwrap(),
+        )
+        .with_api_key(fastnear_api_key.to_string())
+        .with_retries(RPC_ENDPOINT_RETRIES),
+        RPCEndpoint::new("https://archival-rpc.mainnet.near.org".parse().unwrap())
+            .with_retries(RPC_ENDPOINT_RETRIES),
+    ]
+}
+
 pub struct AppState {
     pub http_client: reqwest::Client,
     pub cache: Cache,
@@ -226,12 +268,9 @@ impl AppStateBuilder {
                     ..NetworkConfig::testnet() // Use testnet defaults for sandbox
                 }
             } else {
-                // Otherwise use mainnet with FastNEAR
+                // Otherwise use mainnet with FastNEAR (+ public fallbacks)
                 NetworkConfig {
-                    rpc_endpoints: vec![
-                        RPCEndpoint::new("https://rpc.mainnet.fastnear.com/".parse().unwrap())
-                            .with_api_key(fastnear_api_key.clone()),
-                    ],
+                    rpc_endpoints: default_mainnet_endpoints(&fastnear_api_key),
                     ..NetworkConfig::mainnet()
                 }
             }
@@ -259,14 +298,7 @@ impl AppStateBuilder {
                 }
             } else {
                 NetworkConfig {
-                    rpc_endpoints: vec![
-                        RPCEndpoint::new(
-                            "https://archival-rpc.mainnet.fastnear.com/"
-                                .parse()
-                                .unwrap(),
-                        )
-                        .with_api_key(fastnear_api_key),
-                    ],
+                    rpc_endpoints: default_mainnet_archival_endpoints(&fastnear_api_key),
                     ..NetworkConfig::mainnet()
                 }
             }

--- a/nt-be/src/handlers/treasury/confidential_setup.rs
+++ b/nt-be/src/handlers/treasury/confidential_setup.rs
@@ -33,86 +33,100 @@ pub async fn setup_confidential_treasury(
     target_policy: Value,
     progress: Option<&mpsc::Sender<ProgressEvent>>,
 ) -> Result<(), (StatusCode, String)> {
-    // ── Add Public Key to intents.near ──────────────────────────────────
+    // ── Add Public Key to intents.near (idempotent) ─────────────────────
     if let Some(tx) = progress {
         send_progress(tx, "adding_public_key", "in_progress").await;
     }
 
     let treasury_id_public_key = fetch_mpc_public_key(state, treasury_id.as_str()).await?;
 
-    let public_key_args = json!({
-        "public_key": treasury_id_public_key,
-    });
-    let public_key_args_b64 =
-        base64::engine::general_purpose::STANDARD.encode(public_key_args.to_string());
-    submit_and_approve_proposal(
-        state,
-        treasury_id,
-        json!({
-        "proposal": {
-            "description": "Add public key to intents.near",
-            "kind": {
-                "FunctionCall": {
-                    "receiver_id": INTENTS_CONTRACT_ID,
-                    "actions": [{
-                        "method_name": "add_public_key",
-                        "args": public_key_args_b64,
-                        "deposit": "1",
-                        "gas": NearGas::from_tgas(5),
-                    }],
+    if intents_has_public_key(state, treasury_id, &treasury_id_public_key).await? {
+        tracing::info!(
+            "Confidential setup: public key already registered for {}, skipping add",
+            treasury_id
+        );
+    } else {
+        let public_key_args = json!({
+            "public_key": treasury_id_public_key,
+        });
+        let public_key_args_b64 =
+            base64::engine::general_purpose::STANDARD.encode(public_key_args.to_string());
+        submit_and_approve_proposal(
+            state,
+            treasury_id,
+            json!({
+            "proposal": {
+                "description": "Add public key to intents.near",
+                "kind": {
+                    "FunctionCall": {
+                        "receiver_id": INTENTS_CONTRACT_ID,
+                        "actions": [{
+                            "method_name": "add_public_key",
+                            "args": public_key_args_b64,
+                            "deposit": "1",
+                            "gas": NearGas::from_tgas(5),
+                        }],
+                    }
                 }
-            }
-        }}),
-    )
-    .await?;
+            }}),
+        )
+        .await?;
+    }
 
     if let Some(tx) = progress {
         send_progress(tx, "adding_public_key", "completed").await;
     }
 
-    // ── Auth proposal ───────────────────────────────────────────────────
+    // ── Auth proposal + 1Click authentication (idempotent) ──────────────
     if let Some(tx) = progress {
         send_progress(tx, "authenticating", "in_progress").await;
     }
 
-    tracing::info!(
-        "Confidential setup: creating auth proposal for {}",
-        treasury_id
-    );
+    if has_valid_confidential_token(&state.db_pool, treasury_id).await {
+        tracing::info!(
+            "Confidential setup: {} already authenticated with 1Click, skipping auth",
+            treasury_id
+        );
+    } else {
+        tracing::info!(
+            "Confidential setup: creating auth proposal for {}",
+            treasury_id
+        );
 
-    let (auth_proposal, auth_payload) = build_auth_proposal(state, treasury_id.as_str()).await?;
+        let (auth_proposal, auth_payload) =
+            build_auth_proposal(state, treasury_id.as_str()).await?;
 
-    let (proposal_id, vote_result_debug) =
-        submit_and_approve_proposal(state, treasury_id, auth_proposal).await?;
+        let (proposal_id, vote_result_debug) =
+            submit_and_approve_proposal(state, treasury_id, auth_proposal).await?;
 
-    tracing::info!(
-        "Confidential setup: auth proposal #{} approved for {}",
-        proposal_id,
-        treasury_id
-    );
+        tracing::info!(
+            "Confidential setup: auth proposal #{} approved for {}",
+            proposal_id,
+            treasury_id
+        );
 
-    // ── Authenticate with 1Click ────────────────────────────────────────
-    let sig_bytes = extract_mpc_signature(&vote_result_debug).ok_or_else(|| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to extract MPC signature from auth proposal result".to_string(),
+        let sig_bytes = extract_mpc_signature(&vote_result_debug).ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to extract MPC signature from auth proposal result".to_string(),
+            )
+        })?;
+        let sig_b58 = format!("ed25519:{}", bs58::encode(&sig_bytes).into_string());
+
+        authenticate_with_1click(
+            state,
+            treasury_id,
+            &treasury_id_public_key,
+            &auth_payload,
+            &sig_b58,
         )
-    })?;
-    let sig_b58 = format!("ed25519:{}", bs58::encode(&sig_bytes).into_string());
+        .await?;
 
-    authenticate_with_1click(
-        state,
-        treasury_id,
-        &treasury_id_public_key,
-        &auth_payload,
-        &sig_b58,
-    )
-    .await?;
-
-    tracing::info!(
-        "Confidential setup: DAO {} authenticated with 1Click",
-        treasury_id
-    );
+        tracing::info!(
+            "Confidential setup: DAO {} authenticated with 1Click",
+            treasury_id
+        );
+    }
 
     if let Some(tx) = progress {
         send_progress(tx, "authenticating", "completed").await;
@@ -148,6 +162,56 @@ pub async fn setup_confidential_treasury(
     }
 
     Ok(())
+}
+
+/// Check whether `intents.near` already has the given public key registered
+/// for the treasury. Used to make the `add_public_key` step idempotent on
+/// resume.
+async fn intents_has_public_key(
+    state: &Arc<AppState>,
+    treasury_id: &AccountId,
+    public_key: &str,
+) -> Result<bool, (StatusCode, String)> {
+    Contract(INTENTS_CONTRACT_ID.into())
+        .call_function(
+            "has_public_key",
+            json!({
+                "account_id": treasury_id.as_str(),
+                "public_key": public_key,
+            }),
+        )
+        .read_only::<bool>()
+        .fetch_from(&state.network)
+        .await
+        .map(|r| r.data)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to check has_public_key on intents.near: {e}"),
+            )
+        })
+}
+
+/// Whether a treasury already holds a non-expired 1Click access token. Used to
+/// skip the auth proposal + 1Click authentication on resume.
+async fn has_valid_confidential_token(pool: &sqlx::PgPool, treasury_id: &AccountId) -> bool {
+    sqlx::query_scalar::<_, bool>(
+        r#"
+        SELECT EXISTS (
+            SELECT 1 FROM monitored_accounts
+            WHERE account_id = $1
+              AND confidential_access_token IS NOT NULL
+              AND (
+                confidential_token_expires_at IS NULL
+                OR confidential_token_expires_at > NOW()
+              )
+        )
+        "#,
+    )
+    .bind(treasury_id.as_str())
+    .fetch_one(pool)
+    .await
+    .unwrap_or(false)
 }
 
 /// Submit a proposal and immediately approve it.

--- a/nt-be/src/handlers/treasury/create.rs
+++ b/nt-be/src/handlers/treasury/create.rs
@@ -6,13 +6,14 @@ use axum::{Json, extract::State};
 use base64::{Engine, prelude::BASE64_STANDARD};
 use bigdecimal::BigDecimal;
 use futures::stream::Stream;
-use near_api::{AccountId, Contract, NearToken, Tokens};
+use near_api::{Account, AccountId, Contract, NearToken, Tokens};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
 use crate::{
     AppState,
     constants::TREASURY_FACTORY_CONTRACT_ID,
+    handlers::balance_changes::utils::is_transport_error,
     services::{
         mark_testing_if_needed, register_new_dao_and_wait, register_or_refresh_monitored_account,
         should_mark_testing,
@@ -23,6 +24,16 @@ use super::confidential_setup;
 
 pub const TREASURY_CREATE_DEPOSIT: NearToken = NearToken::from_millinear(90);
 pub const REGISTERING_DAO_TIMEOUT_IN_SECS: u64 = 10;
+
+/// Total attempts for the idempotent creation flow before surfacing a terminal
+/// error to the client. Retries fire for transient transport/RPC errors
+/// (including near-api `Critical` transport errors like timeouts/connection
+/// failures, which it won't fail over on) — each attempt resumes and skips
+/// already-completed steps.
+const MAX_CREATION_ATTEMPTS: u32 = 4;
+
+/// Cap on the exponential backoff between creation attempts.
+const MAX_CREATION_RETRY_BACKOFF_MS: u64 = 4_000;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -301,29 +312,194 @@ async fn treasury_creation_blocked(state: &AppState) -> bool {
     })
 }
 
+/// Whether a failed creation attempt should be retried: only transient
+/// transport/RPC errors are retried, and only while attempts remain.
+fn creation_error_retryable(attempt: u32, message: &str) -> bool {
+    attempt < MAX_CREATION_ATTEMPTS && is_transport_error(message)
+}
+
+/// Build an SSE error event with the given message.
+fn error_event(message: String) -> ProgressEvent {
+    ProgressEvent {
+        step: "error",
+        status: "error",
+        treasury: None,
+        message: Some(message),
+    }
+}
+
+/// On-chain classification of a treasury account, used to make creation
+/// idempotent/resumable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExistingDaoState {
+    /// Account does not exist yet — proceed to create it.
+    Absent,
+    /// Account exists and our backend signer is still a policy member — a
+    /// partially-completed (confidential) setup we own; safe to resume.
+    OursIncomplete,
+    /// Account exists and ownership already reflects the user's members — the
+    /// prior run effectively finished; skip creation/setup and finalize.
+    AlreadyOwnedByUser,
+    /// Account exists but is not ours — the handle is taken by someone else.
+    Taken,
+}
+
+/// Fetch a DAO's current sputnik policy.
+async fn fetch_dao_policy(
+    state: &AppState,
+    treasury: &AccountId,
+) -> Result<serde_json::Value, String> {
+    Contract(treasury.clone())
+        .call_function("get_policy", ())
+        .read_only::<serde_json::Value>()
+        .fetch_from(&state.network)
+        .await
+        .map(|r| r.data)
+        .map_err(|e| format!("Failed to fetch DAO policy: {e}"))
+}
+
+/// Collect all member account IDs across every `Group` role in a policy.
+fn policy_group_members(policy: &serde_json::Value) -> HashSet<String> {
+    let mut members = HashSet::new();
+    if let Some(roles) = policy.get("roles").and_then(|r| r.as_array()) {
+        for role in roles {
+            if let Some(group) = role
+                .get("kind")
+                .and_then(|k| k.get("Group"))
+                .and_then(|g| g.as_array())
+            {
+                for m in group {
+                    if let Some(s) = m.as_str() {
+                        members.insert(s.to_string());
+                    }
+                }
+            }
+        }
+    }
+    members
+}
+
+/// Determine whether the treasury account already exists and, if so, whether
+/// it's a resumable half-created DAO we own, an already-finished one, or a
+/// name taken by someone else.
+async fn classify_treasury_account(
+    state: &AppState,
+    treasury: &AccountId,
+    signer_id: &str,
+    expected_members: &HashSet<String>,
+) -> Result<ExistingDaoState, String> {
+    match Account(treasury.clone())
+        .view()
+        .fetch_from(&state.network)
+        .await
+    {
+        Err(e) if e.to_string().contains("UnknownAccount") => Ok(ExistingDaoState::Absent),
+        Err(e) => Err(format!("Failed to check treasury account: {e}")),
+        Ok(_) => {
+            // Account exists — inspect its DAO policy to decide ownership.
+            let policy = fetch_dao_policy(state, treasury).await?;
+            let members = policy_group_members(&policy);
+            if members.contains(signer_id) {
+                // Backend signer still controls the DAO → sponsor-only policy,
+                // confidential setup never finished. Resume it.
+                Ok(ExistingDaoState::OursIncomplete)
+            } else if !expected_members.is_empty() && expected_members.is_subset(&members) {
+                // Ownership already handed to the user's members.
+                Ok(ExistingDaoState::AlreadyOwnedByUser)
+            } else {
+                Ok(ExistingDaoState::Taken)
+            }
+        }
+    }
+}
+
+/// Entry point spawned by the SSE handler. Serializes concurrent/duplicate
+/// creation attempts for the same treasury behind a Postgres advisory lock,
+/// then runs the (idempotent, resumable) creation flow.
 async fn run_creation(
     state: Arc<AppState>,
     payload: CreateTreasuryRequest,
     tx: mpsc::Sender<ProgressEvent>,
 ) -> Result<(), ProgressEvent> {
     let treasury = payload.account_id.clone();
-    let is_confidential = payload.is_confidential;
 
     if treasury_creation_blocked(&state).await {
         let message = format!("Treasury creation disabled. Treasury: {treasury} is not created.");
         if let Err(e) = state.telegram_client.send_message(&message).await {
             tracing::warn!("Failed to send Telegram notification: {}", e);
         }
-        return Err(ProgressEvent {
-            step: "error",
-            status: "error",
-            treasury: None,
-            message: Some(message),
-        });
+        return Err(error_event(message));
     }
 
-    // ── Step 1: Create DAO ─────────────────────────────────────────────
-    send_progress(&tx, "creating_dao", "in_progress").await;
+    // Per-account advisory lock: two concurrent create-stream calls for the
+    // same treasury must not run the multi-step flow at the same time. We hold
+    // a dedicated connection for the lock's lifetime and unlock explicitly
+    // (returning a pooled connection does not release a session-level lock).
+    let mut lock_conn = state.db_pool.acquire().await.map_err(|e| {
+        tracing::error!("Failed to acquire DB connection for creation lock: {e}");
+        error_event(format!("Internal error acquiring creation lock: {e}"))
+    })?;
+
+    let locked: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock(hashtext($1)::bigint)")
+        .bind(treasury.as_str())
+        .fetch_one(&mut *lock_conn)
+        .await
+        .unwrap_or(false);
+
+    if !locked {
+        return Err(error_event(format!(
+            "Treasury creation is already in progress for {treasury}. Please wait for it to finish."
+        )));
+    }
+
+    // Auto-retry the (idempotent) flow on transient failures so the user never
+    // has to intervene. The spawned task outlives the SSE connection, so this
+    // keeps making progress even if the client disconnects.
+    let mut result = Ok(());
+    for attempt in 1..=MAX_CREATION_ATTEMPTS {
+        result = run_creation_inner(&state, &payload, &tx).await;
+
+        match &result {
+            Ok(()) => break,
+            Err(evt) => {
+                let message = evt.message.as_deref().unwrap_or_default();
+                if !creation_error_retryable(attempt, message) {
+                    break;
+                }
+                let delay = std::time::Duration::from_millis(
+                    (500 * 2u64.pow(attempt - 1)).min(MAX_CREATION_RETRY_BACKOFF_MS),
+                );
+                tracing::warn!(
+                    "Treasury creation for {} failed on attempt {}/{} (retryable): {}. Retrying in {:?}",
+                    treasury,
+                    attempt,
+                    MAX_CREATION_ATTEMPTS,
+                    message,
+                    delay
+                );
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+
+    if let Err(e) = sqlx::query("SELECT pg_advisory_unlock(hashtext($1)::bigint)")
+        .bind(treasury.as_str())
+        .execute(&mut *lock_conn)
+        .await
+    {
+        tracing::warn!("Failed to release creation lock for {}: {}", treasury, e);
+    }
+
+    result
+}
+
+async fn run_creation_inner(
+    state: &Arc<AppState>,
+    payload: &CreateTreasuryRequest,
+    tx: &mpsc::Sender<ProgressEvent>,
+) -> Result<(), ProgressEvent> {
+    let treasury = payload.account_id.clone();
+    let is_confidential = payload.is_confidential;
 
     let user_policy = build_policy(
         &payload.requestors,
@@ -340,45 +516,61 @@ async fn run_creation(
         user_policy.clone()
     };
 
-    let args = prepare_args(&payload, &creation_policy).map_err(|e| {
-        tracing::error!("Error preparing args: {}", e);
-        ProgressEvent {
-            step: "error",
-            status: "error",
-            treasury: None,
-            message: Some(e.to_string()),
+    let payload_members = collect_payload_members(payload);
+
+    // ── Step 1: Create DAO (idempotent / resumable) ────────────────────
+    send_progress(tx, "creating_dao", "in_progress").await;
+
+    let existing =
+        classify_treasury_account(state, &treasury, state.signer_id.as_str(), &payload_members)
+            .await
+            .map_err(error_event)?;
+
+    let mut did_create = false;
+    match existing {
+        ExistingDaoState::Taken => {
+            return Err(error_event(format!(
+                "Treasury {treasury} already exists and is not managed by this platform."
+            )));
         }
-    })?;
+        ExistingDaoState::Absent => {
+            let args = prepare_args(payload, &creation_policy).map_err(|e| {
+                tracing::error!("Error preparing args: {}", e);
+                error_event(e.to_string())
+            })?;
 
-    Contract(TREASURY_FACTORY_CONTRACT_ID.into())
-        .call_function("create", args)
-        .transaction()
-        .max_gas()
-        .deposit(TREASURY_CREATE_DEPOSIT)
-        .with_signer(state.signer_id.clone(), state.signer.clone())
-        .send_to(&state.network)
-        .await
-        .map_err(|e| {
-            tracing::error!("Error creating treasury: {}", e);
-            ProgressEvent {
-                step: "error",
-                status: "error",
-                treasury: None,
-                message: Some(format!("Failed to create treasury: {e}")),
-            }
-        })?
-        .into_result()
-        .map_err(|e| {
-            tracing::error!("Error creating treasury: {}", e);
-            ProgressEvent {
-                step: "error",
-                status: "error",
-                treasury: None,
-                message: Some(format!("Failed to create treasury: {e}")),
-            }
-        })?;
+            // near-api retries the broadcast of this single signed transaction
+            // across endpoints (same tx hash → no duplicate), so we don't add
+            // an app-level retry that would re-sign and risk a second DAO.
+            Contract(TREASURY_FACTORY_CONTRACT_ID.into())
+                .call_function("create", args)
+                .transaction()
+                .max_gas()
+                .deposit(TREASURY_CREATE_DEPOSIT)
+                .with_signer(state.signer_id.clone(), state.signer.clone())
+                .send_to(&state.network)
+                .await
+                .map_err(|e| {
+                    tracing::error!("Error creating treasury: {}", e);
+                    error_event(format!("Failed to create treasury: {e}"))
+                })?
+                .into_result()
+                .map_err(|e| {
+                    tracing::error!("Error creating treasury: {}", e);
+                    error_event(format!("Failed to create treasury: {e}"))
+                })?;
+            did_create = true;
+        }
+        ExistingDaoState::OursIncomplete | ExistingDaoState::AlreadyOwnedByUser => {
+            tracing::info!(
+                "Resuming treasury creation for {} (existing state: {:?})",
+                treasury,
+                existing
+            );
+        }
+    }
 
-    send_progress(&tx, "creating_dao", "completed").await;
+    send_progress(tx, "creating_dao", "completed").await;
 
     if let Err(e) =
         register_or_refresh_monitored_account(&state.db_pool, &treasury, is_confidential).await
@@ -386,41 +578,40 @@ async fn run_creation(
         tracing::warn!("Failed to add treasury to monitored accounts: {:?}", e);
     }
 
-    let creation_cost: BigDecimal = TREASURY_CREATE_DEPOSIT.as_yoctonear().into();
-    if let Err(e) = sqlx::query!(
-        r#"
+    // Only charge the creation deposit + stamp created_by_trezu_at when we
+    // actually broadcast the create this run; resumes must not double-count.
+    if did_create {
+        let creation_cost: BigDecimal = TREASURY_CREATE_DEPOSIT.as_yoctonear().into();
+        if let Err(e) = sqlx::query!(
+            r#"
         UPDATE monitored_accounts
         SET paid_near = paid_near + $2,
             created_by_trezu_at = NOW(),
             updated_at = NOW()
         WHERE account_id = $1
         "#,
-        treasury.as_str(),
-        creation_cost,
-    )
-    .execute(&state.db_pool)
-    .await
-    {
-        tracing::warn!(
-            "Failed to update paid_near for {}: {}",
             treasury.as_str(),
-            e
-        );
+            creation_cost,
+        )
+        .execute(&state.db_pool)
+        .await
+        {
+            tracing::warn!(
+                "Failed to update paid_near for {}: {}",
+                treasury.as_str(),
+                e
+            );
+        }
     }
 
-    // ── Confidential setup ─────────────────────────────────────────────
-    if is_confidential {
-        confidential_setup::setup_confidential_treasury(&state, &treasury, user_policy, Some(&tx))
+    // ── Confidential setup (idempotent per-step) ───────────────────────
+    // Skip entirely if ownership already transferred to the user (finished).
+    if is_confidential && existing != ExistingDaoState::AlreadyOwnedByUser {
+        confidential_setup::setup_confidential_treasury(state, &treasury, user_policy, Some(tx))
             .await
-            .map_err(|(_, msg)| ProgressEvent {
-                step: "error",
-                status: "error",
-                treasury: None,
-                message: Some(msg),
-            })?;
+            .map_err(|(_, msg)| error_event(msg))?;
     }
 
-    let payload_members = collect_payload_members(&payload);
     let should_mark = should_mark_testing(
         treasury.as_str(),
         &payload_members,
@@ -441,7 +632,7 @@ async fn run_creation(
         };
 
     // ── Finalize ───────────────────────────────────────────────────────
-    send_progress(&tx, "finalizing", "in_progress").await;
+    send_progress(tx, "finalizing", "in_progress").await;
 
     match register_new_dao_and_wait(
         &state.db_pool,
@@ -479,7 +670,7 @@ async fn run_creation(
         tracing::warn!("Failed to send Telegram notification: {}", e);
     }
 
-    send_progress(&tx, "finalizing", "completed").await;
+    send_progress(tx, "finalizing", "completed").await;
 
     // ── Done ───────────────────────────────────────────────────────────
     let _ = tx
@@ -497,6 +688,49 @@ async fn run_creation(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn creation_retry_only_on_transport_errors() {
+        // Transient transport errors are retried while attempts remain.
+        assert!(creation_error_retryable(
+            1,
+            "TransportError: error sending request"
+        ));
+        assert!(creation_error_retryable(1, "operation timed out"));
+        assert!(creation_error_retryable(
+            MAX_CREATION_ATTEMPTS - 1,
+            "connection reset"
+        ));
+
+        // Non-transport (logic) errors are never retried.
+        assert!(!creation_error_retryable(
+            1,
+            "Treasury already exists and is not managed by this platform."
+        ));
+        assert!(!creation_error_retryable(1, "1Click auth failed (400)"));
+
+        // No retry on the final attempt, even for transport errors.
+        assert!(!creation_error_retryable(
+            MAX_CREATION_ATTEMPTS,
+            "connection timed out"
+        ));
+    }
+
+    #[test]
+    fn policy_group_members_extracts_all_group_roles() {
+        let policy = build_policy(
+            &["req.near".parse().unwrap()],
+            &["gov.near".parse().unwrap()],
+            &["fin.near".parse().unwrap()],
+            1,
+            1,
+        );
+        let members = policy_group_members(&policy);
+        assert!(members.contains("req.near"));
+        assert!(members.contains("gov.near"));
+        assert!(members.contains("fin.near"));
+        assert_eq!(members.len(), 3);
+    }
 
     #[test]
     fn collect_payload_members_deduplicates_roles() {

--- a/nt-be/tests/rpc_failover_test.rs
+++ b/nt-be/tests/rpc_failover_test.rs
@@ -1,0 +1,152 @@
+//! Real-RPC failover + parity checks for the multi-endpoint NetworkConfig used
+//! by treasury creation.
+//!
+//!   * HTTP 408/429/5xx from a *reachable* provider  -> failover to next endpoint
+//!   * Hard connection error / client timeout          -> `Critical`, NO failover
+//!
+//! The second case is why the creation flow ALSO wraps everything in an
+//! idempotent, transport-aware retry loop (`run_creation`): near-api alone will
+//! not fail over when the primary provider is unreachable or hangs.
+//!
+
+mod common;
+
+use near_api::{Contract, NetworkConfig, RPCEndpoint};
+use serde_json::json;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const DEAD_PRIMARY: &str = "http://127.0.0.1:9"; // closed port → connection refused
+const DEAD_SECONDARY: &str = "http://127.0.0.1:19";
+const FREE_FASTNEAR: &str = "https://free.rpc.fastnear.com";
+const NEAR_ORG: &str = "https://rpc.mainnet.near.org";
+
+/// A read-only call identical in shape to the confidential idempotency guard.
+/// Always returns false, but proves the endpoint accepts the exact request our
+/// flow sends. Uses the real near-api client path.
+async fn has_public_key(network: &NetworkConfig) -> Result<bool, String> {
+    Contract("intents.near".parse().unwrap())
+        .call_function(
+            "has_public_key",
+            json!({
+                "account_id": "intents.near",
+                "public_key": "ed25519:11111111111111111111111111111111",
+            }),
+        )
+        .read_only::<bool>()
+        .fetch_from(network)
+        .await
+        .map(|r| r.data)
+        .map_err(|e| format!("{e:?}"))
+}
+
+fn ep(url: &str) -> RPCEndpoint {
+    RPCEndpoint::new(url.parse().unwrap()).with_retries(2)
+}
+
+/// SURPRISING near-api behavior, pinned by this test: even a plain HTTP 503
+/// from the primary does NOT fail over. A bare 503 (non-schema body) is decoded
+/// as `UnexpectedResponse`, which near-api treats as `Critical` → it returns
+/// immediately and never tries the healthy fallback. (Only a schema-matching
+/// typed error at 408/429/5xx would fail over, which real providers rarely
+/// return.) This is why endpoint failover can't be relied on and the creation
+/// flow uses an application-level retry loop instead.
+#[tokio::test]
+async fn http_5xx_does_not_fail_over() {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&mock)
+        .await;
+
+    let network = NetworkConfig {
+        rpc_endpoints: vec![ep(&mock.uri()), ep(NEAR_ORG)],
+        ..NetworkConfig::mainnet()
+    };
+
+    let result = has_public_key(&network).await;
+    println!("http_5xx_does_not_fail_over: result={result:?}");
+    assert!(
+        result.is_err(),
+        "documents that near-api does NOT fail over on a bare 503, got: {result:?}"
+    );
+}
+
+/// Documents the near-api limitation: a hard connection error on the primary is
+/// `Critical`, so near-api returns immediately WITHOUT trying the fallback.
+/// (Resilience for this case comes from the creation-level retry loop, not from
+/// endpoint failover.)
+#[tokio::test]
+async fn no_failover_on_connection_error() {
+    let network = NetworkConfig {
+        rpc_endpoints: vec![ep(DEAD_PRIMARY), ep(NEAR_ORG)],
+        ..NetworkConfig::mainnet()
+    };
+
+    let result = has_public_key(&network).await;
+    println!("no_failover_on_connection_error: result={result:?}");
+    assert!(
+        result.is_err(),
+        "connection error is Critical in near-api → no failover expected, got: {result:?}"
+    );
+
+    // The surfaced error is transport-classified, so the creation retry loop
+    // (is_transport_error) WILL retry it at the application level.
+    let err = result.unwrap_err();
+    assert!(
+        nt_be::handlers::balance_changes::utils::is_transport_error(&err),
+        "error should be transport-retryable by the creation loop, got: {err}"
+    );
+}
+
+/// All endpoints unreachable → error (which the creation loop then retries).
+#[tokio::test]
+async fn all_endpoints_dead_returns_error() {
+    let network = NetworkConfig {
+        rpc_endpoints: vec![ep(DEAD_PRIMARY), ep(DEAD_SECONDARY)],
+        ..NetworkConfig::mainnet()
+    };
+
+    let result = has_public_key(&network).await;
+    println!("all_endpoints_dead_returns_error: result={result:?}");
+    assert!(
+        result.is_err(),
+        "all-dead endpoints must error, got: {result:?}"
+    );
+}
+
+/// Parity: each production endpoint (incl. authed FastNEAR) returns the SAME
+/// result for the SAME request via the real near-api client path.
+#[tokio::test]
+async fn parity_across_production_endpoints() {
+    let fastnear_key = common::get_fastnear_api_key();
+
+    let endpoints: Vec<(&str, RPCEndpoint)> = vec![
+        (
+            "fastnear (authed)",
+            RPCEndpoint::new("https://rpc.mainnet.fastnear.com/".parse().unwrap())
+                .with_api_key(fastnear_key),
+        ),
+        (
+            "free.fastnear",
+            RPCEndpoint::new(FREE_FASTNEAR.parse().unwrap()),
+        ),
+        ("near.org", RPCEndpoint::new(NEAR_ORG.parse().unwrap())),
+    ];
+
+    let mut results = Vec::new();
+    for (label, endpoint) in endpoints {
+        let network = NetworkConfig {
+            rpc_endpoints: vec![endpoint],
+            ..NetworkConfig::mainnet()
+        };
+        let res = has_public_key(&network).await;
+        println!("parity {label:20} -> {res:?}");
+        results.push(res.unwrap_or_else(|e| panic!("{label} failed: {e}")));
+    }
+
+    assert!(
+        results.windows(2).all(|w| w[0] == w[1]),
+        "all endpoints must return identical results, got: {results:?}"
+    );
+}


### PR DESCRIPTION
#1024

Treasury creation used to get stuck when an RPC call timed out — the DAO would be created but ownership/confidential setup never finished, leaving the user's chosen name "reserved" and unusable.

- **Idempotent & resumable creation:** each step now checks on-chain/DB state before acting, so a re-run skips work that's already done (DAO create, add public key, 1Click auth) instead of duplicating it or failing.
- **Automatic retries:** the creation flow is wrapped in a bounded auto-retry loop (4 attempts, exponential backoff) that resumes from the last completed step on transient RPC/transport errors. Runs in the background, so it keeps going even if the client disconnects.
- **Concurrency guard:** a per-account Postgres advisory lock prevents two create calls for the same treasury from running at the same time.
- **More RPC endpoints + retries:** added fallback mainnet RPC endpoints and raised per-endpoint retries (7) for better resilience.
