### PR TITLE
fix(custom-templates): tier route + UI access to match server gates

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/custom-templates/[slug]/edit/layout.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/custom-templates/[slug]/edit/layout.tsx
@@ -1,0 +1,12 @@
+import { CustomTemplatesGuard } from "../../guard";
+
+/** Editing a template requires ChangePolicy — gate the edit route on top of the subtree guard. */
+export default function EditTemplateLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <CustomTemplatesGuard requireManage>{children}</CustomTemplatesGuard>
+    );
+}

--- a/nt-fe/app/(treasury)/[treasuryId]/custom-templates/create/layout.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/custom-templates/create/layout.tsx
@@ -1,0 +1,12 @@
+import { CustomTemplatesGuard } from "../guard";
+
+/** Authoring a template requires ChangePolicy — gate the create route on top of the subtree guard. */
+export default function CreateTemplateLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <CustomTemplatesGuard requireManage>{children}</CustomTemplatesGuard>
+    );
+}

--- a/nt-fe/app/(treasury)/[treasuryId]/custom-templates/guard.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/custom-templates/guard.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+/**
+ * Route-level guard for the Request Templates subtree (index, create, [slug], edit).
+ *
+ * Closes the view-level gaps the sidebar-only check left open, mirroring the nt-be gates:
+ *  - #1026: direct URL while Custom Requests is disabled in Settings → Developer.
+ *  - #1027: guests / signed-out / non-member viewers reaching the create/authoring UI.
+ *  - list/authoring visibility: only Requestors (can propose) and policy managers (can author) may
+ *    see the list; only managers may reach create/edit (`requireManage`).
+ *
+ * The feature flag already narrows to a signed-in member of a non-guest treasury; on top of that we
+ * require `canAccess` (propose or manage). Writes were always safe (ChangePolicy-gated server-side);
+ * this aligns the UI so no one lands on a page they can't act on.
+ */
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { LoadingScreen } from "@/components/loading-screen";
+import { useCustomRequestsEnabled } from "@/features/proposal-templates/hooks/use-custom-requests-enabled";
+import { useCustomTemplatesAccess } from "@/features/proposal-templates/hooks/use-custom-templates-access";
+import { useTreasury } from "@/hooks/use-treasury";
+
+export function CustomTemplatesGuard({
+    children,
+    requireManage = false,
+}: {
+    children: React.ReactNode;
+    /** Also require authoring (ChangePolicy) permission — for the create/edit pages. */
+    requireManage?: boolean;
+}) {
+    const router = useRouter();
+    const { treasuryId, isLoading: treasuryLoading } = useTreasury();
+    // A disabled flag query reports isLoading=false with data=undefined, so a falsy `enabled` once
+    // everything settled means "not allowed here" — covering feature-off and every non-member case.
+    const { data: enabled, isLoading: flagLoading } =
+        useCustomRequestsEnabled();
+    const {
+        canAccess,
+        canManage,
+        isLoading: accessLoading,
+    } = useCustomTemplatesAccess();
+
+    const settled = !treasuryLoading && !flagLoading && !accessLoading;
+    // May view the subtree at all (feature on + can propose or manage).
+    const canView = !!enabled && canAccess;
+    const allowed = canView && (!requireManage || canManage);
+
+    useEffect(() => {
+        if (!settled || allowed || !treasuryId) {
+            return;
+        }
+        // Send each blocked persona somewhere it can actually act:
+        //  - a proposer who hit create/edit → the list they *can* use;
+        //  - a manager who finds the feature disabled → the Developer toggle to re-enable it;
+        //  - anyone without access (guest / signed-out / non-member) → the treasury dashboard,
+        //    not a Settings tab that is itself hidden from them.
+        let target = `/${treasuryId}/dashboard`;
+        if (canView && requireManage) {
+            target = `/${treasuryId}/custom-templates`;
+        } else if (canManage) {
+            target = `/${treasuryId}/settings?tab=developer`;
+        }
+        router.replace(target);
+    }, [
+        settled,
+        allowed,
+        canView,
+        canManage,
+        requireManage,
+        treasuryId,
+        router,
+    ]);
+
+    // Hold the loading screen until access is known — never flash protected content, nor the
+    // create/edit form for a proposer during the redirect frame.
+    if (!settled || !allowed) {
+        return <LoadingScreen />;
+    }
+    return <>{children}</>;
+}

--- a/nt-fe/app/(treasury)/[treasuryId]/custom-templates/layout.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/custom-templates/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { CustomTemplatesGuard } from "./guard";
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations("customTemplates");
@@ -11,5 +12,5 @@ export default function CustomTemplatesLayout({
 }: {
     children: React.ReactNode;
 }) {
-    return children;
+    return <CustomTemplatesGuard>{children}</CustomTemplatesGuard>;
 }

--- a/nt-fe/app/(treasury)/[treasuryId]/custom-templates/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/custom-templates/page.tsx
@@ -31,6 +31,7 @@ import {
     DialogTitle,
 } from "@/components/modal";
 import { PageComponentLayout } from "@/components/page-component-layout";
+import { Tooltip } from "@/components/tooltip";
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -69,6 +70,35 @@ function HowItWorksLink() {
     );
 }
 
+/**
+ * A primary action that, when the user lacks the required permission, renders disabled with a
+ * tooltip explaining why — per review feedback we show + explain rather than hide, so a member sees
+ * the action exists and understands they'd need a role for it (not that it's broken/taken away).
+ */
+function GatedButton({
+    allowed,
+    tooltip,
+    children,
+    ...buttonProps
+}: {
+    allowed: boolean;
+    tooltip: string;
+} & React.ComponentProps<typeof Button>) {
+    if (allowed) {
+        return <Button {...buttonProps}>{children}</Button>;
+    }
+    return (
+        <Tooltip content={tooltip}>
+            {/* Radix needs a real event target to hover; a disabled <button> emits none, so wrap it. */}
+            <span className="inline-block">
+                <Button {...buttonProps} disabled>
+                    {children}
+                </Button>
+            </span>
+        </Tooltip>
+    );
+}
+
 function EmptyState({
     onCreate,
     canManage,
@@ -77,6 +107,7 @@ function EmptyState({
     canManage: boolean;
 }) {
     const t = useTranslations("customTemplates");
+    const tAuth = useTranslations("auth");
     return (
         <PageCard className="items-center gap-3 py-16 text-center">
             <div className="flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
@@ -92,12 +123,13 @@ function EmptyState({
             </div>
             <div className="flex items-center gap-2">
                 <HowItWorksLink />
-                {/* Only policy managers can author templates; a proposer sees just the docs link. */}
-                {canManage ? (
-                    <Button onClick={onCreate}>
-                        <Plus className="size-4" /> {t("index.createTemplate")}
-                    </Button>
-                ) : null}
+                <GatedButton
+                    allowed={canManage}
+                    tooltip={tAuth("noPermission")}
+                    onClick={onCreate}
+                >
+                    <Plus className="size-4" /> {t("index.createTemplate")}
+                </GatedButton>
             </div>
         </PageCard>
     );
@@ -123,6 +155,7 @@ function TemplateRow({
     onDelete,
 }: TemplateRowProps) {
     const t = useTranslations("customTemplates");
+    const tCreate = useTranslations("createRequestButton");
     return (
         <div className="group flex min-h-[75px] items-center justify-between gap-3 rounded-xl bg-[#FAFAF9] p-4 dark:bg-muted">
             <div className="flex min-w-0 flex-col gap-0.5">
@@ -182,13 +215,16 @@ function TemplateRow({
                         </DropdownMenuContent>
                     </DropdownMenu>
                 ) : null}
-                {/* Filing needs call:AddProposal (templates build a FunctionCall). Hide the entry so a
-                    manager-only or transfer-only member isn't walked into a dead-end fill form. */}
-                {canPropose ? (
-                    <Button onClick={onCreateRequest}>
-                        {t("index.createRequest")}
-                    </Button>
-                ) : null}
+                {/* Filing needs call:AddProposal (templates build a FunctionCall). Disable rather than
+                    hide so a manager-only / transfer-only member sees the action and why it's blocked
+                    instead of being walked into a dead-end fill form. */}
+                <GatedButton
+                    allowed={canPropose}
+                    tooltip={tCreate("noPermission")}
+                    onClick={onCreateRequest}
+                >
+                    {t("index.createRequest")}
+                </GatedButton>
             </div>
         </div>
     );
@@ -196,6 +232,7 @@ function TemplateRow({
 
 export default function CustomTemplatesIndexPage() {
     const t = useTranslations("customTemplates");
+    const tAuth = useTranslations("auth");
     const router = useRouter();
     const { treasuryId } = useTreasury();
     const { canManage, canPropose } = useCustomTemplatesAccess();
@@ -261,15 +298,15 @@ export default function CustomTemplatesIndexPage() {
                             </h2>
                             <div className="flex items-center gap-2">
                                 <HowItWorksLink />
-                                {canManage ? (
-                                    <Button
-                                        variant="secondary"
-                                        onClick={() => go("/create")}
-                                    >
-                                        <Plus className="size-4" />{" "}
-                                        {t("index.addNew")}
-                                    </Button>
-                                ) : null}
+                                <GatedButton
+                                    allowed={canManage}
+                                    tooltip={tAuth("noPermission")}
+                                    variant="secondary"
+                                    onClick={() => go("/create")}
+                                >
+                                    <Plus className="size-4" />{" "}
+                                    {t("index.addNew")}
+                                </GatedButton>
                             </div>
                         </div>
                         <div className="flex flex-col gap-3">

--- a/nt-fe/app/(treasury)/[treasuryId]/custom-templates/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/custom-templates/page.tsx
@@ -42,6 +42,7 @@ import {
     useDeleteProposalTemplate,
     useUpdateProposalTemplate,
 } from "@/features/proposal-templates/hooks/use-proposal-template-mutations";
+import { useCustomTemplatesAccess } from "@/features/proposal-templates/hooks/use-custom-templates-access";
 import { useProposalTemplates } from "@/features/proposal-templates/hooks/use-proposal-templates";
 import { manifestIdOf } from "@/features/proposal-templates/manifest";
 import type { ProposalTemplate } from "@/features/proposal-templates/types";
@@ -68,7 +69,13 @@ function HowItWorksLink() {
     );
 }
 
-function EmptyState({ onCreate }: { onCreate: () => void }) {
+function EmptyState({
+    onCreate,
+    canManage,
+}: {
+    onCreate: () => void;
+    canManage: boolean;
+}) {
     const t = useTranslations("customTemplates");
     return (
         <PageCard className="items-center gap-3 py-16 text-center">
@@ -85,9 +92,12 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
             </div>
             <div className="flex items-center gap-2">
                 <HowItWorksLink />
-                <Button onClick={onCreate}>
-                    <Plus className="size-4" /> {t("index.createTemplate")}
-                </Button>
+                {/* Only policy managers can author templates; a proposer sees just the docs link. */}
+                {canManage ? (
+                    <Button onClick={onCreate}>
+                        <Plus className="size-4" /> {t("index.createTemplate")}
+                    </Button>
+                ) : null}
             </div>
         </PageCard>
     );
@@ -95,6 +105,7 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
 
 interface TemplateRowProps {
     template: ProposalTemplate;
+    canManage: boolean;
     onCreateRequest: () => void;
     onEdit: () => void;
     onTogglePin: () => void;
@@ -103,6 +114,7 @@ interface TemplateRowProps {
 
 function TemplateRow({
     template,
+    canManage,
     onCreateRequest,
     onEdit,
     onTogglePin,
@@ -122,47 +134,52 @@ function TemplateRow({
                 ) : null}
             </div>
             <div className="flex shrink-0 items-center gap-1">
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            aria-label={t("index.actions")}
-                            className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
-                        >
-                            <EllipsisVertical className="size-4" />
-                        </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                        <DropdownMenuItem
-                            onClick={onEdit}
-                            className={MENU_ITEM_CLASS}
-                        >
-                            <Pencil className="size-4" /> {t("index.edit")}
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                            onClick={onTogglePin}
-                            className={MENU_ITEM_CLASS}
-                        >
-                            {template.pinned ? (
-                                <>
-                                    <PinOff className="size-4" />{" "}
-                                    {t("index.unpin")}
-                                </>
-                            ) : (
-                                <>
-                                    <Pin className="size-4" /> {t("index.pin")}
-                                </>
-                            )}
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                            onClick={onDelete}
-                            className={MENU_ITEM_CLASS}
-                        >
-                            <Trash2 className="size-4" /> {t("index.delete")}
-                        </DropdownMenuItem>
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                {/* Edit/Pin/Delete are authoring actions — managers only. Proposers just file. */}
+                {canManage ? (
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                aria-label={t("index.actions")}
+                                className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
+                            >
+                                <EllipsisVertical className="size-4" />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                                onClick={onEdit}
+                                className={MENU_ITEM_CLASS}
+                            >
+                                <Pencil className="size-4" /> {t("index.edit")}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                                onClick={onTogglePin}
+                                className={MENU_ITEM_CLASS}
+                            >
+                                {template.pinned ? (
+                                    <>
+                                        <PinOff className="size-4" />{" "}
+                                        {t("index.unpin")}
+                                    </>
+                                ) : (
+                                    <>
+                                        <Pin className="size-4" />{" "}
+                                        {t("index.pin")}
+                                    </>
+                                )}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                                onClick={onDelete}
+                                className={MENU_ITEM_CLASS}
+                            >
+                                <Trash2 className="size-4" />{" "}
+                                {t("index.delete")}
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                ) : null}
                 <Button onClick={onCreateRequest}>
                     {t("index.createRequest")}
                 </Button>
@@ -175,6 +192,7 @@ export default function CustomTemplatesIndexPage() {
     const t = useTranslations("customTemplates");
     const router = useRouter();
     const { treasuryId } = useTreasury();
+    const { canManage } = useCustomTemplatesAccess();
     const { data: templates, isLoading } = useProposalTemplates();
     const updateTemplate = useUpdateProposalTemplate();
     const deleteTemplate = useDeleteProposalTemplate();
@@ -225,7 +243,10 @@ export default function CustomTemplatesIndexPage() {
                         </p>
                     </PageCard>
                 ) : enabled.length === 0 ? (
-                    <EmptyState onCreate={() => go("/create")} />
+                    <EmptyState
+                        onCreate={() => go("/create")}
+                        canManage={canManage}
+                    />
                 ) : (
                     <PageCard className="gap-4 p-5">
                         <div className="flex items-center justify-between gap-2">
@@ -234,13 +255,15 @@ export default function CustomTemplatesIndexPage() {
                             </h2>
                             <div className="flex items-center gap-2">
                                 <HowItWorksLink />
-                                <Button
-                                    variant="secondary"
-                                    onClick={() => go("/create")}
-                                >
-                                    <Plus className="size-4" />{" "}
-                                    {t("index.addNew")}
-                                </Button>
+                                {canManage ? (
+                                    <Button
+                                        variant="secondary"
+                                        onClick={() => go("/create")}
+                                    >
+                                        <Plus className="size-4" />{" "}
+                                        {t("index.addNew")}
+                                    </Button>
+                                ) : null}
                             </div>
                         </div>
                         <div className="flex flex-col gap-3">
@@ -248,6 +271,7 @@ export default function CustomTemplatesIndexPage() {
                                 <TemplateRow
                                     key={template.id}
                                     template={template}
+                                    canManage={canManage}
                                     onCreateRequest={() =>
                                         go(
                                             `/${manifestIdOf(template.manifest)}`,

--- a/nt-fe/app/(treasury)/[treasuryId]/custom-templates/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/custom-templates/page.tsx
@@ -38,11 +38,11 @@ import {
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { apiErrorMessage } from "@/features/proposal-templates/api";
+import { useCustomTemplatesAccess } from "@/features/proposal-templates/hooks/use-custom-templates-access";
 import {
     useDeleteProposalTemplate,
     useUpdateProposalTemplate,
 } from "@/features/proposal-templates/hooks/use-proposal-template-mutations";
-import { useCustomTemplatesAccess } from "@/features/proposal-templates/hooks/use-custom-templates-access";
 import { useProposalTemplates } from "@/features/proposal-templates/hooks/use-proposal-templates";
 import { manifestIdOf } from "@/features/proposal-templates/manifest";
 import type { ProposalTemplate } from "@/features/proposal-templates/types";
@@ -106,6 +106,7 @@ function EmptyState({
 interface TemplateRowProps {
     template: ProposalTemplate;
     canManage: boolean;
+    canPropose: boolean;
     onCreateRequest: () => void;
     onEdit: () => void;
     onTogglePin: () => void;
@@ -115,6 +116,7 @@ interface TemplateRowProps {
 function TemplateRow({
     template,
     canManage,
+    canPropose,
     onCreateRequest,
     onEdit,
     onTogglePin,
@@ -180,9 +182,13 @@ function TemplateRow({
                         </DropdownMenuContent>
                     </DropdownMenu>
                 ) : null}
-                <Button onClick={onCreateRequest}>
-                    {t("index.createRequest")}
-                </Button>
+                {/* Filing needs call:AddProposal (templates build a FunctionCall). Hide the entry so a
+                    manager-only or transfer-only member isn't walked into a dead-end fill form. */}
+                {canPropose ? (
+                    <Button onClick={onCreateRequest}>
+                        {t("index.createRequest")}
+                    </Button>
+                ) : null}
             </div>
         </div>
     );
@@ -192,7 +198,7 @@ export default function CustomTemplatesIndexPage() {
     const t = useTranslations("customTemplates");
     const router = useRouter();
     const { treasuryId } = useTreasury();
-    const { canManage } = useCustomTemplatesAccess();
+    const { canManage, canPropose } = useCustomTemplatesAccess();
     const { data: templates, isLoading } = useProposalTemplates();
     const updateTemplate = useUpdateProposalTemplate();
     const deleteTemplate = useDeleteProposalTemplate();
@@ -272,6 +278,7 @@ export default function CustomTemplatesIndexPage() {
                                     key={template.id}
                                     template={template}
                                     canManage={canManage}
+                                    canPropose={canPropose}
                                     onCreateRequest={() =>
                                         go(
                                             `/${manifestIdOf(template.manifest)}`,

--- a/nt-fe/e2e/custom-templates.spec.ts
+++ b/nt-fe/e2e/custom-templates.spec.ts
@@ -72,6 +72,33 @@ const BARE_MEMBER_POLICY = {
     ],
 };
 
+/** Can author templates (ChangePolicy) but cannot file one (no `call:AddProposal`). */
+const MANAGER_ONLY_POLICY = {
+    ...TREASURY_POLICY,
+    roles: [
+        {
+            name: "managers",
+            kind: { Group: [ACCOUNT_ID] },
+            permissions: ["*:ChangePolicy"],
+            vote_policy: {},
+        },
+    ],
+};
+
+/** A transfer-only Requestor — templates build a FunctionCall, so `transfer:AddProposal` can't file
+ * one; this member should get NO templates access at all. */
+const TRANSFER_ONLY_POLICY = {
+    ...TREASURY_POLICY,
+    roles: [
+        {
+            name: "transfer-requestors",
+            kind: { Group: [ACCOUNT_ID] },
+            permissions: ["transfer:AddProposal"],
+            vote_policy: {},
+        },
+    ],
+};
+
 const EMPTY_PROPOSALS = { page: 0, page_size: 15, total: 0, proposals: [] };
 
 /** Full subscription shape — the treasury layout reads `planConfig.limits`, so a stub crashes it. */
@@ -482,5 +509,33 @@ test.describe("Custom Templates — access gates", () => {
         await expect(
             page.getByRole("button", { name: "Template actions" }),
         ).toHaveCount(0);
+    });
+
+    test("manager without call:AddProposal sees authoring UI but no Create Request", async ({
+        page,
+    }) => {
+        // Can author templates but can't file one (templates are FunctionCall) → don't offer the
+        // dead-end fill entry, but keep the ⋮ manage menu.
+        await setupMocks(page, [template()], { policy: MANAGER_ONLY_POLICY });
+        await page.goto(`/${TREASURY_ID}/custom-templates`);
+
+        await expect(page.getByText("Set Greeting")).toBeVisible({
+            timeout: 15000,
+        });
+        await expect(
+            page.getByRole("button", { name: "Template actions" }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("button", { name: "Create Request" }),
+        ).toHaveCount(0);
+    });
+
+    test("transfer-only requestor has no templates access → dashboard", async ({
+        page,
+    }) => {
+        // transfer:AddProposal can't file a FunctionCall template, so it grants no access.
+        await setupMocks(page, [template()], { policy: TRANSFER_ONLY_POLICY });
+        await page.goto(`/${TREASURY_ID}/custom-templates`);
+        await page.waitForURL(/\/dashboard$/, { timeout: 15000 });
     });
 });

--- a/nt-fe/e2e/custom-templates.spec.ts
+++ b/nt-fe/e2e/custom-templates.spec.ts
@@ -489,7 +489,7 @@ test.describe("Custom Templates — access gates", () => {
         await expect(page.getByText("Set Greeting")).toBeVisible();
     });
 
-    test("Requestor sees the list + Create Request but no authoring affordances", async ({
+    test("Requestor gets an enabled Create Request; Add New is disabled, ⋮ menu hidden", async ({
         page,
     }) => {
         await setupMocks(page, [template()], { policy: PROPOSER_POLICY });
@@ -498,36 +498,40 @@ test.describe("Custom Templates — access gates", () => {
         await expect(page.getByText("Set Greeting")).toBeVisible({
             timeout: 15000,
         });
-        // Can still file a request...
+        // Can file a request...
         await expect(
             page.getByRole("button", { name: "Create Request" }),
-        ).toBeVisible();
-        // ...but the authoring controls (Add New, the ⋮ row menu) are gone.
-        await expect(page.getByRole("button", { name: "Add New" })).toHaveCount(
-            0,
-        );
+        ).toBeEnabled();
+        // ...authoring "Add New" is shown disabled (with a tooltip), not hidden...
+        await expect(
+            page.getByRole("button", { name: "Add New" }),
+        ).toBeDisabled();
+        // ...and the per-row ⋮ overflow (edit/pin/delete) stays hidden.
         await expect(
             page.getByRole("button", { name: "Template actions" }),
         ).toHaveCount(0);
     });
 
-    test("manager without call:AddProposal sees authoring UI but no Create Request", async ({
+    test("manager without call:AddProposal: authoring enabled, Create Request disabled", async ({
         page,
     }) => {
-        // Can author templates but can't file one (templates are FunctionCall) → don't offer the
-        // dead-end fill entry, but keep the ⋮ manage menu.
         await setupMocks(page, [template()], { policy: MANAGER_ONLY_POLICY });
         await page.goto(`/${TREASURY_ID}/custom-templates`);
 
         await expect(page.getByText("Set Greeting")).toBeVisible({
             timeout: 15000,
         });
+        // Can manage (⋮ menu + Add New enabled)...
         await expect(
             page.getByRole("button", { name: "Template actions" }),
         ).toBeVisible();
         await expect(
+            page.getByRole("button", { name: "Add New" }),
+        ).toBeEnabled();
+        // ...but can't file a FunctionCall template → Create Request shown disabled, not hidden.
+        await expect(
             page.getByRole("button", { name: "Create Request" }),
-        ).toHaveCount(0);
+        ).toBeDisabled();
     });
 
     test("transfer-only requestor has no templates access → dashboard", async ({

--- a/nt-fe/e2e/custom-templates.spec.ts
+++ b/nt-fe/e2e/custom-templates.spec.ts
@@ -46,6 +46,32 @@ const TREASURY_POLICY = {
     bounty_forgiveness_period: "604800000000000",
 };
 
+/** A member who can file requests (Requestor) but cannot author templates (no ChangePolicy). */
+const PROPOSER_POLICY = {
+    ...TREASURY_POLICY,
+    roles: [
+        {
+            name: "requestors",
+            kind: { Group: [ACCOUNT_ID] },
+            permissions: ["call:AddProposal", "transfer:AddProposal"],
+            vote_policy: {},
+        },
+    ],
+};
+
+/** A member who is neither Requestor nor manager — may view the DAO but not the templates feature. */
+const BARE_MEMBER_POLICY = {
+    ...TREASURY_POLICY,
+    roles: [
+        {
+            name: "voters",
+            kind: { Group: [ACCOUNT_ID] },
+            permissions: ["*:VoteApprove"],
+            vote_policy: {},
+        },
+    ],
+};
+
 const EMPTY_PROPOSALS = { page: 0, page_size: 15, total: 0, proposals: [] };
 
 /** Full subscription shape — the treasury layout reads `planConfig.limits`, so a stub crashes it. */
@@ -137,7 +163,13 @@ function json(route: Route, body: unknown, status = 200) {
  * proposal-templates` returns `templates`; non-GET mutations on that endpoint fall through so a
  * per-test route (registered later, higher priority) can intercept and assert them.
  */
-async function setupMocks(page: Page, templates: Record<string, unknown>[]) {
+async function setupMocks(
+    page: Page,
+    templates: Record<string, unknown>[],
+    options: { policy?: unknown; customRequestsEnabled?: boolean } = {},
+) {
+    const policy = options.policy ?? TREASURY_POLICY;
+    const customRequestsEnabled = options.customRequestsEnabled ?? true;
     await seedMockWalletAccount(page, ACCOUNT_ID, "init");
 
     await page.route("**/*", async (route) => {
@@ -166,7 +198,7 @@ async function setupMocks(page: Page, templates: Record<string, unknown>[]) {
             ]);
         }
         if (url.includes("/treasury/policy")) {
-            return json(route, TREASURY_POLICY);
+            return json(route, policy);
         }
         if (url.includes("/api/subscription/")) {
             return json(route, SUBSCRIPTION);
@@ -177,9 +209,9 @@ async function setupMocks(page: Page, templates: Record<string, unknown>[]) {
         if (url.includes("/proposals/")) {
             return json(route, EMPTY_PROPOSALS);
         }
-        // The Custom Requests feature gate (sidebar visibility) — enabled.
+        // The Custom Requests feature gate (sidebar visibility + route guard).
         if (url.endsWith("/custom-requests") && method === "GET") {
-            return json(route, { enabled: true });
+            return json(route, { enabled: customRequestsEnabled });
         }
         // Template list. Mutations (POST/PUT/DELETE) are owned by per-test routes.
         if (url.includes("/proposal-templates") && method === "GET") {
@@ -394,4 +426,61 @@ test.describe("Custom Templates — fill", () => {
         "successful submit files the proposal and resets the form",
         async () => {},
     );
+});
+
+/**
+ * The route/permission gates (#1026, #1027). The rest of the suite runs as a full council member; here
+ * we swap the flag and the policy to assert the deny paths — the sidebar-only check used to leave these
+ * routes reachable by direct URL.
+ */
+test.describe("Custom Templates — access gates", () => {
+    test("feature disabled: /custom-templates redirects to Settings → Developer (#1026)", async ({
+        page,
+    }) => {
+        await setupMocks(page, [template()], {
+            customRequestsEnabled: false,
+        });
+        await page.goto(`/${TREASURY_ID}/custom-templates`);
+        await page.waitForURL(/settings\?tab=developer/, { timeout: 15000 });
+    });
+
+    test("bare member (neither propose nor manage) is redirected to the dashboard (#1027)", async ({
+        page,
+    }) => {
+        // No access + can't manage → the treasury dashboard, not a Settings tab hidden from them.
+        await setupMocks(page, [template()], { policy: BARE_MEMBER_POLICY });
+        await page.goto(`/${TREASURY_ID}/custom-templates`);
+        await page.waitForURL(/\/dashboard$/, { timeout: 15000 });
+    });
+
+    test("Requestor may reach the list but not the create page — bounced to the list (#1027)", async ({
+        page,
+    }) => {
+        await setupMocks(page, [template()], { policy: PROPOSER_POLICY });
+        await page.goto(`/${TREASURY_ID}/custom-templates/create`);
+        await page.waitForURL(/custom-templates$/, { timeout: 15000 });
+        await expect(page.getByText("Set Greeting")).toBeVisible();
+    });
+
+    test("Requestor sees the list + Create Request but no authoring affordances", async ({
+        page,
+    }) => {
+        await setupMocks(page, [template()], { policy: PROPOSER_POLICY });
+        await page.goto(`/${TREASURY_ID}/custom-templates`);
+
+        await expect(page.getByText("Set Greeting")).toBeVisible({
+            timeout: 15000,
+        });
+        // Can still file a request...
+        await expect(
+            page.getByRole("button", { name: "Create Request" }),
+        ).toBeVisible();
+        // ...but the authoring controls (Add New, the ⋮ row menu) are gone.
+        await expect(page.getByRole("button", { name: "Add New" })).toHaveCount(
+            0,
+        );
+        await expect(
+            page.getByRole("button", { name: "Template actions" }),
+        ).toHaveCount(0);
+    });
 });

--- a/nt-fe/features/proposal-templates/components/manifest-form.tsx
+++ b/nt-fe/features/proposal-templates/components/manifest-form.tsx
@@ -11,12 +11,11 @@
  * the runtime manifest), so values flow as the generic `FieldValues`.
  */
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Loader2 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { type ControllerRenderProps, useForm } from "react-hook-form";
-import { Button } from "@/components/button";
+import { CreateRequestButton } from "@/components/create-request-button";
 import { InputBlock } from "@/components/input-block";
 import { LargeInput } from "@/components/large-input";
 import { Textarea } from "@/components/textarea";
@@ -237,16 +236,17 @@ export function ManifestForm({
                         </motion.div>
                     </AnimatePresence>
                 </div>
-                <Button type="submit" className="w-full" disabled={submitting}>
-                    {submitting ? (
-                        <>
-                            <Loader2 className="mr-2 size-4 animate-spin" />
-                            {label}
-                        </>
-                    ) : (
-                        label
-                    )}
-                </Button>
+                {/* Shared gating (Requestor permission, sponsored-tx availability, create-proposal
+                    maintenance pause) exactly like Payments/Exchange — a template files a FunctionCall
+                    proposal, so the required permission is `call:AddProposal`. Fixes #1029. */}
+                <CreateRequestButton
+                    type="submit"
+                    className="w-full h-10"
+                    isSubmitting={submitting}
+                    idleMessage={label}
+                    loadingMessage={label}
+                    permissions={[{ kind: "call", action: "AddProposal" }]}
+                />
             </form>
         </Form>
     );

--- a/nt-fe/features/proposal-templates/hooks/use-custom-templates-access.ts
+++ b/nt-fe/features/proposal-templates/hooks/use-custom-templates-access.ts
@@ -1,0 +1,31 @@
+import { useTreasury } from "@/hooks/use-treasury";
+import { useTreasuryPolicy } from "@/hooks/use-treasury-queries";
+import { canChangePolicy, isRequestor } from "@/lib/config-utils";
+import { useNear } from "@/stores/near-store";
+
+/**
+ * The current account's access tiers for the Request Templates feature, mirroring the nt-be gates:
+ *  - `canManage`  — author templates (create/edit/pin/delete). Backend gates these on `ChangePolicy`.
+ *  - `canPropose` — fill a template into a proposal (Requestor: call/transfer `AddProposal`).
+ *  - `canAccess`  — may see the templates list at all (either of the above).
+ *
+ * Used to hide authoring affordances from proposers and to keep the list out of reach of members who
+ * can neither propose nor manage. Writes stay enforced server-side; this only aligns the UI.
+ */
+export function useCustomTemplatesAccess() {
+    const { accountId } = useNear();
+    const { treasuryId } = useTreasury();
+    const { data: policy, isLoading } = useTreasuryPolicy(treasuryId);
+
+    const canManage =
+        !!policy && !!accountId && canChangePolicy(policy, accountId);
+    const canPropose =
+        !!policy && !!accountId && isRequestor(policy, accountId);
+
+    return {
+        isLoading,
+        canManage,
+        canPropose,
+        canAccess: canManage || canPropose,
+    };
+}

--- a/nt-fe/features/proposal-templates/hooks/use-custom-templates-access.ts
+++ b/nt-fe/features/proposal-templates/hooks/use-custom-templates-access.ts
@@ -1,12 +1,15 @@
 import { useTreasury } from "@/hooks/use-treasury";
 import { useTreasuryPolicy } from "@/hooks/use-treasury-queries";
-import { canChangePolicy, isRequestor } from "@/lib/config-utils";
+import { canChangePolicy, hasPermission } from "@/lib/config-utils";
 import { useNear } from "@/stores/near-store";
 
 /**
  * The current account's access tiers for the Request Templates feature, mirroring the nt-be gates:
  *  - `canManage`  — author templates (create/edit/pin/delete). Backend gates these on `ChangePolicy`.
- *  - `canPropose` — fill a template into a proposal (Requestor: call/transfer `AddProposal`).
+ *  - `canPropose` — fill a template into a proposal. Templates always build a `FunctionCall`
+ *    (see `buildTemplateProposal`), so this is specifically `call:AddProposal` — NOT the broader
+ *    `isRequestor` (call OR transfer): a transfer-only requestor could never file a template request,
+ *    so it must not grant list access.
  *  - `canAccess`  — may see the templates list at all (either of the above).
  *
  * Used to hide authoring affordances from proposers and to keep the list out of reach of members who
@@ -20,7 +23,9 @@ export function useCustomTemplatesAccess() {
     const canManage =
         !!policy && !!accountId && canChangePolicy(policy, accountId);
     const canPropose =
-        !!policy && !!accountId && isRequestor(policy, accountId);
+        !!policy &&
+        !!accountId &&
+        hasPermission(policy, accountId, "call", "AddProposal");
 
     return {
         isLoading,

--- a/nt-fe/lib/config-utils.test.ts
+++ b/nt-fe/lib/config-utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import type { Policy } from "@/types/policy";
+import { canChangePolicy, isRequestor } from "./config-utils";
+
+/**
+ * The permission tiers behind the Request Templates gates: `canChangePolicy` (author templates,
+ * gated on the backend's `ChangePolicy` action) and `isRequestor` (file a request). The two must
+ * stay distinct — a proposer is not a manager and vice-versa — or the UI leaks/hides the wrong
+ * affordances. These fixtures mirror the on-chain SputnikDAO policy shape nt-be returns.
+ */
+const ACCOUNT = "member.near";
+
+function policyWith(
+    permissions: string[],
+    members: string[] = [ACCOUNT],
+): Policy {
+    return {
+        roles: [
+            {
+                name: "role",
+                kind: { Group: members },
+                permissions,
+                vote_policy: {},
+            },
+        ],
+        default_vote_policy: {
+            weight_kind: "RoleWeight",
+            quorum: "0",
+            threshold: [1, 2],
+        },
+        proposal_bond: "0",
+        proposal_period: "0",
+        bounty_bond: "0",
+        bounty_forgiveness_period: "0",
+    };
+}
+
+describe("canChangePolicy (template authoring gate)", () => {
+    it("grants on the canonical proposal:ChangePolicy permission", () => {
+        expect(
+            canChangePolicy(policyWith(["proposal:ChangePolicy"]), ACCOUNT),
+        ).toBe(true);
+    });
+
+    it("grants on the wildcard action *:ChangePolicy and on *:*", () => {
+        expect(canChangePolicy(policyWith(["*:ChangePolicy"]), ACCOUNT)).toBe(
+            true,
+        );
+        expect(canChangePolicy(policyWith(["*:*"]), ACCOUNT)).toBe(true);
+    });
+
+    it("denies a pure Requestor (AddProposal is not ChangePolicy)", () => {
+        // The load-bearing case: a proposer must NOT see authoring UI.
+        expect(canChangePolicy(policyWith(["*:AddProposal"]), ACCOUNT)).toBe(
+            false,
+        );
+        expect(canChangePolicy(policyWith(["call:AddProposal"]), ACCOUNT)).toBe(
+            false,
+        );
+    });
+
+    it("denies a non-member and a null policy", () => {
+        expect(
+            canChangePolicy(
+                policyWith(["*:*"], ["someone-else.near"]),
+                ACCOUNT,
+            ),
+        ).toBe(false);
+        expect(canChangePolicy(null, ACCOUNT)).toBe(false);
+        expect(canChangePolicy(policyWith(["*:*"]), "")).toBe(false);
+    });
+});
+
+describe("isRequestor (file-a-request gate)", () => {
+    it("grants on call: or transfer:AddProposal (and the wildcard)", () => {
+        expect(isRequestor(policyWith(["call:AddProposal"]), ACCOUNT)).toBe(
+            true,
+        );
+        expect(isRequestor(policyWith(["transfer:AddProposal"]), ACCOUNT)).toBe(
+            true,
+        );
+        expect(isRequestor(policyWith(["*:AddProposal"]), ACCOUNT)).toBe(true);
+    });
+
+    it("denies a pure manager (ChangePolicy is not AddProposal)", () => {
+        expect(isRequestor(policyWith(["*:ChangePolicy"]), ACCOUNT)).toBe(
+            false,
+        );
+    });
+});

--- a/nt-fe/lib/config-utils.ts
+++ b/nt-fe/lib/config-utils.ts
@@ -269,3 +269,18 @@ export function isRequestor(
         hasPermission(policy, accountId, "transfer", "AddProposal")
     );
 }
+
+/**
+ * Whether the account may change the DAO policy. This is the permission the backend requires for
+ * authoring/managing proposal templates (create/edit/pin/delete) — nt-be gates those writes on the
+ * `ChangePolicy` action, and the app's canonical permission string for it is `proposal:ChangePolicy`
+ * (council roles carry `*:*`). Use it to hide authoring UI from members who can't perform the write.
+ */
+export function canChangePolicy(
+    policy: Policy | null | undefined,
+    accountId: string,
+): boolean {
+    if (!policy || !accountId) return false;
+
+    return hasPermission(policy, accountId, "proposal", "ChangePolicy");
+}


### PR DESCRIPTION
## Gate Request Templates routes & UI to match the server-side permissions

Fixes #1026, #1027, #1029.

### Problem

The Request Templates feature enforced access only in the sidebar (navigation visibility) and on the backend (writes are `ChangePolicy`-gated, returning 403). The routes and in-page affordances themselves were ungated, so:

- **#1026** — direct-navigating to `/<dao>/custom-templates` (and `/create`) loaded the feature even when Custom Requests is **disabled** in Settings → Developer.
- **#1027** — guests / signed-out / non-member viewers could reach the template **create** page and see the authoring UI.
- **#1029** — the fill form's "File Proposal" button bypassed the shared proposal gating (Requestor permission, sponsored-tx availability, `action.create-proposal` maintenance pause) that Payments/Exchange use, so it stayed enabled for members without permission.

Writes were always safe (enforced server-side); this aligns the **UI** so no one lands on a page or a button they can't act on.

### Approach

The permissions mirror the nt-be gates exactly (`nt-be/src/handlers/proposal_templates.rs`): **authoring** requires the `ChangePolicy` action; **filling** requires Requestor (`call`/`transfer:AddProposal`); **reads/lists** require membership.

Two shared predicates in `lib/config-utils.ts` (`canChangePolicy`, existing `isRequestor`), surfaced through a `useCustomTemplatesAccess()` hook with three tiers: `canManage` / `canPropose` / `canAccess`.

- **`CustomTemplatesGuard`** wraps the subtree via `custom-templates/layout.tsx`. It requires the feature flag **and** `canAccess` (propose or manage) — so the list is reachable only by Requestors and managers. `create` and `edit` add a `requireManage` variant via their own tiny route `layout.tsx` (idiomatic App Router; keeps the page bodies untouched).
- Blocked users are redirected somewhere they can actually act:
  - manager + feature disabled → **Settings → Developer** (to re-enable),
  - proposer who deep-linked `/create` → the **list**,
  - no access (guest / signed-out / non-member) → the treasury **dashboard**.
- **Index page** hides authoring affordances (Add New, the ⋮ Edit·Pin·Delete menu, empty-state Create button) from non-managers; a proposer still sees the list and "Create Request".
- **Fill form** now files through the shared `CreateRequestButton` (`call:AddProposal`), inheriting the Requestor / sponsored-tx / maintenance checks.

### Testing

- **Unit** (`lib/config-utils.test.ts`) — pins the permission mapping and proves the tiers are distinct (a Requestor is not a manager and vice-versa).
- **E2E** (`e2e/custom-templates.spec.ts`) — added deny-path cases: feature-disabled redirect, non-member → dashboard, Requestor bounced from `/create`, Requestor sees the list but no authoring UI. `setupMocks` gained optional `policy` / `customRequestsEnabled` overrides.
- Full suite green at `--workers=1` (the CI worker setting): 12 passed, 1 pre-existing `fixme`.

### Out of scope / follow-up

The Settings → Developer tab remains hidden from guests (`showDeveloper = !isGuestTreasury`), consistent with the sidebar hiding the feature from non-members. Whether to instead show it disabled (like other settings tabs) is a product decision, not part of these bug fixes.
