### PR TITLE
feat: Treasury creation sweeper

### DIFF
--- a/nt-be/migrations/20260703000001_create_incomplete_treasury_creations.sql
+++ b/nt-be/migrations/20260703000001_create_incomplete_treasury_creations.sql
@@ -3,7 +3,16 @@
 -- but before confidential ownership handoff). The intended policy (members +
 -- thresholds) is NOT recoverable from chain for a half-created confidential
 -- DAO, so we store the original request here.
-CREATE TABLE treasury_creation_requests (
+
+-- Lifecycle of a creation request:
+-- 'in_progress' → an attempt is actively running; sweeper leaves it alone
+--                 until it goes stale (crash/restart safety net).
+-- 'pending'     → attempt failed part-way; eligible for sweeping right away.
+-- 'failed'      → terminal (too many attempts, or unrecoverable); needs a human.
+-- Rows are DELETED on success, so the table only holds unfinished creations.
+CREATE TYPE treasury_creation_status AS ENUM ('in_progress', 'pending', 'failed');
+
+CREATE TABLE incomplete_treasury_creations (
     account_id           TEXT PRIMARY KEY,
     name                 TEXT NOT NULL,
     payment_threshold    SMALLINT NOT NULL,
@@ -12,12 +21,7 @@ CREATE TABLE treasury_creation_requests (
     financiers           TEXT[] NOT NULL,
     requestors           TEXT[] NOT NULL,
     is_confidential      BOOLEAN NOT NULL DEFAULT false,
-    -- 'in_progress' → an attempt is actively running; sweeper leaves it alone
-    --                 until it goes stale (crash/restart safety net).
-    -- 'pending'     → attempt failed part-way; eligible for sweeping right away.
-    -- 'failed'      → gave up after too many attempts (terminal, needs a human).
-    -- Rows are DELETED on success, so the table only holds unfinished creations.
-    status               TEXT NOT NULL DEFAULT 'in_progress',
+    status               treasury_creation_status NOT NULL DEFAULT 'in_progress',
     attempts             INTEGER NOT NULL DEFAULT 0,
     last_error           TEXT,
     created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -25,6 +29,6 @@ CREATE TABLE treasury_creation_requests (
 );
 
 -- The sweeper scans active (resumable) rows ordered by updated_at.
-CREATE INDEX idx_treasury_creation_requests_active
-    ON treasury_creation_requests (updated_at)
+CREATE INDEX idx_incomplete_treasury_creations_active
+    ON incomplete_treasury_creations (updated_at)
     WHERE status IN ('pending', 'in_progress');

--- a/nt-be/migrations/20260703000001_create_treasury_creation_requests.sql
+++ b/nt-be/migrations/20260703000001_create_treasury_creation_requests.sql
@@ -1,0 +1,30 @@
+-- Persist treasury creation intent so a background sweeper can resume/finish
+-- any creation that failed part-way (e.g. RPC timeout after the DAO was created
+-- but before confidential ownership handoff). The intended policy (members +
+-- thresholds) is NOT recoverable from chain for a half-created confidential
+-- DAO, so we store the original request here.
+CREATE TABLE treasury_creation_requests (
+    account_id           TEXT PRIMARY KEY,
+    name                 TEXT NOT NULL,
+    payment_threshold    SMALLINT NOT NULL,
+    governance_threshold SMALLINT NOT NULL,
+    governors            TEXT[] NOT NULL,
+    financiers           TEXT[] NOT NULL,
+    requestors           TEXT[] NOT NULL,
+    is_confidential      BOOLEAN NOT NULL DEFAULT false,
+    -- 'in_progress' → an attempt is actively running; sweeper leaves it alone
+    --                 until it goes stale (crash/restart safety net).
+    -- 'pending'     → attempt failed part-way; eligible for sweeping right away.
+    -- 'failed'      → gave up after too many attempts (terminal, needs a human).
+    -- Rows are DELETED on success, so the table only holds unfinished creations.
+    status               TEXT NOT NULL DEFAULT 'in_progress',
+    attempts             INTEGER NOT NULL DEFAULT 0,
+    last_error           TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The sweeper scans active (resumable) rows ordered by updated_at.
+CREATE INDEX idx_treasury_creation_requests_active
+    ON treasury_creation_requests (updated_at)
+    WHERE status IN ('pending', 'in_progress');

--- a/nt-be/src/app_state.rs
+++ b/nt-be/src/app_state.rs
@@ -80,6 +80,10 @@ pub struct AppState {
     /// Used by the enrichment worker to read indexed_dao_outcomes.
     /// None if GOLDSKY_DATABASE_URL is not configured.
     pub goldsky_pool: Option<PgPool>,
+    /// Wakes the treasury creation sweeper immediately (instead of waiting for
+    /// its next poll tick) when an attempt fails, so a half-created treasury is
+    /// retried within moments rather than seconds.
+    pub creation_sweep_notify: Arc<tokio::sync::Notify>,
 }
 
 /// Builder for constructing AppState instances
@@ -378,6 +382,7 @@ impl AppStateBuilder {
             transfer_hint_service,
             neardata_client,
             goldsky_pool,
+            creation_sweep_notify: Arc::new(tokio::sync::Notify::new()),
         })
     }
 }

--- a/nt-be/src/handlers/treasury/create.rs
+++ b/nt-be/src/handlers/treasury/create.rs
@@ -319,6 +319,14 @@ fn creation_error_retryable(attempt: u32, message: &str) -> bool {
     attempt < MAX_CREATION_ATTEMPTS && is_transport_error(message)
 }
 
+/// Whether an error is terminal — it can never succeed on retry, so neither the
+/// in-request loop nor the background sweeper should keep trying. Currently this
+/// is the `ExistingDaoState::Taken` case: the handle exists and belongs to an
+/// account we don't control.
+pub(crate) fn is_terminal_creation_error(message: &str) -> bool {
+    message.contains("already taken")
+}
+
 /// Build an SSE error event with the given message.
 fn error_event(message: String) -> ProgressEvent {
     ProgressEvent {
@@ -503,16 +511,34 @@ pub(crate) async fn run_creation(
             }
         }
         Err(evt) => {
-            // Flip to `pending` so the sweeper picks it up, then wake the
-            // sweeper right away instead of waiting for its next poll tick.
             let message = evt.message.as_deref().unwrap_or_default();
-            if let Err(e) =
-                creation_requests::mark_creation_pending(&state.db_pool, treasury.as_str(), message)
-                    .await
-            {
-                tracing::warn!("Failed to mark creation pending for {}: {}", treasury, e);
+            if is_terminal_creation_error(message) {
+                // The handle is taken by an account we don't control — retrying
+                // can never succeed, so mark it `failed` and do NOT wake the
+                // sweeper (which would otherwise burn its attempts + alert).
+                if let Err(e) = creation_requests::mark_creation_failed(
+                    &state.db_pool,
+                    treasury.as_str(),
+                    message,
+                )
+                .await
+                {
+                    tracing::warn!("Failed to mark creation failed for {}: {}", treasury, e);
+                }
+            } else {
+                // Flip to `pending` so the sweeper picks it up, then wake the
+                // sweeper right away instead of waiting for its next poll tick.
+                if let Err(e) = creation_requests::mark_creation_pending(
+                    &state.db_pool,
+                    treasury.as_str(),
+                    message,
+                )
+                .await
+                {
+                    tracing::warn!("Failed to mark creation pending for {}: {}", treasury, e);
+                }
+                state.creation_sweep_notify.notify_one();
             }
-            state.creation_sweep_notify.notify_one();
         }
     }
 
@@ -564,7 +590,7 @@ async fn run_creation_inner(
     match existing {
         ExistingDaoState::Taken => {
             return Err(error_event(format!(
-                "Treasury {treasury} already exists and is not managed by this platform."
+                "The name \"{treasury}\" is already taken. Please choose a different treasury name."
             )));
         }
         ExistingDaoState::Absent => {
@@ -739,7 +765,7 @@ mod tests {
         // Non-transport (logic) errors are never retried.
         assert!(!creation_error_retryable(
             1,
-            "Treasury already exists and is not managed by this platform."
+            "The name \"foo.sputnik-dao.near\" is already taken. Please choose a different treasury name."
         ));
         assert!(!creation_error_retryable(1, "1Click auth failed (400)"));
 

--- a/nt-be/src/handlers/treasury/create.rs
+++ b/nt-be/src/handlers/treasury/create.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 use super::confidential_setup;
+use super::creation_requests;
 
 pub const TREASURY_CREATE_DEPOSIT: NearToken = NearToken::from_millinear(90);
 pub const REGISTERING_DAO_TIMEOUT_IN_SECS: u64 = 10;
@@ -416,7 +417,7 @@ async fn classify_treasury_account(
 /// Entry point spawned by the SSE handler. Serializes concurrent/duplicate
 /// creation attempts for the same treasury behind a Postgres advisory lock,
 /// then runs the (idempotent, resumable) creation flow.
-async fn run_creation(
+pub(crate) async fn run_creation(
     state: Arc<AppState>,
     payload: CreateTreasuryRequest,
     tx: mpsc::Sender<ProgressEvent>,
@@ -452,6 +453,14 @@ async fn run_creation(
         )));
     }
 
+    // Persist the creation intent so the background sweeper can resume/finish
+    // this treasury if every in-request attempt below fails (or the process
+    // dies). For confidential DAOs the target policy isn't recoverable from
+    // chain, so this stored request is the only way to complete them later.
+    if let Err(e) = creation_requests::record_creation_started(&state.db_pool, &payload).await {
+        tracing::warn!("Failed to record creation start for {}: {}", treasury, e);
+    }
+
     // Auto-retry the (idempotent) flow on transient failures so the user never
     // has to intervene. The spawned task outlives the SSE connection, so this
     // keeps making progress even if the client disconnects.
@@ -479,6 +488,31 @@ async fn run_creation(
                 );
                 tokio::time::sleep(delay).await;
             }
+        }
+    }
+
+    // Record the terminal outcome so the sweeper knows whether to keep trying.
+    match &result {
+        Ok(()) => {
+            // Success → drop the row so the table doesn't accumulate finished
+            // creations; only pending/failed rows are retained.
+            if let Err(e) =
+                creation_requests::delete_creation_request(&state.db_pool, treasury.as_str()).await
+            {
+                tracing::warn!("Failed to delete creation request for {}: {}", treasury, e);
+            }
+        }
+        Err(evt) => {
+            // Flip to `pending` so the sweeper picks it up, then wake the
+            // sweeper right away instead of waiting for its next poll tick.
+            let message = evt.message.as_deref().unwrap_or_default();
+            if let Err(e) =
+                creation_requests::mark_creation_pending(&state.db_pool, treasury.as_str(), message)
+                    .await
+            {
+                tracing::warn!("Failed to mark creation pending for {}: {}", treasury, e);
+            }
+            state.creation_sweep_notify.notify_one();
         }
     }
 

--- a/nt-be/src/handlers/treasury/creation_requests.rs
+++ b/nt-be/src/handlers/treasury/creation_requests.rs
@@ -45,7 +45,7 @@ pub async fn record_creation_started(
 
     sqlx::query(
         r#"
-        INSERT INTO treasury_creation_requests
+        INSERT INTO incomplete_treasury_creations
             (account_id, name, payment_threshold, governance_threshold,
              governors, financiers, requestors, is_confidential, status, updated_at)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'in_progress', NOW())
@@ -78,7 +78,7 @@ pub async fn record_creation_started(
 /// Delete the request on successful completion, so the table only retains
 /// in-flight (`pending`) and gave-up (`failed`) rows.
 pub async fn delete_creation_request(pool: &PgPool, account_id: &str) -> Result<(), sqlx::Error> {
-    sqlx::query("DELETE FROM treasury_creation_requests WHERE account_id = $1")
+    sqlx::query("DELETE FROM incomplete_treasury_creations WHERE account_id = $1")
         .bind(account_id)
         .execute(pool)
         .await?;
@@ -95,7 +95,7 @@ pub async fn mark_creation_pending(
     let truncated: String = error.chars().take(1000).collect();
     sqlx::query(
         r#"
-        UPDATE treasury_creation_requests
+        UPDATE incomplete_treasury_creations
         SET status = 'pending', last_error = $2, updated_at = NOW()
         WHERE account_id = $1 AND status <> 'failed'
         "#,
@@ -107,16 +107,25 @@ pub async fn mark_creation_pending(
     Ok(())
 }
 
-/// Give up on a request that has exhausted its sweep attempts (terminal).
-pub async fn mark_creation_failed(pool: &PgPool, account_id: &str) -> Result<(), sqlx::Error> {
+/// Mark a request `failed` (terminal) and record the error. Used both when a
+/// request exhausts its sweep attempts and when it hits an unrecoverable error
+/// (e.g. the handle is taken). Applies to any non-failed row so it works
+/// straight from `in_progress` as well as `pending`.
+pub async fn mark_creation_failed(
+    pool: &PgPool,
+    account_id: &str,
+    error: &str,
+) -> Result<(), sqlx::Error> {
+    let truncated: String = error.chars().take(1000).collect();
     sqlx::query(
         r#"
-        UPDATE treasury_creation_requests
-        SET status = 'failed', updated_at = NOW()
-        WHERE account_id = $1 AND status = 'pending'
+        UPDATE incomplete_treasury_creations
+        SET status = 'failed', last_error = $2, updated_at = NOW()
+        WHERE account_id = $1 AND status <> 'failed'
         "#,
     )
     .bind(account_id)
+    .bind(truncated)
     .execute(pool)
     .await?;
     Ok(())
@@ -142,10 +151,10 @@ pub async fn claim_stale_pending(
 ) -> Result<Vec<SweepCandidate>, sqlx::Error> {
     let rows = sqlx::query(
         r#"
-        UPDATE treasury_creation_requests
+        UPDATE incomplete_treasury_creations
         SET attempts = attempts + 1, updated_at = NOW()
         WHERE account_id IN (
-            SELECT account_id FROM treasury_creation_requests
+            SELECT account_id FROM incomplete_treasury_creations
             WHERE attempts < $1
               AND (
                     (status = 'pending'

--- a/nt-be/src/handlers/treasury/creation_requests.rs
+++ b/nt-be/src/handlers/treasury/creation_requests.rs
@@ -1,0 +1,211 @@
+//! Persistence for treasury creation intent.
+//!
+//! Every creation attempt records its full request here before doing on-chain
+//! work, and the row is **deleted on success** so the table only ever holds
+//! unfinished creations. A row moves through three states:
+//!
+//! - `in_progress` — a creation is actively running (live request or sweeper).
+//!   The sweeper leaves these alone until they go stale, so it never races an
+//!   attempt that is still underway.
+//! - `pending` — the attempt failed part-way. These are picked up quickly by
+//!   the background sweeper (see [`super::creation_sweeper`]) and re-run.
+//! - `failed` — gave up after too many sweep attempts (kept for review).
+//!
+//! Resuming from this stored request is the only way to finish a half-created
+//! *confidential* DAO, since the intended member policy isn't recoverable from
+//! chain.
+
+use near_api::AccountId;
+use sqlx::{PgPool, Row};
+
+use super::create::CreateTreasuryRequest;
+
+/// Give up sweeping a request after this many attempts and mark it `failed`.
+pub const MAX_SWEEP_ATTEMPTS: i32 = 5;
+
+/// A pending request claimed by the sweeper, with its attempt count.
+pub struct SweepCandidate {
+    pub request: CreateTreasuryRequest,
+    pub attempts: i32,
+}
+
+/// Record (or refresh) the creation intent as `in_progress`. Called at the
+/// start of every creation attempt (live or sweeper). While a row is
+/// `in_progress` the sweeper won't touch it until it goes stale, so an active
+/// attempt is never raced. A pre-existing row (e.g. a prior `pending`/`failed`
+/// one being retried) is re-armed to `in_progress`. The attempt counter is
+/// owned by the sweeper and intentionally left untouched here.
+pub async fn record_creation_started(
+    pool: &PgPool,
+    req: &CreateTreasuryRequest,
+) -> Result<(), sqlx::Error> {
+    let governors: Vec<String> = req.governors.iter().map(|a| a.to_string()).collect();
+    let financiers: Vec<String> = req.financiers.iter().map(|a| a.to_string()).collect();
+    let requestors: Vec<String> = req.requestors.iter().map(|a| a.to_string()).collect();
+
+    sqlx::query(
+        r#"
+        INSERT INTO treasury_creation_requests
+            (account_id, name, payment_threshold, governance_threshold,
+             governors, financiers, requestors, is_confidential, status, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'in_progress', NOW())
+        ON CONFLICT (account_id) DO UPDATE SET
+            name = EXCLUDED.name,
+            payment_threshold = EXCLUDED.payment_threshold,
+            governance_threshold = EXCLUDED.governance_threshold,
+            governors = EXCLUDED.governors,
+            financiers = EXCLUDED.financiers,
+            requestors = EXCLUDED.requestors,
+            is_confidential = EXCLUDED.is_confidential,
+            status = 'in_progress',
+            updated_at = NOW()
+        "#,
+    )
+    .bind(req.account_id.as_str())
+    .bind(&req.name)
+    .bind(i16::from(req.payment_threshold))
+    .bind(i16::from(req.governance_threshold))
+    .bind(&governors)
+    .bind(&financiers)
+    .bind(&requestors)
+    .bind(req.is_confidential)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Delete the request on successful completion, so the table only retains
+/// in-flight (`pending`) and gave-up (`failed`) rows.
+pub async fn delete_creation_request(pool: &PgPool, account_id: &str) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM treasury_creation_requests WHERE account_id = $1")
+        .bind(account_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Mark a part-way creation as `pending` (failed, resumable) and record the
+/// latest error. This is what makes a row eligible for the sweeper to retry.
+pub async fn mark_creation_pending(
+    pool: &PgPool,
+    account_id: &str,
+    error: &str,
+) -> Result<(), sqlx::Error> {
+    let truncated: String = error.chars().take(1000).collect();
+    sqlx::query(
+        r#"
+        UPDATE treasury_creation_requests
+        SET status = 'pending', last_error = $2, updated_at = NOW()
+        WHERE account_id = $1 AND status <> 'failed'
+        "#,
+    )
+    .bind(account_id)
+    .bind(truncated)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Give up on a request that has exhausted its sweep attempts (terminal).
+pub async fn mark_creation_failed(pool: &PgPool, account_id: &str) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        UPDATE treasury_creation_requests
+        SET status = 'failed', updated_at = NOW()
+        WHERE account_id = $1 AND status = 'pending'
+        "#,
+    )
+    .bind(account_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Atomically claim up to `limit` resumable requests, bumping their attempt
+/// counter. `FOR UPDATE SKIP LOCKED` makes this safe across multiple replicas.
+///
+/// Two kinds of rows are eligible:
+/// - `pending` (failed part-way): retried after a per-attempt backoff of
+///   `LEAST(attempts * backoff_base_secs, backoff_cap_secs)`. A freshly-failed
+///   row has `attempts = 0`, so it's picked up on the very next cycle.
+/// - `in_progress` older than `stale_secs`: a live attempt that never finished
+///   (e.g. the process crashed), reclaimed so it doesn't get stuck forever.
+///
+/// Rows at/above the attempt cap are never claimed.
+pub async fn claim_stale_pending(
+    pool: &PgPool,
+    backoff_base_secs: i32,
+    backoff_cap_secs: i32,
+    stale_secs: i32,
+    limit: i32,
+) -> Result<Vec<SweepCandidate>, sqlx::Error> {
+    let rows = sqlx::query(
+        r#"
+        UPDATE treasury_creation_requests
+        SET attempts = attempts + 1, updated_at = NOW()
+        WHERE account_id IN (
+            SELECT account_id FROM treasury_creation_requests
+            WHERE attempts < $1
+              AND (
+                    (status = 'pending'
+                        AND updated_at < NOW() - make_interval(
+                            secs => LEAST(attempts * $2, $3)))
+                 OR (status = 'in_progress'
+                        AND updated_at < NOW() - make_interval(secs => $4))
+                  )
+            ORDER BY updated_at ASC
+            LIMIT $5
+            FOR UPDATE SKIP LOCKED
+        )
+        RETURNING account_id, name, payment_threshold, governance_threshold,
+                  governors, financiers, requestors, is_confidential, attempts
+        "#,
+    )
+    .bind(MAX_SWEEP_ATTEMPTS)
+    .bind(backoff_base_secs)
+    .bind(backoff_cap_secs)
+    .bind(stale_secs)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+
+    let mut candidates = Vec::with_capacity(rows.len());
+    for row in rows {
+        let account_id_str: String = row.try_get("account_id")?;
+        let account_id = match account_id_str.parse::<AccountId>() {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::warn!("Sweeper: skipping unparseable account_id {account_id_str}: {e}");
+                continue;
+            }
+        };
+
+        let governors = parse_account_ids(row.try_get::<Vec<String>, _>("governors")?);
+        let financiers = parse_account_ids(row.try_get::<Vec<String>, _>("financiers")?);
+        let requestors = parse_account_ids(row.try_get::<Vec<String>, _>("requestors")?);
+
+        let payment_threshold: i16 = row.try_get("payment_threshold")?;
+        let governance_threshold: i16 = row.try_get("governance_threshold")?;
+
+        candidates.push(SweepCandidate {
+            request: CreateTreasuryRequest {
+                name: row.try_get("name")?,
+                account_id,
+                payment_threshold: payment_threshold as u8,
+                governance_threshold: governance_threshold as u8,
+                governors,
+                financiers,
+                requestors,
+                is_confidential: row.try_get("is_confidential")?,
+            },
+            attempts: row.try_get("attempts")?,
+        });
+    }
+
+    Ok(candidates)
+}
+
+fn parse_account_ids(raw: Vec<String>) -> Vec<AccountId> {
+    raw.into_iter().filter_map(|s| s.parse().ok()).collect()
+}

--- a/nt-be/src/handlers/treasury/creation_sweeper.rs
+++ b/nt-be/src/handlers/treasury/creation_sweeper.rs
@@ -1,0 +1,190 @@
+//! Background sweeper that finishes half-created treasuries.
+//!
+//! When a creation attempt fails part-way (e.g. an RPC timeout after the DAO is
+//! created but before confidential ownership handoff), its intent is left
+//! `pending` in `treasury_creation_requests`. This worker claims stale pending
+//! requests and re-runs the (idempotent, resumable) creation flow, so a user's
+//! chosen treasury gets finished without them having to come back — even if
+//! they closed the tab or the process restarted.
+//!
+//! It runs both on a periodic poll and immediately when a failing attempt wakes
+//! it via [`AppState::creation_sweep_notify`], so recovery normally starts
+//! within moments of a failure rather than at the next tick.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+use crate::AppState;
+
+use super::create::run_creation;
+use super::creation_requests::{self, MAX_SWEEP_ATTEMPTS, SweepCandidate, claim_stale_pending};
+
+/// How often to scan for resumable creations. Kept short so a failed attempt is
+/// retried within seconds rather than minutes; the scan is a single indexed
+/// query that usually returns nothing, so it's cheap to run often.
+const DEFAULT_INTERVAL_SECS: u64 = 15;
+const DEFAULT_INITIAL_DELAY_SECS: u64 = 15;
+/// Per-attempt backoff for `pending` (failed) rows: eligible after
+/// `LEAST(attempts * base, cap)` seconds of idleness. A freshly-failed row has
+/// `attempts = 0`, so it's retried on the very next cycle (≈ interval);
+/// repeated failures then back off up to the cap.
+const DEFAULT_BACKOFF_BASE_SECS: i32 = 30;
+const DEFAULT_BACKOFF_CAP_SECS: i32 = 300;
+/// Reclaim an `in_progress` row only after it's been silent this long — long
+/// enough that a live attempt is surely dead (crash/restart), so we never race
+/// one that's still running.
+const DEFAULT_STALE_SECS: i32 = 300;
+/// Max requests to process per cycle.
+const BATCH_LIMIT: i32 = 10;
+
+/// Spawn the treasury creation sweeper. Disabled via
+/// `DISABLE_TREASURY_CREATION_SWEEPER=true`.
+pub fn spawn_treasury_creation_sweeper(state: Arc<AppState>) {
+    if env_flag("DISABLE_TREASURY_CREATION_SWEEPER") {
+        tracing::info!(
+            "Treasury creation sweeper disabled (DISABLE_TREASURY_CREATION_SWEEPER=true)"
+        );
+        return;
+    }
+
+    let interval_secs = env_u64(
+        "TREASURY_CREATION_SWEEPER_INTERVAL_SECONDS",
+        DEFAULT_INTERVAL_SECS,
+    );
+    let initial_delay = env_u64(
+        "TREASURY_CREATION_SWEEPER_INITIAL_DELAY_SECONDS",
+        DEFAULT_INITIAL_DELAY_SECS,
+    );
+    let backoff_base_secs = env_u64(
+        "TREASURY_CREATION_SWEEPER_BACKOFF_BASE_SECONDS",
+        DEFAULT_BACKOFF_BASE_SECS as u64,
+    ) as i32;
+    let backoff_cap_secs = env_u64(
+        "TREASURY_CREATION_SWEEPER_BACKOFF_CAP_SECONDS",
+        DEFAULT_BACKOFF_CAP_SECS as u64,
+    ) as i32;
+    let stale_secs = env_u64(
+        "TREASURY_CREATION_SWEEPER_STALE_SECONDS",
+        DEFAULT_STALE_SECS as u64,
+    ) as i32;
+
+    tokio::spawn(async move {
+        tracing::info!(
+            interval_secs,
+            initial_delay_secs = initial_delay,
+            backoff_base_secs,
+            backoff_cap_secs,
+            stale_secs,
+            "Starting treasury creation sweeper"
+        );
+        tokio::time::sleep(Duration::from_secs(initial_delay)).await;
+
+        let notify = state.creation_sweep_notify.clone();
+        let mut timer = tokio::time::interval(Duration::from_secs(interval_secs));
+        loop {
+            // Run a cycle on the periodic tick OR as soon as a failed attempt
+            // pings us — so a fresh failure is retried within moments, while the
+            // poll stays as a fallback for crashed/abandoned creations.
+            tokio::select! {
+                _ = timer.tick() => {}
+                _ = notify.notified() => {}
+            }
+            if let Err(e) =
+                run_sweep_cycle(&state, backoff_base_secs, backoff_cap_secs, stale_secs).await
+            {
+                tracing::error!("Treasury creation sweep cycle failed: {e}");
+            }
+        }
+    });
+}
+
+async fn run_sweep_cycle(
+    state: &Arc<AppState>,
+    backoff_base_secs: i32,
+    backoff_cap_secs: i32,
+    stale_secs: i32,
+) -> Result<(), sqlx::Error> {
+    let candidates = claim_stale_pending(
+        &state.db_pool,
+        backoff_base_secs,
+        backoff_cap_secs,
+        stale_secs,
+        BATCH_LIMIT,
+    )
+    .await?;
+    if candidates.is_empty() {
+        return Ok(());
+    }
+
+    tracing::info!(
+        "Treasury creation sweeper: resuming {} pending creation(s)",
+        candidates.len()
+    );
+
+    for candidate in candidates {
+        resume_one(state, candidate).await;
+    }
+
+    Ok(())
+}
+
+async fn resume_one(state: &Arc<AppState>, candidate: SweepCandidate) {
+    let SweepCandidate { request, attempts } = candidate;
+    let account = request.account_id.to_string();
+
+    // run_creation streams progress; the sweeper has no client, so drain it.
+    let (tx, mut rx) = mpsc::channel(32);
+    let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let result = run_creation(state.clone(), request, tx).await;
+    let _ = drain.await;
+
+    match result {
+        Ok(()) => {
+            tracing::info!("Treasury creation sweeper: completed {account}");
+        }
+        Err(evt) => {
+            let message = evt.message.unwrap_or_default();
+
+            // Another attempt (live request or a parallel sweeper) holds the
+            // advisory lock — not a failure, just try again next cycle.
+            if message.contains("already in progress") {
+                tracing::debug!("Treasury creation sweeper: {account} is busy, will retry");
+                return;
+            }
+
+            tracing::warn!(
+                "Treasury creation sweeper: attempt {attempts}/{MAX_SWEEP_ATTEMPTS} for {account} failed: {message}"
+            );
+
+            if attempts >= MAX_SWEEP_ATTEMPTS {
+                if let Err(e) =
+                    creation_requests::mark_creation_failed(&state.db_pool, &account).await
+                {
+                    tracing::warn!("Failed to mark creation failed for {account}: {e}");
+                }
+                let alert = format!(
+                    "Treasury creation sweeper gave up on {account} after {MAX_SWEEP_ATTEMPTS} attempts. Last error: {message}"
+                );
+                if let Err(e) = state.telegram_client.send_message(&alert).await {
+                    tracing::warn!("Failed to send sweeper give-up alert: {e}");
+                }
+            }
+        }
+    }
+}
+
+fn env_flag(key: &str) -> bool {
+    std::env::var(key)
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false)
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}

--- a/nt-be/src/handlers/treasury/creation_sweeper.rs
+++ b/nt-be/src/handlers/treasury/creation_sweeper.rs
@@ -2,7 +2,7 @@
 //!
 //! When a creation attempt fails part-way (e.g. an RPC timeout after the DAO is
 //! created but before confidential ownership handoff), its intent is left
-//! `pending` in `treasury_creation_requests`. This worker claims stale pending
+//! `pending` in `incomplete_treasury_creations`. This worker claims stale pending
 //! requests and re-runs the (idempotent, resumable) creation flow, so a user's
 //! chosen treasury gets finished without them having to come back — even if
 //! they closed the tab or the process restarted.
@@ -127,13 +127,23 @@ async fn resume_one(state: &Arc<AppState>, candidate: SweepCandidate) {
                 return;
             }
 
+            // Terminal error (e.g. handle taken): run_creation already marked
+            // the row `failed`. Don't warn/alert as a give-up or keep retrying.
+            if super::create::is_terminal_creation_error(&message) {
+                tracing::info!(
+                    "Treasury creation sweeper: {account} is not resumable ({message}); marked failed"
+                );
+                return;
+            }
+
             tracing::warn!(
                 "Treasury creation sweeper: attempt {attempts}/{MAX_SWEEP_ATTEMPTS} for {account} failed: {message}"
             );
 
             if attempts >= MAX_SWEEP_ATTEMPTS {
                 if let Err(e) =
-                    creation_requests::mark_creation_failed(&state.db_pool, &account).await
+                    creation_requests::mark_creation_failed(&state.db_pool, &account, &message)
+                        .await
                 {
                     tracing::warn!("Failed to mark creation failed for {account}: {e}");
                 }

--- a/nt-be/src/handlers/treasury/creation_sweeper.rs
+++ b/nt-be/src/handlers/treasury/creation_sweeper.rs
@@ -24,18 +24,18 @@ use super::creation_requests::{self, MAX_SWEEP_ATTEMPTS, SweepCandidate, claim_s
 /// How often to scan for resumable creations. Kept short so a failed attempt is
 /// retried within seconds rather than minutes; the scan is a single indexed
 /// query that usually returns nothing, so it's cheap to run often.
-const DEFAULT_INTERVAL_SECS: u64 = 15;
-const DEFAULT_INITIAL_DELAY_SECS: u64 = 15;
+const INTERVAL_SECS: u64 = 15;
+const INITIAL_DELAY_SECS: u64 = 15;
 /// Per-attempt backoff for `pending` (failed) rows: eligible after
 /// `LEAST(attempts * base, cap)` seconds of idleness. A freshly-failed row has
 /// `attempts = 0`, so it's retried on the very next cycle (≈ interval);
 /// repeated failures then back off up to the cap.
-const DEFAULT_BACKOFF_BASE_SECS: i32 = 30;
-const DEFAULT_BACKOFF_CAP_SECS: i32 = 300;
+const BACKOFF_BASE_SECS: i32 = 30;
+const BACKOFF_CAP_SECS: i32 = 300;
 /// Reclaim an `in_progress` row only after it's been silent this long — long
 /// enough that a live attempt is surely dead (crash/restart), so we never race
 /// one that's still running.
-const DEFAULT_STALE_SECS: i32 = 300;
+const STALE_SECS: i32 = 300;
 /// Max requests to process per cycle.
 const BATCH_LIMIT: i32 = 10;
 
@@ -49,40 +49,19 @@ pub fn spawn_treasury_creation_sweeper(state: Arc<AppState>) {
         return;
     }
 
-    let interval_secs = env_u64(
-        "TREASURY_CREATION_SWEEPER_INTERVAL_SECONDS",
-        DEFAULT_INTERVAL_SECS,
-    );
-    let initial_delay = env_u64(
-        "TREASURY_CREATION_SWEEPER_INITIAL_DELAY_SECONDS",
-        DEFAULT_INITIAL_DELAY_SECS,
-    );
-    let backoff_base_secs = env_u64(
-        "TREASURY_CREATION_SWEEPER_BACKOFF_BASE_SECONDS",
-        DEFAULT_BACKOFF_BASE_SECS as u64,
-    ) as i32;
-    let backoff_cap_secs = env_u64(
-        "TREASURY_CREATION_SWEEPER_BACKOFF_CAP_SECONDS",
-        DEFAULT_BACKOFF_CAP_SECS as u64,
-    ) as i32;
-    let stale_secs = env_u64(
-        "TREASURY_CREATION_SWEEPER_STALE_SECONDS",
-        DEFAULT_STALE_SECS as u64,
-    ) as i32;
-
     tokio::spawn(async move {
         tracing::info!(
-            interval_secs,
-            initial_delay_secs = initial_delay,
-            backoff_base_secs,
-            backoff_cap_secs,
-            stale_secs,
+            interval_secs = INTERVAL_SECS,
+            initial_delay_secs = INITIAL_DELAY_SECS,
+            backoff_base_secs = BACKOFF_BASE_SECS,
+            backoff_cap_secs = BACKOFF_CAP_SECS,
+            stale_secs = STALE_SECS,
             "Starting treasury creation sweeper"
         );
-        tokio::time::sleep(Duration::from_secs(initial_delay)).await;
+        tokio::time::sleep(Duration::from_secs(INITIAL_DELAY_SECS)).await;
 
         let notify = state.creation_sweep_notify.clone();
-        let mut timer = tokio::time::interval(Duration::from_secs(interval_secs));
+        let mut timer = tokio::time::interval(Duration::from_secs(INTERVAL_SECS));
         loop {
             // Run a cycle on the periodic tick OR as soon as a failed attempt
             // pings us — so a fresh failure is retried within moments, while the
@@ -91,26 +70,19 @@ pub fn spawn_treasury_creation_sweeper(state: Arc<AppState>) {
                 _ = timer.tick() => {}
                 _ = notify.notified() => {}
             }
-            if let Err(e) =
-                run_sweep_cycle(&state, backoff_base_secs, backoff_cap_secs, stale_secs).await
-            {
+            if let Err(e) = run_sweep_cycle(&state).await {
                 tracing::error!("Treasury creation sweep cycle failed: {e}");
             }
         }
     });
 }
 
-async fn run_sweep_cycle(
-    state: &Arc<AppState>,
-    backoff_base_secs: i32,
-    backoff_cap_secs: i32,
-    stale_secs: i32,
-) -> Result<(), sqlx::Error> {
+async fn run_sweep_cycle(state: &Arc<AppState>) -> Result<(), sqlx::Error> {
     let candidates = claim_stale_pending(
         &state.db_pool,
-        backoff_base_secs,
-        backoff_cap_secs,
-        stale_secs,
+        BACKOFF_BASE_SECS,
+        BACKOFF_CAP_SECS,
+        STALE_SECS,
         BATCH_LIMIT,
     )
     .await?;
@@ -180,11 +152,4 @@ fn env_flag(key: &str) -> bool {
     std::env::var(key)
         .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
         .unwrap_or(false)
-}
-
-fn env_u64(key: &str, default: u64) -> u64 {
-    std::env::var(key)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(default)
 }

--- a/nt-be/src/handlers/treasury/mod.rs
+++ b/nt-be/src/handlers/treasury/mod.rs
@@ -2,6 +2,8 @@ pub mod check_handle_unused;
 pub mod confidential_setup;
 pub mod config;
 pub mod create;
+pub mod creation_requests;
+pub mod creation_sweeper;
 pub mod custom_requests;
 pub mod policy;
 pub mod whitelist_request;

--- a/nt-be/src/main.rs
+++ b/nt-be/src/main.rs
@@ -188,6 +188,10 @@ async fn async_main() {
         state.clone(),
     );
 
+    // Spawn treasury creation sweeper (finishes half-created treasuries left
+    // pending by failed/interrupted creation attempts).
+    nt_be::handlers::treasury::creation_sweeper::spawn_treasury_creation_sweeper(state.clone());
+
     // Spawn status monitor worker (Oh Dear health checks + fallback warnings)
     nt_be::handlers::status::run_status_monitor_loop(state.clone());
 

--- a/nt-be/src/utils/test_utils.rs
+++ b/nt-be/src/utils/test_utils.rs
@@ -140,6 +140,7 @@ pub fn build_test_state(db_pool: sqlx::PgPool) -> AppState {
         transfer_hint_service: transfer_hint_service.map(Arc::new),
         goldsky_pool: None,
         neardata_client: None,
+        creation_sweep_notify: Arc::new(tokio::sync::Notify::new()),
     }
 }
 

--- a/nt-be/tests/common/mod.rs
+++ b/nt-be/tests/common/mod.rs
@@ -162,6 +162,7 @@ pub fn build_test_state(db_pool: sqlx::PgPool) -> AppState {
         transfer_hint_service: transfer_hint_service.map(Arc::new),
         neardata_client: None,
         goldsky_pool: None,
+        creation_sweep_notify: Arc::new(tokio::sync::Notify::new()),
     }
 }
 

--- a/nt-fe/e2e/start-page.spec.ts
+++ b/nt-fe/e2e/start-page.spec.ts
@@ -120,7 +120,7 @@ test("Signed in + has treasury => redirects to /{daoId}", async ({ page }) => {
     );
 });
 
-test("Signed in + no treasuries + creation error => waitlist is shown", async ({
+test("Signed in + no treasuries + creation disabled => waitlist is shown", async ({
     page,
 }) => {
     await setupStartPageMocks(page, {
@@ -135,11 +135,15 @@ test("Signed in + no treasuries + creation error => waitlist is shown", async ({
             body: JSON.stringify({ unused: true }),
         }),
     );
+    // A permanent error (creation disabled) is not resumable, so the UI skips
+    // the in-session recovery re-drives and falls straight through to the
+    // waitlist. A transient error would instead spin for the full recovery
+    // window before showing the waitlist.
     await page.route("**/api/treasury/create-stream", async (route) =>
         route.fulfill({
             status: 200,
             headers: { "content-type": "text/event-stream" },
-            body: `data: {"step":"error","status":"error","message":"Mocked creation failure"}\n\n`,
+            body: `data: {"step":"error","status":"error","message":"Treasury creation disabled"}\n\n`,
         }),
     );
 

--- a/nt-fe/features/onboarding/components/create-treasury-entry.tsx
+++ b/nt-fe/features/onboarding/components/create-treasury-entry.tsx
@@ -51,7 +51,7 @@ function isPermanentCreationError(message?: string): boolean {
     if (!message) return false;
     const normalized = message.toLowerCase();
     return (
-        normalized.includes("not managed by this platform") ||
+        normalized.includes("already taken") ||
         normalized.includes("creation disabled")
     );
 }

--- a/nt-fe/features/onboarding/components/create-treasury-entry.tsx
+++ b/nt-fe/features/onboarding/components/create-treasury-entry.tsx
@@ -38,6 +38,24 @@ import { cn } from "@/lib/utils";
 import { useNear } from "@/stores/near-store";
 
 const ACCOUNT_SUFFIX = ".sputnik-dao.near";
+
+// After a resumable failure, the backend sweeper finishes the treasury in the
+// background. We re-drive the idempotent creation flow a few times so the user
+// lands in their treasury within this session instead of seeing an error.
+const CREATION_RECOVERY_MAX_ATTEMPTS = 12;
+const CREATION_RECOVERY_DELAY_MS = 5000;
+
+// Errors that will never succeed on retry (name taken, creation switched off).
+// Everything else is treated as transient/resumable.
+function isPermanentCreationError(message?: string): boolean {
+    if (!message) return false;
+    const normalized = message.toLowerCase();
+    return (
+        normalized.includes("not managed by this platform") ||
+        normalized.includes("creation disabled")
+    );
+}
+
 type InitialScreen = "create" | "login";
 type LoginScreenSource = "sign-in" | "connect-wallet";
 type FormValues = {
@@ -390,49 +408,126 @@ export function TreasuryOnboardingPage({
         setShowWaitlist(false);
         setProgressOpen(true);
 
-        try {
+        const finishWithTreasury = (treasuryId: string) => {
+            setProgressSteps((prev) =>
+                prev.map((step) => ({ ...step, status: "completed" })),
+            );
+            setCreatedTreasuryId(treasuryId);
+            trackEvent("treasury-created", { treasury_id: treasuryId });
+            trackEvent("onboarding-completed", { treasury_id: treasuryId });
+            queryClient.invalidateQueries({
+                queryKey: ["userTreasuries", accountId],
+            });
+            router.push(`/${treasuryId}`);
+        };
+
+        // Drive a single create-stream attempt. The backend flow is idempotent,
+        // so this can be safely re-driven to resume a half-finished creation.
+        //
+        // `trackProgress` maps per-step events onto the modal. We only do this
+        // for the first (live) attempt; during recovery the re-drives replay
+        // earlier steps and skip already-done ones, which would make the UI jump
+        // around — so there we ignore step events and hold a single spinner
+        // (see `showLoaderOnCurrentStep`) until it's actually done.
+        const attemptStream = async (
+            trackProgress: boolean,
+        ): Promise<
+            | { done: true; treasuryId: string }
+            | { done: false; message?: string }
+        > => {
+            let outcome:
+                | { done: true; treasuryId: string }
+                | { done: false; message?: string } = { done: false };
             await createTreasuryStream(request, (event) => {
                 if (event.step === "done") {
-                    const treasuryId = event.treasury!;
-                    setProgressSteps((prev) =>
-                        prev.map((step) => ({
-                            ...step,
-                            status: "completed",
-                        })),
-                    );
-                    setCreatedTreasuryId(treasuryId);
-                    trackEvent("treasury-created", {
-                        treasury_id: treasuryId,
-                    });
-                    trackEvent("onboarding-completed", {
-                        treasury_id: treasuryId,
-                    });
-                    queryClient.invalidateQueries({
-                        queryKey: ["userTreasuries", accountId],
-                    });
-                    router.push(`/${treasuryId}`);
+                    outcome = { done: true, treasuryId: event.treasury! };
                     return;
                 }
-
                 if (event.step === "error") {
-                    setProgressOpen(false);
-                    setShowWaitlist(true);
+                    outcome = { done: false, message: event.message };
                     return;
                 }
-
+                if (!trackProgress) return;
                 setProgressSteps((prev) =>
-                    prev.map((step) => {
-                        if (step.id !== event.step) return step;
-                        return {
-                            ...step,
-                            status: event.status as CreationStep["status"],
-                        };
-                    }),
+                    prev.map((step) =>
+                        step.id === event.step
+                            ? {
+                                  ...step,
+                                  status: event.status as CreationStep["status"],
+                              }
+                            : step,
+                    ),
                 );
             });
+            return outcome;
+        };
+
+        // Show the spinner on the step where it stalled (the first one that
+        // hasn't completed), so the modal never looks frozen while we recover.
+        const showLoaderOnCurrentStep = () => {
+            setProgressSteps((prev) => {
+                const idx = prev.findIndex(
+                    (step) => step.status !== "completed",
+                );
+                if (idx === -1) return prev;
+                return prev.map((step, i) =>
+                    i === idx ? { ...step, status: "in_progress" } : step,
+                );
+            });
+        };
+
+        // Keep the progress modal open and re-drive the flow until the backend
+        // (this call or the background sweeper) finishes the treasury, then send
+        // the user straight into it. Returns false if it never completes in time.
+        const recoverInSession = async (): Promise<boolean> => {
+            showLoaderOnCurrentStep();
+            for (
+                let attempt = 0;
+                attempt < CREATION_RECOVERY_MAX_ATTEMPTS;
+                attempt++
+            ) {
+                await new Promise((resolve) =>
+                    setTimeout(resolve, CREATION_RECOVERY_DELAY_MS),
+                );
+                try {
+                    const result = await attemptStream(false);
+                    if (result.done) {
+                        finishWithTreasury(result.treasuryId);
+                        return true;
+                    }
+                    if (isPermanentCreationError(result.message)) {
+                        return false;
+                    }
+                } catch {
+                    // Transient network blip — keep trying until the window ends.
+                }
+                // Re-assert the spinner in case that attempt left the steps
+                // static (e.g. the backend was busy and streamed nothing).
+                showLoaderOnCurrentStep();
+            }
+            return false;
+        };
+
+        try {
+            const first = await attemptStream(true);
+            if (first.done) {
+                finishWithTreasury(first.treasuryId);
+                return;
+            }
+            // A permanent error can't be resumed; otherwise the sweeper is
+            // already finishing it, so try to land the user in it this session.
+            if (
+                isPermanentCreationError(first.message) ||
+                !(await recoverInSession())
+            ) {
+                setProgressOpen(false);
+                setShowWaitlist(true);
+            }
         } catch {
-            setProgressOpen(false);
-            setShowWaitlist(true);
+            if (!(await recoverInSession())) {
+                setProgressOpen(false);
+                setShowWaitlist(true);
+            }
         }
     };
 


### PR DESCRIPTION
#1024
The previous PR made treasury creation idempotent, resumable, concurrency-safe, and retried transient errors in-request. But if all in-request retries failed (or the process died mid-flow), the treasury was still left half-created until someone intervened.

This PR adds durable, automatic recovery so those half-created treasuries always get finished — and the user isn't stranded in the meantime.

**Persist creation intent**
- New `treasury_creation_requests` table stores the full request. Status lifecycle: `in_progress` while an attempt runs → `pending` if it fails part-way → row **deleted** on success → `failed` only after max attempts. For confidential DAOs this is the only way to recover the intended member policy, since it can't be read back from chain.

**Background sweeper**
- A worker resumes any `pending` creation by re-running the (already idempotent) flow. It's **woken immediately** when an attempt fails, so recovery starts within moments, and also **polls** as a fallback for crashed/abandoned attempts (reclaims stale `in_progress` rows). Gives up after max attempts → marks `failed` + Telegram alert.

**In-session frontend recovery**
- After a resumable error, the progress modal stays open, holds a spinner on the stalled step, and re-drives the idempotent flow until it completes — then redirects the user straight into their treasury. Permanent errors (name taken / creation disabled) go straight to the waitlist.