### PR TITLE
feat: improve dashboard chart controls, refresh skeletons

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/assets.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/assets.tsx
@@ -8,6 +8,7 @@ import { ConfidentialState } from "@/components/confidential-state";
 import { EmptyState } from "@/components/empty-state";
 import { StepperHeader } from "@/components/step-wizard";
 import { Tooltip } from "@/components/tooltip";
+import { useIsHistoryRefreshing } from "@/features/activity";
 import { useAggregatedTokens } from "@/hooks/use-assets";
 import { useTreasury } from "@/hooks/use-treasury";
 import type { TreasuryAsset } from "@/lib/api";
@@ -22,6 +23,7 @@ export default function Assets({ tokens, state }: Props) {
     const t = useTranslations("assetsPage");
     const tCommon = useTranslations("common");
     const { isConfidential } = useTreasury();
+    const isHistoryRefreshing = useIsHistoryRefreshing();
     const aggregatedTokens = useAggregatedTokens(tokens);
     const bucketVisibility = getDashboardBucketVisibility(tokens);
     const hasTabs = bucketVisibility.showLocked || bucketVisibility.showEarning;
@@ -31,7 +33,7 @@ export default function Assets({ tokens, state }: Props) {
             return <ConfidentialState skeleton={<AssetsTableSkeleton />} />;
         }
 
-        if (state === "loading") {
+        if (state === "loading" || isHistoryRefreshing) {
             return <AssetsTableSkeleton />;
         }
 

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -637,6 +637,7 @@ export default function BalanceWithGraph({
                                         size="sm"
                                         disabled={isLoadingTokens || isLoading}
                                         className="h-9 min-w-[140px] justify-between font-normal"
+                                        data-testid="chart-token-trigger"
                                     >
                                         {selectedToken === "all" ? (
                                             <span className="flex items-center gap-2">
@@ -714,6 +715,7 @@ export default function BalanceWithGraph({
                                         size="sm"
                                         disabled={isLoadingTokens || isLoading}
                                         className="h-9 w-fit justify-between gap-1.5 font-normal"
+                                        data-testid="chart-period-trigger"
                                     >
                                         <span>
                                             {t(`period.${selectedPeriod}`)}
@@ -732,6 +734,7 @@ export default function BalanceWithGraph({
                                                 setSelectedPeriod(period)
                                             }
                                             className="flex items-center justify-between gap-2"
+                                            data-testid={`chart-period-option-${period}`}
                                         >
                                             <span>{t(`period.${period}`)}</span>
                                             {selectedPeriod === period && (

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -3,6 +3,8 @@
 import {
     ArrowLeftRight,
     ArrowUpRightIcon,
+    Check,
+    ChevronDown,
     Coins,
     Download,
     Info,
@@ -16,6 +18,12 @@ import { Button } from "@/components/button";
 import { PageCard } from "@/components/card";
 import { Tooltip } from "@/components/tooltip";
 import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
     Select,
     SelectContent,
     SelectItem,
@@ -24,7 +32,6 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useTreasury } from "@/hooks/use-treasury";
 import { useBalanceChart } from "@/hooks/use-treasury-queries";
 import type { ChartInterval, TreasuryAsset } from "@/lib/api";
@@ -38,6 +45,7 @@ import {
 } from "@/lib/dashboard-balance-view";
 import { formatBalance, formatCurrencyWithSubCent } from "@/lib/utils";
 import { HistoryRefreshButton } from "@/features/activity/components/history-refresh-button";
+import { useIsHistoryRefreshing } from "@/features/activity";
 import BalanceChart from "./chart";
 
 interface Props {
@@ -130,6 +138,7 @@ export default function BalanceWithGraph({
     const t = useTranslations("balanceWithGraph");
     const tCommon = useTranslations("common");
     const locale = useLocale();
+    const isHistoryRefreshing = useIsHistoryRefreshing();
     const {
         treasuryId,
         isConfidential: isConfidentialTreasury,
@@ -621,28 +630,21 @@ export default function BalanceWithGraph({
                     </div>
                     {!isConfidential && (
                         <div className="hidden md:flex md:flex-row items-end flex-col gap-1 md:gap-2 md:items-center">
-                            <Select
-                                value={selectedToken}
-                                onValueChange={setSelectedToken}
-                            >
-                                <SelectTrigger
-                                    size="sm"
-                                    className="min-w-[140px] w-full"
-                                    disabled={
-                                        isLoadingTokens ||
-                                        (!isConfidential &&
-                                            (isLoading ||
-                                                chartData.data.length === 0))
-                                    }
-                                >
-                                    <SelectValue>
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        disabled={isLoadingTokens || isLoading}
+                                        className="h-9 min-w-[140px] justify-between font-normal"
+                                    >
                                         {selectedToken === "all" ? (
-                                            <div className="flex items-center gap-2">
+                                            <span className="flex items-center gap-2">
                                                 <Coins className="size-4" />
                                                 <span>{t("allTokens")}</span>
-                                            </div>
+                                            </span>
                                         ) : (
-                                            <div className="flex items-center gap-2">
+                                            <span className="flex items-center gap-2">
                                                 {selectedTokenGroup?.icon && (
                                                     <img
                                                         src={
@@ -657,23 +659,36 @@ export default function BalanceWithGraph({
                                                     />
                                                 )}
                                                 <span>{selectedToken}</span>
-                                            </div>
+                                            </span>
                                         )}
-                                    </SelectValue>
-                                </SelectTrigger>
-                                <SelectContent className="max-h-[300px] overflow-y-auto">
-                                    <SelectItem value="all">
-                                        <div className="flex items-center gap-2">
+                                        <ChevronDown className="size-4 opacity-50" />
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent
+                                    align="end"
+                                    className="max-h-[300px] min-w-[140px] overflow-y-auto"
+                                >
+                                    <DropdownMenuItem
+                                        onSelect={() => setSelectedToken("all")}
+                                        className="flex items-center justify-between gap-2"
+                                    >
+                                        <span className="flex items-center gap-2">
                                             <Coins className="size-4" />
                                             <span>{t("allTokens")}</span>
-                                        </div>
-                                    </SelectItem>
+                                        </span>
+                                        {selectedToken === "all" && (
+                                            <Check className="size-4" />
+                                        )}
+                                    </DropdownMenuItem>
                                     {groupedTokens.map((group) => (
-                                        <SelectItem
+                                        <DropdownMenuItem
                                             key={group.symbol}
-                                            value={group.symbol}
+                                            onSelect={() =>
+                                                setSelectedToken(group.symbol)
+                                            }
+                                            className="flex items-center justify-between gap-2"
                                         >
-                                            <div className="flex items-center gap-2">
+                                            <span className="flex items-center gap-2">
                                                 {group.icon && (
                                                     <img
                                                         src={group.icon}
@@ -684,38 +699,48 @@ export default function BalanceWithGraph({
                                                     />
                                                 )}
                                                 <span>{group.symbol}</span>
-                                            </div>
-                                        </SelectItem>
+                                            </span>
+                                            {selectedToken === group.symbol && (
+                                                <Check className="size-4" />
+                                            )}
+                                        </DropdownMenuItem>
                                     ))}
-                                </SelectContent>
-                            </Select>
-                            {!isConfidential && (
-                                <ToggleGroup
-                                    type="single"
-                                    size="sm"
-                                    variant={"default"}
-                                    className="border border-input"
-                                    disabled={
-                                        isLoadingTokens ||
-                                        isLoading ||
-                                        chartData.data.length === 0
-                                    }
-                                    value={selectedPeriod}
-                                    onValueChange={(e) =>
-                                        e && setSelectedPeriod(e as TimePeriod)
-                                    }
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        disabled={isLoadingTokens || isLoading}
+                                        className="h-9 w-fit justify-between gap-1.5 font-normal"
+                                    >
+                                        <span>
+                                            {t(`period.${selectedPeriod}`)}
+                                        </span>
+                                        <ChevronDown className="size-4 opacity-50" />
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent
+                                    align="end"
+                                    className="min-w-[92px]"
                                 >
-                                    {TIME_PERIODS.map((e) => (
-                                        <ToggleGroupItem
-                                            key={e}
-                                            value={e}
-                                            className="hover:text-foreground"
+                                    {TIME_PERIODS.map((period) => (
+                                        <DropdownMenuItem
+                                            key={period}
+                                            onSelect={() =>
+                                                setSelectedPeriod(period)
+                                            }
+                                            className="flex items-center justify-between gap-2"
                                         >
-                                            {t(`period.${e}`)}
-                                        </ToggleGroupItem>
+                                            <span>{t(`period.${period}`)}</span>
+                                            {selectedPeriod === period && (
+                                                <Check className="size-4" />
+                                            )}
+                                        </DropdownMenuItem>
                                     ))}
-                                </ToggleGroup>
-                            )}
+                                </DropdownMenuContent>
+                            </DropdownMenu>
                         </div>
                     )}
                     <HistoryRefreshButton />
@@ -765,9 +790,7 @@ export default function BalanceWithGraph({
                         size="sm"
                         className="w-[140px]"
                         disabled={
-                            isLoadingTokens ||
-                            (!isConfidential &&
-                                (isLoading || chartData.data.length === 0))
+                            isLoadingTokens || (!isConfidential && isLoading)
                         }
                     >
                         <SelectValue>
@@ -838,7 +861,9 @@ export default function BalanceWithGraph({
                 )}
             </div>
             <div className={cn(isConfidential ? "hidden" : "")}>
-                {isLoading || (isFetching && chartData.data.length === 0) ? (
+                {isLoading ||
+                isHistoryRefreshing ||
+                (isFetching && chartData.data.length === 0) ? (
                     <div className="h-56 w-full space-y-3 p-4">
                         <Skeleton className="h-50 w-full" />
                     </div>

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -558,9 +558,6 @@ export default function BalanceWithGraph({
                                                         ", ",
                                                     )}
                                                 </p>
-                                                <p className="text-muted-foreground mt-1 text-[10px]">
-                                                    {t("noPriceHistory")}
-                                                </p>
                                             </div>
                                         }
                                     >

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -5,6 +5,7 @@ import {
     ArrowUpRightIcon,
     Check,
     ChevronDown,
+    ClockIcon,
     Coins,
     Download,
     Info,
@@ -16,6 +17,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { AuthButton } from "@/components/auth-button";
 import { Button } from "@/components/button";
 import { PageCard } from "@/components/card";
+import { EmptyState } from "@/components/empty-state";
 import { Tooltip } from "@/components/tooltip";
 import {
     DropdownMenu,
@@ -870,6 +872,16 @@ export default function BalanceWithGraph({
                     <div className="h-56 w-full space-y-3 p-4">
                         <Skeleton className="h-50 w-full" />
                     </div>
+                ) : selectedToken !== "all" &&
+                  displayChartData.data.length === 0 ? (
+                    <EmptyState
+                        icon={ClockIcon}
+                        title={t("noTokenChartTitle")}
+                        description={t("noTokenChartDescription", {
+                            symbol: selectedTokenGroup?.symbol ?? selectedToken,
+                        })}
+                        className="h-56"
+                    />
                 ) : (
                     <BalanceChart
                         data={displayChartData.data}

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/page.tsx
@@ -3,7 +3,10 @@
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { PageComponentLayout } from "@/components/page-component-layout";
-import { RecentActivity } from "@/features/activity";
+import {
+    HistoryRefreshIndicatorProvider,
+    RecentActivity,
+} from "@/features/activity";
 import { OnboardingProgress } from "@/features/onboarding";
 import { CreateBanner } from "@/features/onboarding/components/create-banner";
 import { InfoBox } from "@/features/onboarding/components/info-box";
@@ -38,35 +41,39 @@ export default function AppPage() {
 
     return (
         <PageComponentLayout title={t("title")} description={t("description")}>
-            <div className="flex flex-col lg:flex-row gap-5">
-                <div className="flex flex-col gap-5 lg:w-3/5 w-full">
-                    <div className="lg:hidden empty:hidden">
-                        <CreateBanner />
+            <HistoryRefreshIndicatorProvider>
+                <div className="flex flex-col lg:flex-row gap-5">
+                    <div className="flex flex-col gap-5 lg:w-3/5 w-full">
+                        <div className="lg:hidden empty:hidden">
+                            <CreateBanner />
+                        </div>
+                        <OnboardingProgress
+                            onDepositClick={handleDepositOpen}
+                        />
+                        <BalanceWithGraph
+                            tokens={tokens}
+                            isHidden={isHidden}
+                            onDepositClick={handleDepositOpen}
+                            isLoading={isAssetsLoading}
+                        />
+                        <Assets
+                            tokens={tokens}
+                            state={
+                                isHidden
+                                    ? "hidden"
+                                    : isAssetsLoading
+                                      ? "loading"
+                                      : "ready"
+                            }
+                        />
+                        <RecentActivity />
                     </div>
-                    <OnboardingProgress onDepositClick={handleDepositOpen} />
-                    <BalanceWithGraph
-                        tokens={tokens}
-                        isHidden={isHidden}
-                        onDepositClick={handleDepositOpen}
-                        isLoading={isAssetsLoading}
-                    />
-                    <Assets
-                        tokens={tokens}
-                        state={
-                            isHidden
-                                ? "hidden"
-                                : isAssetsLoading
-                                  ? "loading"
-                                  : "ready"
-                        }
-                    />
-                    <RecentActivity />
+                    <div className="flex flex-col gap-5 w-full lg:w-2/5">
+                        <InfoBox />
+                        <PendingRequests />
+                    </div>
                 </div>
-                <div className="flex flex-col gap-5 w-full lg:w-2/5">
-                    <InfoBox />
-                    <PendingRequests />
-                </div>
-            </div>
+            </HistoryRefreshIndicatorProvider>
             <BalanceWarningModal />
             <WelcomeTooltip />
             <CongratsTooltip />

--- a/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
@@ -734,10 +734,7 @@ export default function RequestReceiptPage({
     const destinationAmountWithDecimals =
         receiptProposalData?.destinationAmountWithDecimals;
     const isExecutableReceipt = status === "Executed";
-    const shouldUseSwapExecutionDate =
-        isExecutableReceipt &&
-        !!depositAddress &&
-        !isConfidentialRequestProposal;
+    const shouldUseSwapExecutionDate = isExecutableReceipt && !!depositAddress;
 
     const { data: transaction, isLoading: isLoadingTransaction } =
         useProposalTransaction(
@@ -752,6 +749,14 @@ export default function RequestReceiptPage({
         shouldUseSwapExecutionDate,
         treasuryId,
     );
+    // Intents-routed proposals gate the receipt on a SUCCESS swap status — a
+    // pending/failed/refunded swap has no finalized receipt (mirrors the sidebar
+    // button gate). Public treasury receipts stay accessible to logged-out /
+    // non-member (guest) viewers regardless of swap status.
+    const isSwapSuccessReady =
+        !shouldUseSwapExecutionDate ||
+        (!isConfidential && isGuestTreasury) ||
+        swapStatus?.status === "SUCCESS";
     const transactionDate = getProposalExecutedDate(swapStatus, transaction);
     const isExchangeProposal = receiptProposalVariant === "exchange";
     const hasDepositAddress = !!depositAddress;
@@ -852,6 +857,7 @@ export default function RequestReceiptPage({
         (!isSingleReceiptProposal || receiptProposalData !== null) &&
         !!policy &&
         isExecutableReceipt &&
+        isSwapSuccessReady &&
         !(isBatchPaymentProposal && isConfidential);
     const batchPayments = batchPaymentData?.payments ?? [];
     const paymentsToRender = useMemo(
@@ -992,7 +998,11 @@ export default function RequestReceiptPage({
         ],
     );
 
-    if (isLoadingProposal || (canLoadPolicy && isLoadingPolicy)) {
+    if (
+        isLoadingProposal ||
+        (canLoadPolicy && isLoadingPolicy) ||
+        (shouldUseSwapExecutionDate && isLoadingSwapStatus)
+    ) {
         return (
             <div className="min-h-dvh bg-muted p-4 print:bg-white">
                 <div className="mx-auto w-full max-w-[700px]">

--- a/nt-fe/e2e/dashboard-chart-mobile.spec.ts
+++ b/nt-fe/e2e/dashboard-chart-mobile.spec.ts
@@ -221,9 +221,10 @@ test("dashboard chart x-axis labels should not overlap on desktop with 3M period
         .first()
         .waitFor({ state: "visible", timeout: 15_000 });
 
-    // On desktop, the time period selector is a ToggleGroup (hidden on mobile)
-    const btn3M = page.locator(".hidden.md\\:flex").getByText("3M");
-    await btn3M.click();
+    // On desktop, the time period selector is a dropdown (hidden on mobile):
+    // open the trigger, then pick "3M" from the portaled menu.
+    await page.getByTestId("chart-period-trigger").click();
+    await page.getByTestId("chart-period-option-3M").click();
 
     // Wait for chart to re-render with 3M data
     await chartContainer

--- a/nt-fe/e2e/dashboard-chart-periods.spec.ts
+++ b/nt-fe/e2e/dashboard-chart-periods.spec.ts
@@ -135,6 +135,16 @@ async function setupMocks(page: Page) {
 }
 
 /**
+ * Select a time period from the desktop dropdown. The trigger shows the
+ * currently selected period; the other options live in a portaled menu that
+ * must be opened first.
+ */
+async function selectDesktopPeriod(page: Page, period: string) {
+    await page.getByTestId("chart-period-trigger").click();
+    await page.getByTestId(`chart-period-option-${period}`).click();
+}
+
+/**
  * Collect x-axis tick labels from the rendered chart.
  * Returns an array of { text, left, right } for each visible tick label.
  */
@@ -262,11 +272,8 @@ test.describe("Dashboard chart time period aggregation (issue #228)", () => {
                 .first()
                 .waitFor({ state: "visible", timeout: 15_000 });
 
-            // Select the target time period via desktop ToggleGroup
-            const periodBtn = page
-                .locator(".hidden.md\\:flex")
-                .getByText(period, { exact: true });
-            await periodBtn.click();
+            // Select the target time period via the desktop dropdown
+            await selectDesktopPeriod(page, period);
 
             // Wait for chart to re-render with new period data
             await page.waitForTimeout(2000);
@@ -375,11 +382,8 @@ test.describe("Dashboard chart time period aggregation (issue #228)", () => {
             .waitFor({ state: "visible", timeout: 15_000 });
 
         for (const period of ["1W", "1M", "3M", "1Y"] as const) {
-            // Select period
-            const periodBtn = page
-                .locator(".hidden.md\\:flex")
-                .getByText(period, { exact: true });
-            await periodBtn.click();
+            // Select period via the desktop dropdown
+            await selectDesktopPeriod(page, period);
             await page.waitForTimeout(2000);
 
             // Count rendered data points in the SVG path

--- a/nt-fe/features/activity/components/history-refresh-button.tsx
+++ b/nt-fe/features/activity/components/history-refresh-button.tsx
@@ -2,7 +2,7 @@
 
 import { RefreshCw } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { Button } from "@/components/button";
 import { useTreasury } from "@/hooks/use-treasury";
 import {
@@ -12,6 +12,7 @@ import {
 } from "@/hooks/use-treasury-queries";
 import type { ConfidentialHistoryRefreshStatus } from "@/lib/api";
 import { cn, formatRelativeTime } from "@/lib/utils";
+import { useSetHistoryRefreshing } from "./history-refresh-indicator";
 
 type RefreshControlState =
     | "ready"
@@ -103,6 +104,17 @@ export function HistoryRefreshButton({ className }: { className?: string }) {
     const isRefreshing = isConfidential
         ? isConfidentialRefreshing
         : publicRefresh.isRefreshing;
+
+    // Publish the in-flight state so dashboard widgets fed by the refreshed
+    // queries (chart, assets, recent activity) can show skeletons meanwhile.
+    const setHistoryRefreshing = useSetHistoryRefreshing();
+    useEffect(() => {
+        setHistoryRefreshing(isRefreshing);
+    }, [isRefreshing, setHistoryRefreshing]);
+    useEffect(() => {
+        return () => setHistoryRefreshing(false);
+    }, [setHistoryRefreshing]);
+
     const lastUpdatedAt = isConfidential
         ? refreshStatus?.lastUpdatedAt
         : publicRefresh.lastUpdatedAt;

--- a/nt-fe/features/activity/components/history-refresh-indicator.tsx
+++ b/nt-fe/features/activity/components/history-refresh-indicator.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import {
+    createContext,
+    type ReactNode,
+    useContext,
+    useMemo,
+    useState,
+} from "react";
+
+interface HistoryRefreshIndicatorValue {
+    /** True while a treasury history refresh is in flight. */
+    isRefreshing: boolean;
+    setIsRefreshing: (value: boolean) => void;
+}
+
+const HistoryRefreshIndicatorContext =
+    createContext<HistoryRefreshIndicatorValue | null>(null);
+
+/**
+ * Provides a shared "history refresh in progress" flag so that widgets fed by
+ * the refreshed queries (balance chart, assets table, recent activity) can show
+ * skeletons while the refresh button re-fetches their data.
+ */
+export function HistoryRefreshIndicatorProvider({
+    children,
+}: {
+    children: ReactNode;
+}) {
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const value = useMemo(
+        () => ({ isRefreshing, setIsRefreshing }),
+        [isRefreshing],
+    );
+
+    return (
+        <HistoryRefreshIndicatorContext.Provider value={value}>
+            {children}
+        </HistoryRefreshIndicatorContext.Provider>
+    );
+}
+
+/** Whether a treasury history refresh is currently in progress. */
+export function useIsHistoryRefreshing(): boolean {
+    return useContext(HistoryRefreshIndicatorContext)?.isRefreshing ?? false;
+}
+
+/**
+ * Setter used by the refresh button to publish its in-flight state. Returns a
+ * no-op when there is no provider so the button can be used standalone.
+ */
+export function useSetHistoryRefreshing(): (value: boolean) => void {
+    const context = useContext(HistoryRefreshIndicatorContext);
+    return context?.setIsRefreshing ?? noop;
+}
+
+function noop() {}

--- a/nt-fe/features/activity/components/recent-activity-card.tsx
+++ b/nt-fe/features/activity/components/recent-activity-card.tsx
@@ -66,6 +66,7 @@ import { NEAR_NETWORK_ID } from "@/constants/network-ids";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useWarningMessage } from "@/hooks/use-warnings";
 import { useWarnings } from "@/hooks/use-warnings";
+import { useIsHistoryRefreshing } from "./history-refresh-indicator";
 import { TransactionDetailsModal } from "./transaction-details-modal";
 
 const ITEMS_ON_DASHBOARD = 10;
@@ -226,6 +227,7 @@ export function RecentActivity() {
         new Set(),
     );
     const isMobile = useMediaQuery("(max-width: 640px)");
+    const isHistoryRefreshing = useIsHistoryRefreshing();
     const isHidden = isConfidential && isGuestTreasury;
     const { getWarning } = useWarnings();
     const activityWarning = getWarning("data.activity");
@@ -603,7 +605,7 @@ export function RecentActivity() {
                             heading={activityWarningCopy.heading}
                             body={activityWarningCopy.body}
                         />
-                    ) : isLoading ? (
+                    ) : isLoading || isHistoryRefreshing ? (
                         <RecentActivitySkeleton />
                     ) : activities.length === 0 ? (
                         <EmptyState

--- a/nt-fe/features/activity/index.ts
+++ b/nt-fe/features/activity/index.ts
@@ -1,4 +1,9 @@
 export { RecentActivity } from "./components/recent-activity-card";
+export {
+    HistoryRefreshIndicatorProvider,
+    useIsHistoryRefreshing,
+    useSetHistoryRefreshing,
+} from "./components/history-refresh-indicator";
 export { ActivityTable } from "./components/activity-table";
 export { TransactionDetailsModal } from "./components/transaction-details-modal";
 export { TransactionHashCell } from "./components/transaction-hash-cell";

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -378,8 +378,10 @@ export function ProposalSidebar({
         shouldFetchSwapStatus,
         treasuryId,
     );
-    const shouldRequireSwapSuccess =
-        hasDepositAddress && !isConfidentialRequestProposal;
+    // Any intents-routed proposal (including confidential requests) must have a
+    // SUCCESS swap status before a receipt can be generated — a pending/failed/
+    // refunded swap has no finalized transaction to receipt.
+    const shouldRequireSwapSuccess = hasDepositAddress;
     // Public treasury receipts should remain accessible for logged-out users
     // and non-members from the requests page.
     const isPublicTreasuryGuestViewer = !isConfidential && isGuestTreasury;
@@ -390,6 +392,19 @@ export function ProposalSidebar({
         isExecuted &&
         (shouldUseSwapDate ? isLoadingSwapStatus : isLoadingTransaction);
     const isHidden = isConfidential && isGuestTreasury;
+
+    // Confidential exchange (a confidential request that is not a payment).
+    const isConfidentialExchange =
+        isConfidentialRequestProposal && !isConfidentialPayment;
+    // Swap is still settling (no finalized transaction yet).
+    const isSwapProcessing = swapStatus?.status === "PROCESSING";
+    // Hide the transaction link for confidential requests while the swap is
+    // still processing — there is no finalized transaction to link to yet.
+    const hideTransactionLink =
+        isConfidentialRequestProposal && isSwapProcessing;
+    // Confidential exchanges link to NEAR Blocks; other intents-routed
+    // proposals use the NEAR Intents explorer (masked for confidential).
+    const useNearblocksLink = !hasDepositAddress || isConfidentialExchange;
     // Receipt button visibility rules:
     // - Proposal must be executed and of a receipt-eligible kind.
     // - For intents-routed proposals (with depositAddress), swap status must be SUCCESS.
@@ -527,9 +542,23 @@ export function ProposalSidebar({
                             </Link>
                         </Button>
                     )}
-                    {/* Intents-routed proposals link to the NEAR Intents explorer
-                        (masked route for confidential, standard for public). */}
-                    {isExecuted && hasDepositAddress ? (
+                    {/* Transaction link. Hidden for confidential requests while
+                        the swap is still processing. Confidential exchanges link
+                        to NEAR Blocks; other intents-routed proposals use the
+                        NEAR Intents explorer (masked for confidential). */}
+                    {hideTransactionLink ? null : useNearblocksLink ? (
+                        transaction && (
+                            <Link
+                                href={transaction.nearblocks_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex font-medium text-sm items-center justify-center gap-1.5 text-foreground"
+                            >
+                                <SquareArrowOutUpRight className="size-4" />
+                                {t("viewTransaction")}
+                            </Link>
+                        )
+                    ) : (
                         <Link
                             href={
                                 getIntentsExplorerUrl(
@@ -544,19 +573,6 @@ export function ProposalSidebar({
                             <SquareArrowOutUpRight className="size-4" />
                             {t("viewTransaction")}
                         </Link>
-                    ) : (
-                        /* For other proposals, show regular transaction link */
-                        transaction && (
-                            <Link
-                                href={transaction.nearblocks_url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="inline-flex font-medium text-sm items-center justify-center gap-1.5 text-foreground"
-                            >
-                                <SquareArrowOutUpRight className="size-4" />
-                                {t("viewTransaction")}
-                            </Link>
-                        )
                     )}
                 </div>
             )}

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "Verfügbar",
         "bucketLocked": "Gesperrt",
         "bucketEarning": "Erträge",
+        "noTokenChartTitle": "Ihre Daten werden geladen",
+        "noTokenChartDescription": "Wir laden Ihre Asset-Daten. Das kann etwas dauern.",
         "period": {
             "1W": "1W",
             "1M": "1M",

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -1809,12 +1809,11 @@
         "chartNow": "Jetzt",
         "totalBalance": "Gesamtguthaben",
         "excludedTokens": "Ausgeschlossene Token:",
-        "noPriceHistory": "Kein Preisverlauf. Wählen Sie ein Token, um dessen Guthabenänderungen zu sehen.",
         "bucketAvailable": "Verfügbar",
         "bucketLocked": "Gesperrt",
         "bucketEarning": "Erträge",
-        "noTokenChartTitle": "Ihre Daten werden geladen",
-        "noTokenChartDescription": "Wir laden Ihre Asset-Daten. Das kann etwas dauern.",
+        "noTokenChartTitle": "Derzeit keine Daten verfügbar",
+        "noTokenChartDescription": "Wir können den Verlauf dieses Tokens noch nicht laden. Schauen Sie bald wieder vorbei.",
         "period": {
             "1W": "1W",
             "1M": "1M",
@@ -1859,7 +1858,7 @@
         "usdValue": "USD-Wert",
         "tokenBalance": "Token-Guthaben",
         "emptyTitle": "Noch nichts anzuzeigen",
-        "emptyDescription": "Fügen Sie Vermögenswerte hinzu, um Ihr Portfolio zu verfolgen."
+        "emptyDescription": "Kein Kontostandsverlauf verfügbar"
     },
     "user": {
         "saveToAddressBook": "Im Adressbuch speichern",

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "Available",
         "bucketLocked": "Locked",
         "bucketEarning": "Earning",
+        "noTokenChartTitle": "Loading your data",
+        "noTokenChartDescription": "We're loading your asset data. This might take some time.",
         "period": {
             "1W": "1W",
             "1M": "1M",

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -1809,12 +1809,11 @@
         "chartNow": "Now",
         "totalBalance": "Total Balance",
         "excludedTokens": "Excluded tokens:",
-        "noPriceHistory": "No price history. Select a token to see its balance changes.",
         "bucketAvailable": "Available",
         "bucketLocked": "Locked",
         "bucketEarning": "Earning",
-        "noTokenChartTitle": "Loading your data",
-        "noTokenChartDescription": "We're loading your asset data. This might take some time.",
+        "noTokenChartTitle": "No data to show right now",
+        "noTokenChartDescription": "We can't load this token's history yet. Check back soon.",
         "period": {
             "1W": "1W",
             "1M": "1M",
@@ -1859,7 +1858,7 @@
         "usdValue": "USD Value",
         "tokenBalance": "Token Balance",
         "emptyTitle": "Nothing to show yet",
-        "emptyDescription": "Add assets to start tracking your portfolio."
+        "emptyDescription": "No balance history available"
     },
     "user": {
         "saveToAddressBook": "Save to Address book",

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "Disponible",
         "bucketLocked": "Bloqueado",
         "bucketEarning": "Rendimiento",
+        "noTokenChartTitle": "Cargando tus datos",
+        "noTokenChartDescription": "Estamos cargando los datos de tus activos. Esto puede tardar un poco.",
         "period": {
             "1W": "1S",
             "1M": "1m",

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -1809,12 +1809,11 @@
         "chartNow": "Ahora",
         "totalBalance": "Saldo total",
         "excludedTokens": "Tokens excluidos:",
-        "noPriceHistory": "Sin historial de precios. Selecciona un token para ver los cambios en su saldo.",
         "bucketAvailable": "Disponible",
         "bucketLocked": "Bloqueado",
         "bucketEarning": "Rendimiento",
-        "noTokenChartTitle": "Cargando tus datos",
-        "noTokenChartDescription": "Estamos cargando los datos de tus activos. Esto puede tardar un poco.",
+        "noTokenChartTitle": "No hay datos para mostrar ahora",
+        "noTokenChartDescription": "Aún no podemos cargar el historial de este token. Vuelve pronto.",
         "period": {
             "1W": "1S",
             "1M": "1m",
@@ -1859,7 +1858,7 @@
         "usdValue": "Valor en USD",
         "tokenBalance": "Saldo de tokens",
         "emptyTitle": "Nada que mostrar aún",
-        "emptyDescription": "Añade activos para empezar a seguir tu cartera."
+        "emptyDescription": "No hay historial de saldo disponible"
     },
     "user": {
         "saveToAddressBook": "Guardar en libreta de direcciones",

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "Disponible",
         "bucketLocked": "Verrouillé",
         "bucketEarning": "En gain",
+        "noTokenChartTitle": "Chargement de vos données",
+        "noTokenChartDescription": "Nous chargeons les données de vos actifs. Cela peut prendre un certain temps.",
         "period": {
             "1W": "1S",
             "1M": "1M",

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -1809,12 +1809,11 @@
         "chartNow": "Maintenant",
         "totalBalance": "Solde total",
         "excludedTokens": "Tokens exclus :",
-        "noPriceHistory": "Aucun historique de prix. Sélectionnez un token pour voir ses variations de solde.",
         "bucketAvailable": "Disponible",
         "bucketLocked": "Verrouillé",
         "bucketEarning": "En gain",
-        "noTokenChartTitle": "Chargement de vos données",
-        "noTokenChartDescription": "Nous chargeons les données de vos actifs. Cela peut prendre un certain temps.",
+        "noTokenChartTitle": "Aucune donnée à afficher pour le moment",
+        "noTokenChartDescription": "Nous ne pouvons pas encore charger l'historique de ce token. Revenez bientôt.",
         "period": {
             "1W": "1S",
             "1M": "1M",
@@ -1859,7 +1858,7 @@
         "usdValue": "Valeur USD",
         "tokenBalance": "Solde du token",
         "emptyTitle": "Rien à afficher pour l'instant",
-        "emptyDescription": "Ajoutez des actifs pour commencer à suivre votre portefeuille."
+        "emptyDescription": "Aucun historique de solde disponible"
     },
     "user": {
         "saveToAddressBook": "Enregistrer dans le carnet d'adresses",

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -1809,12 +1809,11 @@
         "chartNow": "עכשיו",
         "totalBalance": "יתרה כוללת",
         "excludedTokens": "טוקנים לא נכללים:",
-        "noPriceHistory": "אין היסטוריית מחירים. בחר טוקן כדי לראות את שינויי היתרה שלו.",
         "bucketAvailable": "זמין",
         "bucketLocked": "נעול",
         "bucketEarning": "מרוויח",
-        "noTokenChartTitle": "טוען את הנתונים שלך",
-        "noTokenChartDescription": "אנחנו טוענים את נתוני הנכסים שלך. זה עשוי לקחת זמן מה.",
+        "noTokenChartTitle": "אין נתונים להצגה כרגע",
+        "noTokenChartDescription": "אנחנו עדיין לא יכולים לטעון את היסטוריית הטוקן הזה. בדוק שוב בקרוב.",
         "period": {
             "1W": "שבוע",
             "1M": "חודש",
@@ -1859,7 +1858,7 @@
         "usdValue": "ערך USD",
         "tokenBalance": "יתרת טוקן",
         "emptyTitle": "אין מה להציג עדיין",
-        "emptyDescription": "הוסף נכסים כדי להתחיל לעקוב אחר התיק שלך."
+        "emptyDescription": "אין היסטוריית יתרה זמינה"
     },
     "user": {
         "saveToAddressBook": "שמור בספר הכתובות",

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "זמין",
         "bucketLocked": "נעול",
         "bucketEarning": "מרוויח",
+        "noTokenChartTitle": "טוען את הנתונים שלך",
+        "noTokenChartDescription": "אנחנו טוענים את נתוני הנכסים שלך. זה עשוי לקחת זמן מה.",
         "period": {
             "1W": "שבוע",
             "1M": "חודש",

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -1809,12 +1809,11 @@
         "chartNow": "Sekarang",
         "totalBalance": "Saldo Total",
         "excludedTokens": "Token yang dikecualikan:",
-        "noPriceHistory": "Tidak ada riwayat harga. Pilih token untuk melihat perubahan saldonya.",
         "bucketAvailable": "Tersedia",
         "bucketLocked": "Terkunci",
         "bucketEarning": "Pendapatan",
-        "noTokenChartTitle": "Memuat data Anda",
-        "noTokenChartDescription": "Kami sedang memuat data aset Anda. Ini mungkin memerlukan beberapa waktu.",
+        "noTokenChartTitle": "Belum ada data untuk ditampilkan",
+        "noTokenChartDescription": "Kami belum dapat memuat riwayat token ini. Silakan cek kembali nanti.",
         "period": {
             "1W": "1Mg",
             "1M": "1Bl",
@@ -1859,7 +1858,7 @@
         "usdValue": "Nilai USD",
         "tokenBalance": "Saldo Token",
         "emptyTitle": "Belum ada apa-apa untuk ditampilkan",
-        "emptyDescription": "Tambahkan aset untuk mulai melacak portofolio Anda."
+        "emptyDescription": "Tidak ada riwayat saldo"
     },
     "user": {
         "saveToAddressBook": "Simpan ke Buku alamat",

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "Tersedia",
         "bucketLocked": "Terkunci",
         "bucketEarning": "Pendapatan",
+        "noTokenChartTitle": "Memuat data Anda",
+        "noTokenChartDescription": "Kami sedang memuat data aset Anda. Ini mungkin memerlukan beberapa waktu.",
         "period": {
             "1W": "1Mg",
             "1M": "1Bl",

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "利用可能",
         "bucketLocked": "ロック",
         "bucketEarning": "収益中",
+        "noTokenChartTitle": "データを読み込んでいます",
+        "noTokenChartDescription": "資産データを読み込んでいます。少し時間がかかる場合があります。",
         "period": {
             "1W": "1週",
             "1M": "1ヶ月",

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -1809,12 +1809,11 @@
         "chartNow": "現在",
         "totalBalance": "総残高",
         "excludedTokens": "除外トークン:",
-        "noPriceHistory": "価格履歴がありません。トークンを選択して残高変動を確認してください。",
         "bucketAvailable": "利用可能",
         "bucketLocked": "ロック",
         "bucketEarning": "収益中",
-        "noTokenChartTitle": "データを読み込んでいます",
-        "noTokenChartDescription": "資産データを読み込んでいます。少し時間がかかる場合があります。",
+        "noTokenChartTitle": "現在表示できるデータはありません",
+        "noTokenChartDescription": "このトークンの履歴をまだ読み込めません。しばらくしてからもう一度ご確認ください。",
         "period": {
             "1W": "1週",
             "1M": "1ヶ月",
@@ -1859,7 +1858,7 @@
         "usdValue": "USD価値",
         "tokenBalance": "トークン残高",
         "emptyTitle": "まだ表示するものはありません",
-        "emptyDescription": "資産を追加してポートフォリオの追跡を開始してください。"
+        "emptyDescription": "残高履歴がありません"
     },
     "user": {
         "saveToAddressBook": "アドレス帳に保存",

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -1809,12 +1809,11 @@
         "chartNow": "현재",
         "totalBalance": "총 잔액",
         "excludedTokens": "제외된 토큰:",
-        "noPriceHistory": "가격 기록이 없습니다. 잔액 변화를 보려면 토큰을 선택하세요.",
         "bucketAvailable": "사용 가능",
         "bucketLocked": "잠김",
         "bucketEarning": "수익 중",
-        "noTokenChartTitle": "데이터를 불러오는 중",
-        "noTokenChartDescription": "자산 데이터를 불러오는 중입니다. 시간이 다소 걸릴 수 있습니다.",
+        "noTokenChartTitle": "지금 표시할 데이터가 없습니다",
+        "noTokenChartDescription": "이 토큰의 기록을 아직 불러올 수 없습니다. 잠시 후 다시 확인해 주세요.",
         "period": {
             "1W": "1주",
             "1M": "1개월",
@@ -1859,7 +1858,7 @@
         "usdValue": "USD 가치",
         "tokenBalance": "토큰 잔액",
         "emptyTitle": "아직 표시할 내용이 없습니다",
-        "emptyDescription": "포트폴리오 추적을 시작하려면 자산을 추가하세요."
+        "emptyDescription": "잔액 기록이 없습니다"
     },
     "user": {
         "saveToAddressBook": "주소록에 저장",

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "사용 가능",
         "bucketLocked": "잠김",
         "bucketEarning": "수익 중",
+        "noTokenChartTitle": "데이터를 불러오는 중",
+        "noTokenChartDescription": "자산 데이터를 불러오는 중입니다. 시간이 다소 걸릴 수 있습니다.",
         "period": {
             "1W": "1주",
             "1M": "1개월",

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "Disponível",
         "bucketLocked": "Bloqueado",
         "bucketEarning": "Rendendo",
+        "noTokenChartTitle": "Carregando seus dados",
+        "noTokenChartDescription": "Estamos carregando os dados dos seus ativos. Isso pode levar algum tempo.",
         "period": {
             "1W": "1S",
             "1M": "1M",

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -1809,12 +1809,11 @@
         "chartNow": "Agora",
         "totalBalance": "Saldo total",
         "excludedTokens": "Tokens excluídos:",
-        "noPriceHistory": "Sem histórico de preços. Selecione um token para ver as variações de saldo dele.",
         "bucketAvailable": "Disponível",
         "bucketLocked": "Bloqueado",
         "bucketEarning": "Rendendo",
-        "noTokenChartTitle": "Carregando seus dados",
-        "noTokenChartDescription": "Estamos carregando os dados dos seus ativos. Isso pode levar algum tempo.",
+        "noTokenChartTitle": "Nenhum dado para mostrar agora",
+        "noTokenChartDescription": "Ainda não conseguimos carregar o histórico deste token. Volte em breve.",
         "period": {
             "1W": "1S",
             "1M": "1M",
@@ -1859,7 +1858,7 @@
         "usdValue": "Valor em USD",
         "tokenBalance": "Saldo do token",
         "emptyTitle": "Nada para mostrar ainda",
-        "emptyDescription": "Adicione ativos para começar a acompanhar seu portfólio."
+        "emptyDescription": "Nenhum histórico de saldo disponível"
     },
     "user": {
         "saveToAddressBook": "Salvar no catálogo de endereços",

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -1809,12 +1809,11 @@
         "chartNow": "Şimdi",
         "totalBalance": "Toplam Bakiye",
         "excludedTokens": "Hariç tutulan tokenler:",
-        "noPriceHistory": "Fiyat geçmişi yok. Bakiye değişikliklerini görmek için bir token seçin.",
         "bucketAvailable": "Kullanılabilir",
         "bucketLocked": "Kilitli",
         "bucketEarning": "Kazanç",
-        "noTokenChartTitle": "Verileriniz yükleniyor",
-        "noTokenChartDescription": "Varlık verileriniz yükleniyor. Bu biraz zaman alabilir.",
+        "noTokenChartTitle": "Şu anda gösterilecek veri yok",
+        "noTokenChartDescription": "Bu token'ın geçmişini henüz yükleyemiyoruz. Kısa süre sonra tekrar kontrol edin.",
         "period": {
             "1W": "1H",
             "1M": "1A",
@@ -1859,7 +1858,7 @@
         "usdValue": "USD Değeri",
         "tokenBalance": "Token Bakiyesi",
         "emptyTitle": "Henüz gösterilecek bir şey yok",
-        "emptyDescription": "Portföyünüzü takip etmeye başlamak için varlıklar ekleyin."
+        "emptyDescription": "Bakiye geçmişi bulunmuyor"
     },
     "user": {
         "saveToAddressBook": "Adres defterine kaydet",

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "Kullanılabilir",
         "bucketLocked": "Kilitli",
         "bucketEarning": "Kazanç",
+        "noTokenChartTitle": "Verileriniz yükleniyor",
+        "noTokenChartDescription": "Varlık verileriniz yükleniyor. Bu biraz zaman alabilir.",
         "period": {
             "1W": "1H",
             "1M": "1A",

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "Доступно",
         "bucketLocked": "Заблоковано",
         "bucketEarning": "Заробіток",
+        "noTokenChartTitle": "Завантаження ваших даних",
+        "noTokenChartDescription": "Ми завантажуємо дані про ваші активи. Це може зайняти деякий час.",
         "period": {
             "1W": "1т",
             "1M": "1м",

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -1809,12 +1809,11 @@
         "chartNow": "Зараз",
         "totalBalance": "Загальний баланс",
         "excludedTokens": "Виключені токени:",
-        "noPriceHistory": "Немає історії цін. Оберіть токен, щоб побачити зміни його балансу.",
         "bucketAvailable": "Доступно",
         "bucketLocked": "Заблоковано",
         "bucketEarning": "Заробіток",
-        "noTokenChartTitle": "Завантаження ваших даних",
-        "noTokenChartDescription": "Ми завантажуємо дані про ваші активи. Це може зайняти деякий час.",
+        "noTokenChartTitle": "Зараз немає даних для показу",
+        "noTokenChartDescription": "Ми поки що не можемо завантажити історію цього токена. Завітайте пізніше.",
         "period": {
             "1W": "1т",
             "1M": "1м",
@@ -1859,7 +1858,7 @@
         "usdValue": "Значення у USD",
         "tokenBalance": "Баланс токенів",
         "emptyTitle": "Поки що нічого показувати",
-        "emptyDescription": "Додайте активи, щоб почати відстежувати портфель."
+        "emptyDescription": "Історія балансу недоступна"
     },
     "user": {
         "saveToAddressBook": "Зберегти в адресну книгу",

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -1809,12 +1809,11 @@
         "chartNow": "Bây giờ",
         "totalBalance": "Tổng số dư",
         "excludedTokens": "Token bị loại trừ:",
-        "noPriceHistory": "Không có lịch sử giá. Chọn một token để xem thay đổi số dư.",
         "bucketAvailable": "Khả dụng",
         "bucketLocked": "Đã khóa",
         "bucketEarning": "Thu nhập",
-        "noTokenChartTitle": "Đang tải dữ liệu của bạn",
-        "noTokenChartDescription": "Chúng tôi đang tải dữ liệu tài sản của bạn. Việc này có thể mất một chút thời gian.",
+        "noTokenChartTitle": "Hiện chưa có dữ liệu để hiển thị",
+        "noTokenChartDescription": "Chúng tôi chưa thể tải lịch sử của token này. Vui lòng quay lại sau.",
         "period": {
             "1W": "1T",
             "1M": "1Th",
@@ -1859,7 +1858,7 @@
         "usdValue": "Giá trị USD",
         "tokenBalance": "Số dư token",
         "emptyTitle": "Chưa có gì để hiển thị",
-        "emptyDescription": "Thêm tài sản để bắt đầu theo dõi danh mục đầu tư của bạn."
+        "emptyDescription": "Không có lịch sử số dư"
     },
     "user": {
         "saveToAddressBook": "Lưu vào sổ địa chỉ",

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "Khả dụng",
         "bucketLocked": "Đã khóa",
         "bucketEarning": "Thu nhập",
+        "noTokenChartTitle": "Đang tải dữ liệu của bạn",
+        "noTokenChartDescription": "Chúng tôi đang tải dữ liệu tài sản của bạn. Việc này có thể mất một chút thời gian.",
         "period": {
             "1W": "1T",
             "1M": "1Th",

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -1809,12 +1809,11 @@
         "chartNow": "现在",
         "totalBalance": "总余额",
         "excludedTokens": "已排除代币:",
-        "noPriceHistory": "无价格历史。请选择代币以查看其余额变化。",
         "bucketAvailable": "可用",
         "bucketLocked": "已锁定",
         "bucketEarning": "收益中",
-        "noTokenChartTitle": "正在加载您的数据",
-        "noTokenChartDescription": "我们正在加载您的资产数据，这可能需要一些时间。",
+        "noTokenChartTitle": "暂无可显示的数据",
+        "noTokenChartDescription": "我们暂时无法加载该代币的历史记录，请稍后再试。",
         "period": {
             "1W": "1周",
             "1M": "1月",
@@ -1859,7 +1858,7 @@
         "usdValue": "美元价值",
         "tokenBalance": "代币余额",
         "emptyTitle": "暂无内容",
-        "emptyDescription": "添加资产以开始跟踪您的投资组合。"
+        "emptyDescription": "暂无余额历史记录"
     },
     "user": {
         "saveToAddressBook": "保存到地址簿",

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -1813,6 +1813,8 @@
         "bucketAvailable": "可用",
         "bucketLocked": "已锁定",
         "bucketEarning": "收益中",
+        "noTokenChartTitle": "正在加载您的数据",
+        "noTokenChartDescription": "我们正在加载您的资产数据，这可能需要一些时间。",
         "period": {
             "1W": "1周",
             "1M": "1月",


### PR DESCRIPTION
### Dashboard – Balance chart 
- Replaced the token and time selectors with a Dropdown component. #982 #983
- Token and time selectors stay enabled when a token has no history for the selected period, so users can switch back to another asset/period instead of getting stuck in the empty state. #963

### Dashboard – Refresh button
- Clicking refresh now shows skeleton loaders on the chart, assets table, and recent activity while their data is being refreshed, instead of showing stale data with no feedback. #573 #981

### Request details – Transaction link
- Hide the "View transaction" link for confidential requests while the swap is still processing (no finalized transaction to link to yet). #677
- Confidential exchanges now link to NEAR Blocks instead of the masked NEAR Intents explorer, as confidential exchange depositAddress link gives 404 link.