### PR TITLE
Address review + clippy; move apalis board onto the main HTTP service behind Basic Auth

### DIFF
--- a/nt-be/docs/BACKGROUND_JOBS.md
+++ b/nt-be/docs/BACKGROUND_JOBS.md
@@ -17,9 +17,13 @@ What this replaces: 17 hand-rolled `tokio::spawn` + interval loops in
 
 ## Web UI
 
-Set `JOBS_UI_ADDR` (e.g. `127.0.0.1:3003`) to serve the board + its REST
-API (`/api/v1`). **The board has no authentication** — bind it to
-localhost / a private network, never the public interface. Unset = disabled.
+The apalis-board (UI + its REST API at `/api/v1`) is served on the main
+HTTP service — same listener/port as the rest of the API, like the
+warnings admin pages — as the router's `fallback_service`. Every board
+route is behind **HTTP Basic Auth** using the same `ADMIN_USERS`
+credentials as the warnings admin pages; with `ADMIN_USERS` unset the
+board returns `401` for all requests. Unknown public `/api/*` paths keep
+returning a plain `404` (the board only owns `/api/v1`).
 
 ## Queues
 

--- a/nt-be/src/config/plans.rs
+++ b/nt-be/src/config/plans.rs
@@ -322,6 +322,10 @@ pub fn get_volume_limit(plan_type: PlanType) -> Option<u64> {
 }
 
 #[cfg(test)]
+// Amounts are in cents; literals group as `dollars_cents` (e.g.
+// `10_000_00` = $10,000.00) for readability, which trips the
+// inconsistent-digit-grouping lint.
+#[allow(clippy::inconsistent_digit_grouping)]
 mod tests {
     use super::*;
 

--- a/nt-be/src/handlers/subscription/reset_job.rs
+++ b/nt-be/src/handlers/subscription/reset_job.rs
@@ -109,8 +109,6 @@ async fn reset_due_monthly_plan_credits_at(
     Ok(updated_count)
 }
 
-/// Run background service that resets credits at startup and then at every UTC midnight.
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/nt-be/src/jobs/handlers.rs
+++ b/nt-be/src/jobs/handlers.rs
@@ -51,7 +51,7 @@ pub async fn price_sync(_t: Tick, state: Data<Arc<AppState>>) -> Result<String, 
         state.http_client.clone(),
         state.env_vars.defillama_api_base_url.clone(),
     );
-    let summary = crate::services::run_price_sync_cycle(&state.db_pool, &provider).await;
+    let summary = crate::services::run_price_sync_cycle(&state.db_pool, &provider).await?;
     Ok(summary)
 }
 

--- a/nt-be/src/jobs/mod.rs
+++ b/nt-be/src/jobs/mod.rs
@@ -71,12 +71,12 @@ pub fn schedule_every_secs(secs: u64) -> Schedule {
             );
         }
         format!("*/{secs} * * * * *")
-    } else if secs % 86_400 == 0 {
+    } else if secs.is_multiple_of(86_400) {
         if secs > 86_400 {
             tracing::warn!(secs, "multi-day intervals rounded down to daily");
         }
         "0 0 0 * * *".to_string()
-    } else if secs % 3600 == 0 {
+    } else if secs.is_multiple_of(3600) {
         let hours = secs / 3600;
         if 24 % hours != 0 {
             tracing::warn!(
@@ -85,7 +85,7 @@ pub fn schedule_every_secs(secs: u64) -> Schedule {
             );
         }
         format!("0 0 */{hours} * * *")
-    } else if secs % 60 == 0 {
+    } else if secs.is_multiple_of(60) {
         let mins = secs / 60;
         if 60 % mins != 0 {
             tracing::warn!(
@@ -234,7 +234,13 @@ pub async fn spawn_all(state: Arc<AppState>) -> JobQueues {
         );
         // Event-driven wake: a failed creation attempt pings the Notify so
         // the sweep runs within moments instead of waiting for the poll.
-        if let Some(store) = queues.last().map(|(_, s)| s.clone()) {
+        // Look the queue up by name — relying on `last()` breaks silently
+        // if another queue is later registered below this block.
+        if let Some(store) = queues
+            .iter()
+            .find(|(name, _)| *name == "treasury-creation-sweeper")
+            .map(|(_, s)| s.clone())
+        {
             let notify = state.creation_sweep_notify.clone();
             tokio::spawn(async move {
                 loop {
@@ -346,15 +352,79 @@ pub async fn spawn_all(state: Arc<AppState>) -> JobQueues {
         "ft-lockup-refresh",
     ] {
         if let Some(store) = queues.storage(queue) {
-            push_now(store, "startup").await;
+            // Label the push with the real queue name so a failed push is
+            // attributed to the right queue in the logs.
+            push_now(store, queue).await;
         }
     }
 
     queues
 }
 
-/// apalis-board: REST API + web UI over every registered queue.
-pub fn board_router(queues: &JobQueues) -> Router {
+const BOARD_AUTH_REALM: &str = "Trezu Jobs Board";
+
+/// HTTP Basic Auth gate for the board, reusing the same admin credentials
+/// (`ADMIN_USERS`) and check as the warnings admin pages
+/// (`handlers::warnings::admin`).
+async fn board_basic_auth(
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::http::{
+        StatusCode,
+        header::{AUTHORIZATION, WWW_AUTHENTICATE},
+    };
+    use axum::response::IntoResponse;
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+
+    let unauthorized = || {
+        (
+            StatusCode::UNAUTHORIZED,
+            [(
+                WWW_AUTHENTICATE,
+                format!("Basic realm=\"{BOARD_AUTH_REALM}\""),
+            )],
+            "Unauthorized",
+        )
+            .into_response()
+    };
+
+    if state.env_vars.admin_users.is_empty() {
+        tracing::warn!("apalis board UI blocked: no ADMIN_USERS configured");
+        return unauthorized();
+    }
+
+    let credentials = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Basic "))
+        .and_then(|encoded| STANDARD.decode(encoded).ok())
+        .and_then(|decoded| String::from_utf8(decoded).ok());
+
+    let authenticated = credentials
+        .as_deref()
+        .and_then(|creds| creds.split_once(':'))
+        .and_then(|(username, password)| {
+            crate::utils::admin_auth::authenticate_admin(
+                &state.env_vars.admin_users,
+                username,
+                password,
+            )
+        })
+        .is_some();
+
+    if authenticated {
+        next.run(request).await
+    } else {
+        unauthorized()
+    }
+}
+
+/// apalis-board: REST API + web UI over every registered queue, gated by
+/// HTTP Basic Auth against the admin credentials.
+pub fn board_router(queues: &JobQueues, state: Arc<AppState>) -> Router {
     use apalis_board::axum::framework::{ApiBuilder, RegisterRoute};
     use apalis_board::axum::ui::ServeUI;
 
@@ -366,17 +436,20 @@ pub fn board_router(queues: &JobQueues) -> Router {
     Router::new()
         .nest("/api/v1", api.build())
         .fallback_service(ServeUI::new())
+        .layer(axum::middleware::from_fn_with_state(
+            state,
+            board_basic_auth,
+        ))
 }
 
 /// Serves the board on its own listener when `JOBS_UI_ADDR` is set
-/// (e.g. `127.0.0.1:3003`). Separate from the public API on purpose —
-/// the board has no auth of its own.
-pub fn spawn_board_server(queues: &JobQueues) {
+/// (e.g. `127.0.0.1:3003`), gated by Basic Auth against `ADMIN_USERS`.
+pub fn spawn_board_server(queues: &JobQueues, state: Arc<AppState>) {
     let Ok(addr) = std::env::var("JOBS_UI_ADDR") else {
         tracing::info!("apalis board UI disabled (JOBS_UI_ADDR not set)");
         return;
     };
-    let router = board_router(queues);
+    let router = board_router(queues, state);
     tokio::spawn(async move {
         let listener = match tokio::net::TcpListener::bind(&addr).await {
             Ok(listener) => listener,

--- a/nt-be/src/jobs/mod.rs
+++ b/nt-be/src/jobs/mod.rs
@@ -6,8 +6,9 @@
 //! (`apalis.jobs`). That gives us, uniformly and for free:
 //!
 //! - per-job queues with task history, results, and errors in Postgres
-//! - the apalis-board web UI (`/` on `JOBS_UI_ADDR`) to inspect queues,
-//!   workers, and task outcomes, and to trigger a job manually (PUT a task)
+//! - the apalis-board web UI (mounted on the main HTTP service behind
+//!   Basic Auth) to inspect queues, workers, and task outcomes, and to
+//!   trigger a job manually (PUT a task)
 //! - tracing spans per task and `concurrency(1)` so cycles never overlap
 //!
 //! Schedules keep their old intervals/env-var overrides. Jobs that used to
@@ -422,8 +423,37 @@ async fn board_basic_auth(
     }
 }
 
+/// Keeps unknown `/api/*` requests a plain 404 instead of letting the
+/// board's UI fallback answer them. The board's own API lives at
+/// `/api/v1`; every other `/api/*` path belongs to the public API and must
+/// not be shadowed (or challenged for board auth) by mounting the board.
+/// True for `/api/*` paths that belong to the public API, not the board.
+/// The board owns exactly `/api/v1` and everything under `/api/v1/`.
+fn is_foreign_api_path(path: &str) -> bool {
+    path.starts_with("/api/") && path != "/api/v1" && !path.starts_with("/api/v1/")
+}
+
+async fn board_api_guard(
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    if is_foreign_api_path(request.uri().path()) {
+        return axum::http::StatusCode::NOT_FOUND.into_response();
+    }
+    next.run(request).await
+}
+
 /// apalis-board: REST API + web UI over every registered queue, gated by
 /// HTTP Basic Auth against the admin credentials.
+///
+/// Mounted as the main HTTP service's `fallback_service` (see `main.rs`)
+/// rather than on a separate port, so it lives behind the same listener as
+/// the rest of the API — like the warnings admin pages. The board frontend
+/// (apalis-board) is a root-mounted SPA (absolute asset paths +
+/// `origin`-based API base), so it must be served from `/`; the API guard
+/// above preserves the public API's 404 behaviour, and Basic Auth gates
+/// every board route (API, UI, and static assets).
 pub fn board_router(queues: &JobQueues, state: Arc<AppState>) -> Router {
     use apalis_board::axum::framework::{ApiBuilder, RegisterRoute};
     use apalis_board::axum::ui::ServeUI;
@@ -436,31 +466,35 @@ pub fn board_router(queues: &JobQueues, state: Arc<AppState>) -> Router {
     Router::new()
         .nest("/api/v1", api.build())
         .fallback_service(ServeUI::new())
+        // Auth gates every board route. Applied inside the guard so that an
+        // unknown public `/api/*` path 404s without an auth challenge.
         .layer(axum::middleware::from_fn_with_state(
             state,
             board_basic_auth,
         ))
+        .layer(axum::middleware::from_fn(board_api_guard))
 }
 
-/// Serves the board on its own listener when `JOBS_UI_ADDR` is set
-/// (e.g. `127.0.0.1:3003`), gated by Basic Auth against `ADMIN_USERS`.
-pub fn spawn_board_server(queues: &JobQueues, state: Arc<AppState>) {
-    let Ok(addr) = std::env::var("JOBS_UI_ADDR") else {
-        tracing::info!("apalis board UI disabled (JOBS_UI_ADDR not set)");
-        return;
-    };
-    let router = board_router(queues, state);
-    tokio::spawn(async move {
-        let listener = match tokio::net::TcpListener::bind(&addr).await {
-            Ok(listener) => listener,
-            Err(e) => {
-                tracing::error!(addr, error = %e, "failed to bind jobs UI listener");
-                return;
-            }
-        };
-        tracing::info!(addr = %addr, "apalis board UI running");
-        if let Err(e) = axum::serve(listener, router).await {
-            tracing::error!(error = %e, "jobs UI server exited");
-        }
-    });
+#[cfg(test)]
+mod tests {
+    use super::is_foreign_api_path;
+
+    #[test]
+    fn board_owns_only_api_v1() {
+        // Board's own API — must reach the board (not a public 404).
+        assert!(!is_foreign_api_path("/api/v1"));
+        assert!(!is_foreign_api_path("/api/v1/queues"));
+        assert!(!is_foreign_api_path("/api/v1/queues/price-sync/tasks"));
+
+        // Public API namespace — must stay a 404, never shadowed by the
+        // board or challenged for board auth.
+        assert!(is_foreign_api_path("/api/warnings"));
+        assert!(is_foreign_api_path("/api/user/create"));
+        assert!(is_foreign_api_path("/api/v10/x")); // not a v1 subpath
+
+        // Non-API paths belong to the board UI (served after auth).
+        assert!(!is_foreign_api_path("/"));
+        assert!(!is_foreign_api_path("/queues"));
+        assert!(!is_foreign_api_path("/apalis-board-web-abc.js"));
+    }
 }

--- a/nt-be/src/main.rs
+++ b/nt-be/src/main.rs
@@ -31,9 +31,9 @@ async fn async_main() {
 
     // All background jobs run as apalis workers: cron schedules piped into
     // per-job Postgres queues (see src/jobs/). The returned registry backs
-    // the apalis-board web UI served on JOBS_UI_ADDR.
+    // the apalis-board web UI, mounted below on the main HTTP service.
     let job_queues = nt_be::jobs::spawn_all(state.clone()).await;
-    nt_be::jobs::spawn_board_server(&job_queues, state.clone());
+    let board = nt_be::jobs::board_router(&job_queues, state.clone());
 
     // Configure CORS - must specify exact origins, methods, and headers when using credentials
     let origins: Vec<HeaderValue> = state
@@ -78,6 +78,10 @@ async fn async_main() {
                 .with_state(state)
                 .layer(open_cors),
         )
+        // apalis-board (jobs UI + API) on the same listener, behind Basic
+        // Auth. It answers only paths no other route matched; its API guard
+        // keeps unknown public `/api/*` a plain 404.
+        .fallback_service(board)
         .layer(SentryHttpLayer::new().enable_transaction())
         .layer(NewSentryLayer::<Request<Body>>::new_from_top());
 

--- a/nt-be/src/main.rs
+++ b/nt-be/src/main.rs
@@ -33,7 +33,7 @@ async fn async_main() {
     // per-job Postgres queues (see src/jobs/). The returned registry backs
     // the apalis-board web UI served on JOBS_UI_ADDR.
     let job_queues = nt_be::jobs::spawn_all(state.clone()).await;
-    nt_be::jobs::spawn_board_server(&job_queues);
+    nt_be::jobs::spawn_board_server(&job_queues, state.clone());
 
     // Configure CORS - must specify exact origins, methods, and headers when using credentials
     let origins: Vec<HeaderValue> = state

--- a/nt-be/src/services/dao_sync/dao_list_sync.rs
+++ b/nt-be/src/services/dao_sync/dao_list_sync.rs
@@ -9,11 +9,6 @@ use sqlx::PgPool;
 /// Sputnik DAO factory contract
 const SPUTNIK_DAO_FACTORY: &str = "sputnik-dao.near";
 
-/// Run the background DAO list sync service
-///
-/// This function runs in a loop, fetching the complete DAO list from sputnik-dao.near
-/// every 5 minutes and upserting into the local database.
-
 /// Sync DAO list from sputnik-dao.near factory
 ///
 /// Fetches all DAOs and upserts them into the database.

--- a/nt-be/src/services/dao_sync/dao_policy_sync.rs
+++ b/nt-be/src/services/dao_sync/dao_policy_sync.rs
@@ -15,11 +15,6 @@ const MAX_DAOS_PER_CYCLE: i64 = 50;
 /// Period after which non-dirty DAOs should be re-synced (24 hours = daily)
 const STALE_THRESHOLD_HOURS: i64 = 24;
 
-/// Run the background DAO policy sync service
-///
-/// This function runs in a loop, processing dirty DAOs immediately
-/// and stale DAOs periodically.
-
 /// Process dirty DAOs (high priority)
 pub async fn process_dirty_daos(
     pool: &PgPool,

--- a/nt-be/src/services/price_sync.rs
+++ b/nt-be/src/services/price_sync.rs
@@ -19,35 +19,38 @@ use bigdecimal::BigDecimal;
 /// Maximum number of provider asset IDs to request in one current-price call.
 const CURRENT_PRICE_BATCH_SIZE: usize = 50;
 
+/// Error type for a price sync cycle — boxed so it propagates to the
+/// apalis handler and marks the task failed on apalis-board.
+pub type PriceSyncError = Box<dyn std::error::Error + Send + Sync>;
+
 /// Run one price sync cycle: backfill missing end-of-day prices, then
-/// refresh current prices. Returns a short human-readable summary.
+/// refresh current prices. Returns a short human-readable summary on
+/// success, or an error so a failed run is reported as failed (not
+/// silently `Ok`) on the board.
 pub async fn run_price_sync_cycle<P: PriceProvider + Send + Sync>(
     pool: &PgPool,
     provider: &P,
-) -> String {
-    let provider_asset_ids = match get_all_provider_asset_ids(pool, provider).await {
-        Ok(assets) => assets,
-        Err(e) => {
+) -> Result<String, PriceSyncError> {
+    let provider_asset_ids = get_all_provider_asset_ids(pool, provider)
+        .await
+        .map_err(|e| {
             tracing::error!("Failed to load price sync asset list: {}", e);
-            return format!("failed to load asset list: {e}");
-        }
-    };
+            format!("failed to load asset list: {e}")
+        })?;
 
     if provider_asset_ids.is_empty() {
-        return "no assets to sync".to_string();
+        return Ok("no assets to sync".to_string());
     }
 
     // Find assets that need syncing (don't have yesterday's price).
     // We sync end-of-day prices, so we only sync completed days.
     let yesterday = (Utc::now() - chrono::Duration::days(1)).date_naive();
-    let assets_needing_sync =
-        match get_assets_needing_sync(pool, &provider_asset_ids, yesterday).await {
-            Ok(assets) => assets,
-            Err(e) => {
-                tracing::error!("Failed to check which assets need sync: {}", e);
-                return format!("failed to check sync targets: {e}");
-            }
-        };
+    let assets_needing_sync = get_assets_needing_sync(pool, &provider_asset_ids, yesterday)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to check which assets need sync: {}", e);
+            format!("failed to check sync targets: {e}")
+        })?;
 
     let mut synced_assets = 0usize;
     if !assets_needing_sync.is_empty() {
@@ -63,6 +66,8 @@ pub async fn run_price_sync_cycle<P: PriceProvider + Send + Sync>(
                     tracing::info!("Synced {} prices for {}", count, asset_id);
                 }
                 Err(e) => {
+                    // Per-asset failures are expected (delistings, provider
+                    // gaps) and don't fail the whole cycle.
                     tracing::warn!("Failed to sync prices for {}: {}", asset_id, e);
                 }
             }
@@ -72,18 +77,19 @@ pub async fn run_price_sync_cycle<P: PriceProvider + Send + Sync>(
         }
     }
 
-    let current = match sync_current_prices(pool, provider, &provider_asset_ids).await {
-        Ok(count) => count,
-        Err(e) => {
-            tracing::warn!("Failed to refresh current prices: {}", e);
-            0
-        }
-    };
+    // The current-price refresh is the cycle's main job; a failure here is
+    // a real failure of the run and must surface as such.
+    let current = sync_current_prices(pool, provider, &provider_asset_ids)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to refresh current prices: {}", e);
+            format!("failed to refresh current prices: {e}")
+        })?;
 
-    format!(
+    Ok(format!(
         "backfilled {synced_assets} assets, refreshed {current}/{} current prices",
         provider_asset_ids.len()
-    )
+    ))
 }
 
 /// Get list of provider asset IDs that need syncing (latest price is before target date)

--- a/nt-be/src/services/public_dashboard.rs
+++ b/nt-be/src/services/public_dashboard.rs
@@ -671,7 +671,6 @@ pub async fn ensure_this_week_public_dashboard_snapshot(
         .map(Some)
 }
 
-#[tracing::instrument(level = "info", skip_all, fields(job = "public_dashboard_refresh"))]
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Targets the `apalis-background-jobs` PR branch (#1042).

## Review comments (Copilot)
- **jobs/mod.rs** — the treasury-creation-sweeper Notify wake looked up its queue via `queues.last()` (breaks if a queue is later registered below it) → explicit lookup by name.
- **jobs/mod.rs** — the startup push loop labelled every push `"startup"` for error logging → pass the real queue name.
- **price_sync.rs** — `run_price_sync_cycle` returned a summary `String` and never an error, so failed runs showed as *successful* on apalis-board. Now returns `Result<String, _>` and propagates the blocking failures (asset-list load, sync-target check, current-price refresh); the handler `?`-propagates so the task is marked failed. Per-asset failures stay best-effort.

## apalis board on the main HTTP service, behind Basic Auth
- Removed the separate `JOBS_UI_ADDR` listener. The board (UI + `/api/v1`) is now the main router's `fallback_service` — same port as the rest of the API, like the warnings admin pages.
- Every board route is gated by HTTP Basic Auth reusing the warnings admin credentials/check (`utils::admin_auth::authenticate_admin` against `ADMIN_USERS`); unset `ADMIN_USERS` ⇒ 401.
- apalis-board is a root-mounted SPA (absolute asset paths + an `origin`-based API base baked into the wasm), so it can't be nested under a sub-path without rebuilding the frontend — it's served from `/`. A guard keeps unknown public `/api/*` paths a plain 404 (the board owns only `/api/v1`), so the public API's not-found behaviour is unchanged. Unit-tested the guard predicate.

## clippy
- `% == 0` → `is_multiple_of`; removed orphaned loop-era doc comments and a stray `#[tracing::instrument]` left by the loop→cron refactor; scoped `allow(inconsistent_digit_grouping)` on the plans cents-literal tests. `cargo clippy -- -D warnings` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)