### PR TITLE
fix: remove dropdown trigger borders and link near.com confidential payment

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -790,7 +790,7 @@ export default function BalanceWithGraph({
                 <Select value={selectedToken} onValueChange={setSelectedToken}>
                     <SelectTrigger
                         size="sm"
-                        className="w-[140px]"
+                        className="w-[140px] border-0 shadow-none focus:ring-0"
                         disabled={
                             isLoadingTokens || (!isConfidential && isLoading)
                         }
@@ -849,7 +849,10 @@ export default function BalanceWithGraph({
                             setSelectedPeriod(value as TimePeriod)
                         }
                     >
-                        <SelectTrigger size="sm" className="w-[92px]">
+                        <SelectTrigger
+                            size="sm"
+                            className="w-[92px] border-0 shadow-none focus:ring-0"
+                        >
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent>

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx
@@ -895,7 +895,7 @@ export default function ExportActivityPage() {
                                                     >
                                                         <Button
                                                             variant="outline"
-                                                            className="w-full justify-between bg-muted! dark:bg-muted! border-0! shadow-none! hover:bg-general-tertiary! dark:hover:bg-general-tertiary! font-normal"
+                                                            className="w-full justify-between bg-muted! dark:bg-muted! hover:bg-general-tertiary! dark:hover:bg-general-tertiary! font-normal"
                                                         >
                                                             <div className="flex items-center gap-2 min-w-0 flex-1">
                                                                 <Coins className="w-4 h-4 shrink-0" />
@@ -986,7 +986,7 @@ export default function ExportActivityPage() {
                                                     >
                                                         <Button
                                                             variant="outline"
-                                                            className="w-full justify-between bg-muted! dark:bg-muted! border-0! shadow-none! hover:bg-general-tertiary! dark:hover:bg-general-tertiary! font-normal"
+                                                            className="w-full justify-between bg-muted! dark:bg-muted! hover:bg-general-tertiary! dark:hover:bg-general-tertiary! font-normal"
                                                         >
                                                             <span className="truncate flex-1 text-left">
                                                                 {getSelectedTypesLabel()}

--- a/nt-fe/components/ui/dropdown-menu.tsx
+++ b/nt-fe/components/ui/dropdown-menu.tsx
@@ -8,7 +8,21 @@ import { cn } from "@/lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+/** Strips border/shadow/ring from triggers — especially when a Button is passed via `asChild`. */
+const dropdownMenuTriggerClassName =
+    "outline-none border-0! shadow-none! focus-visible:border-0! focus-visible:ring-0! focus-visible:ring-offset-0! data-[state=open]:border-0! data-[state=open]:ring-0!";
+
+const DropdownMenuTrigger = React.forwardRef<
+    React.ElementRef<typeof DropdownMenuPrimitive.Trigger>,
+    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+    <DropdownMenuPrimitive.Trigger
+        ref={ref}
+        className={cn(dropdownMenuTriggerClassName, className)}
+        {...props}
+    />
+));
+DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName;
 
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 
@@ -186,6 +200,7 @@ DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
     DropdownMenu,
+    dropdownMenuTriggerClassName,
     DropdownMenuTrigger,
     DropdownMenuContent,
     DropdownMenuItem,

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -21,6 +21,7 @@ import { StepIcon } from "@/components/step-icon";
 import { Skeleton } from "@/components/ui/skeleton";
 import { User } from "@/components/user";
 import { SlotWarning } from "@/components/warning-message";
+import type { PaymentRequestData } from "@/features/proposals/types/index";
 import { useProposalInsufficientBalance } from "@/features/proposals/hooks/use-proposal-insufficient-balance";
 import { extractProposalData } from "@/features/proposals/utils/proposal-extractors";
 import {
@@ -43,6 +44,7 @@ import {
 } from "@/hooks/use-proposals";
 import { useTreasury } from "@/hooks/use-treasury";
 import { useProposalApproveBlock, useSlotBlock } from "@/hooks/use-warnings";
+import { isNearComPaymentRoute } from "@/lib/intents-network";
 import Big from "@/lib/big";
 import { getApproversAndThreshold } from "@/lib/config-utils";
 import type { Proposal } from "@/lib/proposals-api";
@@ -330,6 +332,7 @@ export function ProposalSidebar({
     // Confidential metadata is backend-enriched and nested under mapped.data.
     let depositAddress: string | undefined;
     let isConfidentialPayment = false;
+    let confidentialPaymentData: PaymentRequestData | undefined;
     let confidentialProposalCreatedAt: Date | undefined;
     let confidentialExecutedAt: Date | undefined;
     if (isExchangeProposal || isPaymentProposal || isConfidentialRequest) {
@@ -345,6 +348,10 @@ export function ProposalSidebar({
                 );
                 const mapped = confidentialData?.mapped;
                 isConfidentialPayment = mapped?.type === "payment";
+                if (isConfidentialPayment) {
+                    confidentialPaymentData =
+                        mapped?.data as PaymentRequestData;
+                }
                 depositAddress = mapped?.data?.depositAddress;
             } else {
                 depositAddress = (data as any)?.depositAddress;
@@ -402,9 +409,16 @@ export function ProposalSidebar({
     // still processing — there is no finalized transaction to link to yet.
     const hideTransactionLink =
         isConfidentialRequestProposal && isSwapProcessing;
-    // Confidential exchanges link to NEAR Blocks; other intents-routed
-    // proposals use the NEAR Intents explorer (masked for confidential).
-    const useNearblocksLink = !hasDepositAddress || isConfidentialExchange;
+    // Confidential exchanges and near.com confidential payments link to NEAR
+    // Blocks; other intents-routed proposals use the NEAR Intents explorer
+    // (masked for confidential).
+    const isConfidentialNearComPayment =
+        isConfidentialPayment &&
+        isNearComPaymentRoute(confidentialPaymentData ?? {});
+    const useNearblocksLink =
+        !hasDepositAddress ||
+        isConfidentialExchange ||
+        isConfidentialNearComPayment;
     // Receipt button visibility rules:
     // - Proposal must be executed and of a receipt-eligible kind.
     // - For intents-routed proposals (with depositAddress), swap status must be SUCCESS.
@@ -543,9 +557,10 @@ export function ProposalSidebar({
                         </Button>
                     )}
                     {/* Transaction link. Hidden for confidential requests while
-                        the swap is still processing. Confidential exchanges link
-                        to NEAR Blocks; other intents-routed proposals use the
-                        NEAR Intents explorer (masked for confidential). */}
+                        the swap is still processing. Confidential exchanges and
+                        near.com confidential payments link to NEAR Blocks; other
+                        intents-routed proposals use the NEAR Intents explorer
+                        (masked for confidential). */}
                     {hideTransactionLink ? null : useNearblocksLink ? (
                         transaction && (
                             <Link


### PR DESCRIPTION
#573 #677
- Add borderless default styles to `DropdownMenuTrigger` so button-based triggers no longer show an extra border, shadow, or focus ring (including open state)
- Route confidential near.com payments to the NEAR Blocks transaction link instead of the Intents explorer
