### PR TITLE
fix: confidential policy handoff

### DIFF
--- a/nt-be/src/handlers/treasury/check_handle_unused.rs
+++ b/nt-be/src/handlers/treasury/check_handle_unused.rs
@@ -39,8 +39,15 @@ pub async fn check_handle_unused(
         .await
     {
         Ok(_) => Ok(Json(CheckHandleUnusedResponse { unused: false })),
-        Err(e) => Ok(Json(CheckHandleUnusedResponse {
-            unused: dbg!(e.to_string()).contains("UnknownAccount"),
-        })),
+        Err(e) => {
+            if e.to_string().contains("UnknownAccount") {
+                Ok(Json(CheckHandleUnusedResponse { unused: true }))
+            } else {
+                Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to check treasury handle: {e}"),
+                ))
+            }
+        }
     }
 }

--- a/nt-be/src/handlers/treasury/confidential_setup.rs
+++ b/nt-be/src/handlers/treasury/confidential_setup.rs
@@ -584,7 +584,10 @@ async fn submit_and_approve_proposal(
     let proposal_id: u64 = add_outcome.json().map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to parse proposal id from add_proposal return value: {}", e),
+            format!(
+                "Failed to parse proposal id from add_proposal return value: {}",
+                e
+            ),
         )
     })?;
 

--- a/nt-be/src/handlers/treasury/confidential_setup.rs
+++ b/nt-be/src/handlers/treasury/confidential_setup.rs
@@ -30,12 +30,30 @@ use crate::observability::sanitize_sensitive_json_value;
 /// The treasury must have been created with `state.signer_id` as the sole
 /// Admin+Approver member (threshold=1) so this function can submit and
 /// immediately approve proposals.
+///
+/// When `resume` is false (fresh creation this run), skip on-chain/DB
+/// idempotency probes and execute each step directly. When true (sweeper /
+/// in-session recovery), check whether each step already completed before
+/// submitting transactions.
 pub async fn setup_confidential_treasury(
     state: &Arc<AppState>,
     treasury_id: &AccountId,
     target_policy: Value,
     progress: Option<&mpsc::Sender<ProgressEvent>>,
+    resume: bool,
 ) -> Result<(), (StatusCode, String)> {
+    if resume {
+        tracing::info!(
+            "Confidential setup: resuming {} — checking each step before acting",
+            treasury_id
+        );
+    } else {
+        tracing::info!(
+            "Confidential setup: fresh DAO {} — running steps without pre-checks",
+            treasury_id
+        );
+    }
+
     // ── Add Public Key to intents.near (idempotent) ─────────────────────
     if let Some(tx) = progress {
         send_progress(tx, "adding_public_key", "in_progress").await;
@@ -44,7 +62,13 @@ pub async fn setup_confidential_treasury(
     let treasury_id_public_key =
         fetch_mpc_public_key(state, treasury_id.as_str(), treasury_id.as_str()).await?;
 
-    if intents_has_public_key(state, treasury_id, &treasury_id_public_key).await? {
+    let public_key_already_registered = if resume {
+        intents_has_public_key(state, treasury_id, &treasury_id_public_key).await?
+    } else {
+        false
+    };
+
+    if public_key_already_registered {
         tracing::info!(
             "Confidential setup: public key already registered for {}, skipping add",
             treasury_id
@@ -86,7 +110,13 @@ pub async fn setup_confidential_treasury(
         send_progress(tx, "authenticating", "in_progress").await;
     }
 
-    if has_valid_confidential_token(&state.db_pool, treasury_id).await {
+    let already_authenticated = if resume {
+        has_valid_confidential_token(&state.db_pool, treasury_id).await
+    } else {
+        false
+    };
+
+    if already_authenticated {
         tracing::info!(
             "Confidential setup: {} already authenticated with 1Click, skipping auth",
             treasury_id
@@ -163,18 +193,22 @@ pub async fn setup_confidential_treasury(
     }
 
     let expected_members = policy_group_members(&target_policy);
-    if user_policy_applied(state, treasury_id, &expected_members).await? {
+    let policy_already_applied = if resume {
+        tracing::info!(
+            treasury = %treasury_id,
+            expected_members = ?expected_members,
+            "Confidential setup: checking whether user policy is already on-chain"
+        );
+        user_policy_applied(state, treasury_id, &expected_members).await?
+    } else {
+        false
+    };
+
+    if policy_already_applied {
         tracing::info!(
             "Confidential setup: policy already reflects user config for {}, skipping ChangePolicy",
             treasury_id
         );
-    } else if let Some(pending_id) = find_in_progress_change_policy(state, treasury_id).await? {
-        tracing::info!(
-            "Confidential setup: approving pending ChangePolicy proposal #{} for {}",
-            pending_id,
-            treasury_id
-        );
-        approve_existing_proposal(state, treasury_id, pending_id).await?;
     } else {
         let change_policy_proposal = json!({
             "proposal": {
@@ -197,11 +231,26 @@ pub async fn setup_confidential_treasury(
         );
     }
 
-    if !user_policy_applied(state, treasury_id, &expected_members).await? {
+    // On resume, verify on-chain policy after a possibly skipped ChangePolicy.
+    // On a fresh run we just submitted ChangePolicy (or it failed with Err above).
+    if resume && !user_policy_applied(state, treasury_id, &expected_members).await? {
+        tracing::error!(
+            treasury = %treasury_id,
+            expected_members = ?expected_members,
+            "ChangePolicy finished but user members are still not on-chain policy"
+        );
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             "ChangePolicy did not apply user members to on-chain policy".to_string(),
         ));
+    }
+
+    if resume {
+        tracing::info!(
+            treasury = %treasury_id,
+            expected_members = ?expected_members,
+            "Confidential setup: user policy verified on-chain"
+        );
     }
 
     if let Some(tx) = progress {
@@ -551,6 +600,28 @@ async fn has_valid_confidential_token(pool: &sqlx::PgPool, treasury_id: &Account
     .unwrap_or(false)
 }
 
+/// Short label for logs, e.g. `ChangePolicy` or `FunctionCall:intents.near::add_public_key`.
+fn proposal_kind_summary(kind: &Value) -> String {
+    if kind.get("ChangePolicy").is_some() {
+        return "ChangePolicy".to_string();
+    }
+    if let Some(fc) = kind.get("FunctionCall") {
+        let receiver = fc
+            .get("receiver_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?");
+        let method = fc
+            .get("actions")
+            .and_then(|a| a.as_array())
+            .and_then(|a| a.first())
+            .and_then(|a| a.get("method_name"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("?");
+        return format!("FunctionCall:{receiver}::{method}");
+    }
+    "unknown".to_string()
+}
+
 /// Submit a proposal and immediately approve it.
 ///
 /// Returns `(proposal_id, vote_result_debug)`. The debug string can be
@@ -563,6 +634,12 @@ async fn submit_and_approve_proposal(
     treasury_id: &AccountId,
     proposal: Value,
 ) -> Result<(u64, String), (StatusCode, String)> {
+    let kind_summary = proposal
+        .get("proposal")
+        .and_then(|p| p.get("kind"))
+        .map(proposal_kind_summary)
+        .unwrap_or_else(|| "unknown".to_string());
+
     // Submit proposal — the contract returns the new proposal id as the
     // function return value (JSON-encoded u64). Use that directly instead of
     // `get_last_proposal_id - 1`, which races when RPC reads lag behind writes.
@@ -575,13 +652,35 @@ async fn submit_and_approve_proposal(
         .send_to(&state.network)
         .await
         .map_err(|e| {
+            tracing::error!(
+                treasury = %treasury_id,
+                kind = %kind_summary,
+                "add_proposal failed: {e}"
+            );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to submit proposal: {}", e),
             )
         })?;
 
-    let proposal_id: u64 = add_outcome.json().map_err(|e| {
+    let add_success = add_outcome.into_result().map_err(|e| {
+        tracing::error!(
+            treasury = %treasury_id,
+            kind = %kind_summary,
+            "add_proposal on-chain execution failed: {e}"
+        );
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Proposal submission failed: {}", e),
+        )
+    })?;
+
+    let proposal_id: u64 = add_success.json().map_err(|e| {
+        tracing::error!(
+            treasury = %treasury_id,
+            kind = %kind_summary,
+            "failed to decode add_proposal return value as u64: {e}"
+        );
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!(
@@ -606,13 +705,20 @@ async fn approve_existing_proposal(
         .fetch_from(&state.network)
         .await
         .map_err(|e| {
+            tracing::error!(
+                treasury = %treasury_id,
+                proposal_id,
+                "get_proposal failed before vote: {e}"
+            );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to fetch proposal #{}: {}", proposal_id, e),
             )
         })?
         .data;
+
     let kind = proposal_data["kind"].clone();
+    let kind_summary = proposal_kind_summary(&kind);
 
     let vote_outcome = near_api::Contract(treasury_id.clone())
         .call_function(
@@ -631,6 +737,12 @@ async fn approve_existing_proposal(
         .send_to(&state.network)
         .await
         .map_err(|e| {
+            tracing::error!(
+                treasury = %treasury_id,
+                proposal_id,
+                kind = %kind_summary,
+                "act_proposal failed: {e}"
+            );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to vote on proposal #{}: {}", proposal_id, e),
@@ -639,6 +751,12 @@ async fn approve_existing_proposal(
 
     let vote_debug = format!("{:?}", vote_outcome);
     vote_outcome.into_result().map_err(|e| {
+        tracing::error!(
+            treasury = %treasury_id,
+            proposal_id,
+            kind = %kind_summary,
+            "act_proposal on-chain execution failed: {e}"
+        );
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Proposal #{} vote failed: {}", proposal_id, e),
@@ -648,7 +766,8 @@ async fn approve_existing_proposal(
     Ok((proposal_id, vote_debug))
 }
 
-/// Whether the on-chain policy already includes all intended user members.
+/// Whether the on-chain policy reflects the user's config: all intended members
+/// are present and the backend sponsor no longer controls the DAO.
 async fn user_policy_applied(
     state: &Arc<AppState>,
     treasury_id: &AccountId,
@@ -661,53 +780,8 @@ async fn user_policy_applied(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
     let members = policy_group_members(&policy);
-    Ok(expected_members.is_subset(&members))
-}
-
-/// Find an existing `ChangePolicy` proposal that was submitted but never voted on.
-async fn find_in_progress_change_policy(
-    state: &Arc<AppState>,
-    treasury_id: &AccountId,
-) -> Result<Option<u64>, (StatusCode, String)> {
-    let last_id: u64 = Contract(treasury_id.clone())
-        .call_function("get_last_proposal_id", ())
-        .read_only::<u64>()
-        .fetch_from(&state.network)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get last proposal ID: {}", e),
-            )
-        })?
-        .data;
-
-    for proposal_id in 0..last_id {
-        let proposal_data: Value = Contract(treasury_id.clone())
-            .call_function("get_proposal", json!({"id": proposal_id}))
-            .read_only::<Value>()
-            .fetch_from(&state.network)
-            .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to fetch proposal #{}: {}", proposal_id, e),
-                )
-            })?
-            .data;
-
-        let status = proposal_data.get("status").and_then(|v| v.as_str());
-        let is_change_policy = proposal_data
-            .get("kind")
-            .and_then(|k| k.get("ChangePolicy"))
-            .is_some();
-
-        if status == Some("InProgress") && is_change_policy {
-            return Ok(Some(proposal_id));
-        }
-    }
-
-    Ok(None)
+    let sponsor_removed = !members.contains(state.signer_id.as_str());
+    Ok(sponsor_removed && expected_members.is_subset(&members))
 }
 
 /// Authenticate the DAO with the 1Click API using an MPC signature.

--- a/nt-be/src/handlers/treasury/confidential_setup.rs
+++ b/nt-be/src/handlers/treasury/confidential_setup.rs
@@ -7,6 +7,7 @@
 //! 2. Authenticate with 1Click API using the MPC signature
 //! 3. Submit ChangePolicy proposal (user's real config) → vote
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use base64::Engine;
@@ -15,7 +16,7 @@ use reqwest::StatusCode;
 use serde_json::{Value, json};
 use tokio::sync::mpsc;
 
-use super::create::{ProgressEvent, send_progress};
+use super::create::{ProgressEvent, fetch_dao_policy, policy_group_members, send_progress};
 use crate::AppState;
 use crate::constants::INTENTS_CONTRACT_ID;
 use crate::handlers::intents::confidential::prepare_auth::{
@@ -161,25 +162,47 @@ pub async fn setup_confidential_treasury(
         send_progress(tx, "setting_policy", "in_progress").await;
     }
 
-    let change_policy_proposal = json!({
-        "proposal": {
-            "description": "Set treasury policy to user configuration",
-            "kind": {
-                "ChangePolicy": {
-                    "policy": target_policy,
+    let expected_members = policy_group_members(&target_policy);
+    if user_policy_applied(state, treasury_id, &expected_members).await? {
+        tracing::info!(
+            "Confidential setup: policy already reflects user config for {}, skipping ChangePolicy",
+            treasury_id
+        );
+    } else if let Some(pending_id) = find_in_progress_change_policy(state, treasury_id).await? {
+        tracing::info!(
+            "Confidential setup: approving pending ChangePolicy proposal #{} for {}",
+            pending_id,
+            treasury_id
+        );
+        approve_existing_proposal(state, treasury_id, pending_id).await?;
+    } else {
+        let change_policy_proposal = json!({
+            "proposal": {
+                "description": "Set treasury policy to user configuration",
+                "kind": {
+                    "ChangePolicy": {
+                        "policy": target_policy,
+                    }
                 }
             }
-        }
-    });
+        });
 
-    let (policy_proposal_id, _) =
-        submit_and_approve_proposal(state, treasury_id, change_policy_proposal).await?;
+        let (policy_proposal_id, _) =
+            submit_and_approve_proposal(state, treasury_id, change_policy_proposal).await?;
 
-    tracing::info!(
-        "Confidential setup: policy proposal #{} approved for {}",
-        policy_proposal_id,
-        treasury_id
-    );
+        tracing::info!(
+            "Confidential setup: policy proposal #{} approved for {}",
+            policy_proposal_id,
+            treasury_id
+        );
+    }
+
+    if !user_policy_applied(state, treasury_id, &expected_members).await? {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "ChangePolicy did not apply user members to on-chain policy".to_string(),
+        ));
+    }
 
     if let Some(tx) = progress {
         send_progress(tx, "setting_policy", "completed").await;
@@ -540,8 +563,10 @@ async fn submit_and_approve_proposal(
     treasury_id: &AccountId,
     proposal: Value,
 ) -> Result<(u64, String), (StatusCode, String)> {
-    // Submit proposal
-    near_api::Contract(treasury_id.clone())
+    // Submit proposal — the contract returns the new proposal id as the
+    // function return value (JSON-encoded u64). Use that directly instead of
+    // `get_last_proposal_id - 1`, which races when RPC reads lag behind writes.
+    let add_outcome = near_api::Contract(treasury_id.clone())
         .call_function("add_proposal", proposal)
         .transaction()
         .gas(NearGas::from_tgas(100))
@@ -554,31 +579,24 @@ async fn submit_and_approve_proposal(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Failed to submit proposal: {}", e),
             )
-        })?
-        .into_result()
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Proposal submission failed: {}", e),
-            )
         })?;
 
-    // Get the proposal ID (last_id - 1)
-    let last_id: u64 = Contract(treasury_id.clone())
-        .call_function("get_last_proposal_id", ())
-        .read_only::<u64>()
-        .fetch_from(&state.network)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get last proposal ID: {}", e),
-            )
-        })?
-        .data;
-    let proposal_id = last_id - 1;
+    let proposal_id: u64 = add_outcome.json().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to parse proposal id from add_proposal return value: {}", e),
+        )
+    })?;
 
-    // Fetch the proposal to get its kind (required by act_proposal)
+    approve_existing_proposal(state, treasury_id, proposal_id).await
+}
+
+/// Vote to approve an existing proposal and wait for execution to finish.
+async fn approve_existing_proposal(
+    state: &Arc<AppState>,
+    treasury_id: &AccountId,
+    proposal_id: u64,
+) -> Result<(u64, String), (StatusCode, String)> {
     let proposal_data: Value = Contract(treasury_id.clone())
         .call_function("get_proposal", json!({"id": proposal_id}))
         .read_only::<Value>()
@@ -591,10 +609,9 @@ async fn submit_and_approve_proposal(
             )
         })?
         .data;
-    let kind = &proposal_data["kind"];
+    let kind = proposal_data["kind"].clone();
 
-    // Vote to approve
-    let result = near_api::Contract(treasury_id.clone())
+    let vote_outcome = near_api::Contract(treasury_id.clone())
         .call_function(
             "act_proposal",
             json!({
@@ -607,6 +624,7 @@ async fn submit_and_approve_proposal(
         .max_gas()
         .deposit(NearToken::from_yoctonear(0))
         .with_signer(state.signer_id.clone(), state.signer.clone())
+        .wait_until(near_openapi_types::TxExecutionStatus::ExecutedOptimistic)
         .send_to(&state.network)
         .await
         .map_err(|e| {
@@ -616,7 +634,77 @@ async fn submit_and_approve_proposal(
             )
         })?;
 
-    Ok((proposal_id, format!("{:?}", result)))
+    let vote_debug = format!("{:?}", vote_outcome);
+    vote_outcome.into_result().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Proposal #{} vote failed: {}", proposal_id, e),
+        )
+    })?;
+
+    Ok((proposal_id, vote_debug))
+}
+
+/// Whether the on-chain policy already includes all intended user members.
+async fn user_policy_applied(
+    state: &Arc<AppState>,
+    treasury_id: &AccountId,
+    expected_members: &HashSet<String>,
+) -> Result<bool, (StatusCode, String)> {
+    if expected_members.is_empty() {
+        return Ok(false);
+    }
+    let policy = fetch_dao_policy(state, treasury_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    let members = policy_group_members(&policy);
+    Ok(expected_members.is_subset(&members))
+}
+
+/// Find an existing `ChangePolicy` proposal that was submitted but never voted on.
+async fn find_in_progress_change_policy(
+    state: &Arc<AppState>,
+    treasury_id: &AccountId,
+) -> Result<Option<u64>, (StatusCode, String)> {
+    let last_id: u64 = Contract(treasury_id.clone())
+        .call_function("get_last_proposal_id", ())
+        .read_only::<u64>()
+        .fetch_from(&state.network)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to get last proposal ID: {}", e),
+            )
+        })?
+        .data;
+
+    for proposal_id in 0..last_id {
+        let proposal_data: Value = Contract(treasury_id.clone())
+            .call_function("get_proposal", json!({"id": proposal_id}))
+            .read_only::<Value>()
+            .fetch_from(&state.network)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to fetch proposal #{}: {}", proposal_id, e),
+                )
+            })?
+            .data;
+
+        let status = proposal_data.get("status").and_then(|v| v.as_str());
+        let is_change_policy = proposal_data
+            .get("kind")
+            .and_then(|k| k.get("ChangePolicy"))
+            .is_some();
+
+        if status == Some("InProgress") && is_change_policy {
+            return Ok(Some(proposal_id));
+        }
+    }
+
+    Ok(None)
 }
 
 /// Authenticate the DAO with the 1Click API using an MPC signature.

--- a/nt-be/src/handlers/treasury/confidential_setup.rs
+++ b/nt-be/src/handlers/treasury/confidential_setup.rs
@@ -648,7 +648,6 @@ async fn submit_and_approve_proposal(
         .transaction()
         .gas(NearGas::from_tgas(100))
         .with_signer(state.signer_id.clone(), state.signer.clone())
-        .wait_until(near_openapi_types::TxExecutionStatus::ExecutedOptimistic)
         .send_to(&state.network)
         .await
         .map_err(|e| {
@@ -733,7 +732,6 @@ async fn approve_existing_proposal(
         .max_gas()
         .deposit(NearToken::from_yoctonear(0))
         .with_signer(state.signer_id.clone(), state.signer.clone())
-        .wait_until(near_openapi_types::TxExecutionStatus::ExecutedOptimistic)
         .send_to(&state.network)
         .await
         .map_err(|e| {

--- a/nt-be/src/handlers/treasury/create.rs
+++ b/nt-be/src/handlers/treasury/create.rs
@@ -694,14 +694,10 @@ async fn run_creation_inner(
     // Confirm the user's members are on-chain before we declare success. Without
     // this, a failed ChangePolicy vote could still reach `Ok(())` and delete the
     // incomplete row, leaving a sponsor-only DAO with no sweeper recovery.
-    let final_state = classify_treasury_account(
-        state,
-        &treasury,
-        state.signer_id.as_str(),
-        &payload_members,
-    )
-    .await
-    .map_err(error_event)?;
+    let final_state =
+        classify_treasury_account(state, &treasury, state.signer_id.as_str(), &payload_members)
+            .await
+            .map_err(error_event)?;
 
     if final_state != ExistingDaoState::AlreadyOwnedByUser {
         return Err(error_event(format!(

--- a/nt-be/src/handlers/treasury/create.rs
+++ b/nt-be/src/handlers/treasury/create.rs
@@ -388,6 +388,25 @@ pub(crate) fn policy_group_members(policy: &serde_json::Value) -> HashSet<String
     members
 }
 
+/// Classify an existing DAO from its on-chain policy members.
+///
+/// The backend sponsor must not appear in the final user policy. While the
+/// sponsor is still a member, the DAO is treated as an incomplete confidential
+/// setup we own and can resume.
+fn classify_from_policy_members(
+    members: &HashSet<String>,
+    signer_id: &str,
+    expected_members: &HashSet<String>,
+) -> ExistingDaoState {
+    if members.contains(signer_id) {
+        return ExistingDaoState::OursIncomplete;
+    }
+    if !expected_members.is_empty() && expected_members.is_subset(members) {
+        return ExistingDaoState::AlreadyOwnedByUser;
+    }
+    ExistingDaoState::Taken
+}
+
 /// Determine whether the treasury account already exists and, if so, whether
 /// it's a resumable half-created DAO we own, an already-finished one, or a
 /// name taken by someone else.
@@ -405,19 +424,13 @@ async fn classify_treasury_account(
         Err(e) if e.to_string().contains("UnknownAccount") => Ok(ExistingDaoState::Absent),
         Err(e) => Err(format!("Failed to check treasury account: {e}")),
         Ok(_) => {
-            // Account exists — inspect its DAO policy to decide ownership.
             let policy = fetch_dao_policy(state, treasury).await?;
             let members = policy_group_members(&policy);
-            if members.contains(signer_id) {
-                // Backend signer still controls the DAO → sponsor-only policy,
-                // confidential setup never finished. Resume it.
-                Ok(ExistingDaoState::OursIncomplete)
-            } else if !expected_members.is_empty() && expected_members.is_subset(&members) {
-                // Ownership already handed to the user's members.
-                Ok(ExistingDaoState::AlreadyOwnedByUser)
-            } else {
-                Ok(ExistingDaoState::Taken)
-            }
+            Ok(classify_from_policy_members(
+                &members,
+                signer_id,
+                expected_members,
+            ))
         }
     }
 }
@@ -666,10 +679,18 @@ async fn run_creation_inner(
 
     // ── Confidential setup (idempotent per-step) ───────────────────────
     // Skip entirely if ownership already transferred to the user (finished).
+    // Fresh creates skip per-step pre-checks; resumes probe on-chain state first.
     if is_confidential && existing != ExistingDaoState::AlreadyOwnedByUser {
-        confidential_setup::setup_confidential_treasury(state, &treasury, user_policy, Some(tx))
-            .await
-            .map_err(|(_, msg)| error_event(msg))?;
+        let resume = !did_create;
+        confidential_setup::setup_confidential_treasury(
+            state,
+            &treasury,
+            user_policy,
+            Some(tx),
+            resume,
+        )
+        .await
+        .map_err(|(_, msg)| error_event(msg))?;
     }
 
     let should_mark = should_mark_testing(
@@ -788,6 +809,23 @@ mod tests {
             MAX_CREATION_ATTEMPTS,
             "connection timed out"
         ));
+    }
+
+    #[test]
+    fn classify_from_policy_members_requires_sponsor_removed() {
+        let sponsor = "sponsor.near";
+        let user = "alice.near";
+        let sponsor_only = HashSet::from([sponsor.to_string()]);
+        let user_members = HashSet::from([user.to_string()]);
+
+        assert_eq!(
+            classify_from_policy_members(&sponsor_only, sponsor, &user_members),
+            ExistingDaoState::OursIncomplete
+        );
+        assert_eq!(
+            classify_from_policy_members(&user_members, sponsor, &user_members),
+            ExistingDaoState::AlreadyOwnedByUser
+        );
     }
 
     #[test]

--- a/nt-be/src/handlers/treasury/create.rs
+++ b/nt-be/src/handlers/treasury/create.rs
@@ -354,7 +354,7 @@ enum ExistingDaoState {
 }
 
 /// Fetch a DAO's current sputnik policy.
-async fn fetch_dao_policy(
+pub(crate) async fn fetch_dao_policy(
     state: &AppState,
     treasury: &AccountId,
 ) -> Result<serde_json::Value, String> {
@@ -368,7 +368,7 @@ async fn fetch_dao_policy(
 }
 
 /// Collect all member account IDs across every `Group` role in a policy.
-fn policy_group_members(policy: &serde_json::Value) -> HashSet<String> {
+pub(crate) fn policy_group_members(policy: &serde_json::Value) -> HashSet<String> {
     let mut members = HashSet::new();
     if let Some(roles) = policy.get("roles").and_then(|r| r.as_array()) {
         for role in roles {
@@ -690,6 +690,24 @@ async fn run_creation_inner(
                 should_mark
             }
         };
+
+    // Confirm the user's members are on-chain before we declare success. Without
+    // this, a failed ChangePolicy vote could still reach `Ok(())` and delete the
+    // incomplete row, leaving a sponsor-only DAO with no sweeper recovery.
+    let final_state = classify_treasury_account(
+        state,
+        &treasury,
+        state.signer_id.as_str(),
+        &payload_members,
+    )
+    .await
+    .map_err(error_event)?;
+
+    if final_state != ExistingDaoState::AlreadyOwnedByUser {
+        return Err(error_event(format!(
+            "Treasury creation incomplete ({final_state:?}): user members are not yet on-chain"
+        )));
+    }
 
     // ── Finalize ───────────────────────────────────────────────────────
     send_progress(tx, "finalizing", "in_progress").await;

--- a/nt-fe/features/onboarding/components/create-treasury-entry.tsx
+++ b/nt-fe/features/onboarding/components/create-treasury-entry.tsx
@@ -354,7 +354,11 @@ export function TreasuryOnboardingPage({
         setIsCheckingHandle(true);
         try {
             const result = await checkHandleUnused(fullAccountId);
-            if (!result?.unused) {
+            if (result === null) {
+                toast.error(t("creationFailed"));
+                return false;
+            }
+            if (!result.unused) {
                 form.setError("accountName", {
                     message: tValidation("accountTaken"),
                 });


### PR DESCRIPTION
#1000 
- Fix a bug where `act_proposal` votes could fail on chain but still be treated as success, leaving DAOs with sponsor-only membership.
- Use the `add_proposal` return value for proposal IDs instead of `get_last_proposal_id - 1`.
- Only finish creation (and delete the incomplete row) after user members are confirmed on-chain.