### PR TITLE
chore: update confidential recipient network options and copy

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -187,10 +187,12 @@ export function RecipientNetworkSelect({
         return [];
     }, [bridgeAssetMatch, isConfidential, t, token]);
 
-    const availableOptions = useMemo(
-        () => [nearComOption, ...tokenNetworkOptions],
-        [nearComOption, tokenNetworkOptions],
-    );
+    const availableOptions = useMemo(() => {
+        const options = isConfidential
+            ? [...tokenNetworkOptions, nearComOption]
+            : tokenNetworkOptions;
+        return [...options].sort((a, b) => a.name.localeCompare(b.name));
+    }, [isConfidential, nearComOption, tokenNetworkOptions]);
 
     const selectedOption = useMemo(() => {
         if (!value) return null;

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -1703,8 +1703,8 @@
         "incompatible": "Inkompatibel",
         "comingSoon": "Demnächst verfügbar",
         "forMembersOnly": "Nur für Mitglieder",
-        "nearComDescription": "Vertrauliches Netzwerk für near.com und Trezu",
-        "nearDescription": "Netzwerk für öffentliche Auszahlungen"
+        "nearComDescription": "Netzwerk für vertrauliches Trezu",
+        "nearDescription": "Netzwerk für öffentliche Auszahlungen und near.com-Wallet"
     },
     "addressBookTable": {
         "emptyTitle": "Noch keine Empfänger",

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -1703,8 +1703,8 @@
         "incompatible": "Incompatible",
         "comingSoon": "Coming Soon",
         "forMembersOnly": "For Members Only",
-        "nearComDescription": "Confidential network of near.com and trezu",
-        "nearDescription": "Network for public withdrawal"
+        "nearComDescription": "Network for confidential trezu",
+        "nearDescription": "Network for public withdrawal and near.com wallet"
     },
     "addressBookTable": {
         "emptyTitle": "No recipients yet",

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -1703,8 +1703,8 @@
         "incompatible": "Incompatible",
         "comingSoon": "Próximamente",
         "forMembersOnly": "Solo para miembros",
-        "nearComDescription": "Red confidencial para near.com y trezu",
-        "nearDescription": "Red para retiro público"
+        "nearComDescription": "Red para trezu confidencial",
+        "nearDescription": "Red para retiro público y billetera near.com"
     },
     "addressBookTable": {
         "emptyTitle": "Aún no hay destinatarios",

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -1703,8 +1703,8 @@
         "incompatible": "Incompatible",
         "comingSoon": "Bientôt disponible",
         "forMembersOnly": "Réservé aux membres",
-        "nearComDescription": "Réseau confidentiel pour near.com et trezu",
-        "nearDescription": "Réseau pour retrait public"
+        "nearComDescription": "Réseau pour trezu confidentiel",
+        "nearDescription": "Réseau pour retrait public et portefeuille near.com"
     },
     "addressBookTable": {
         "emptyTitle": "Aucun destinataire pour l'instant",

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -1703,8 +1703,8 @@
         "incompatible": "לא תואם",
         "comingSoon": "בקרוב",
         "forMembersOnly": "לחברים בלבד",
-        "nearComDescription": "רשת סודית עבור near.com ו-Trezu",
-        "nearDescription": "רשת למשיכה ציבורית"
+        "nearComDescription": "רשת עבור trezu חסוי",
+        "nearDescription": "רשת למשיכה ציבורית וארנק near.com"
     },
     "addressBookTable": {
         "emptyTitle": "אין נמענים עדיין",

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -1703,8 +1703,8 @@
         "incompatible": "Tidak Kompatibel",
         "comingSoon": "Segera Hadir",
         "forMembersOnly": "Hanya untuk anggota",
-        "nearComDescription": "Jaringan rahasia untuk near.com dan trezu",
-        "nearDescription": "Jaringan untuk penarikan publik"
+        "nearComDescription": "Jaringan untuk trezu rahasia",
+        "nearDescription": "Jaringan untuk penarikan publik dan dompet near.com"
     },
     "addressBookTable": {
         "emptyTitle": "Belum ada penerima",

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -1703,8 +1703,8 @@
         "incompatible": "非互換",
         "comingSoon": "近日公開",
         "forMembersOnly": "メンバー限定",
-        "nearComDescription": "near.comとtrezuの機密ネットワーク",
-        "nearDescription": "公開出金用ネットワーク"
+        "nearComDescription": "機密trezu用ネットワーク",
+        "nearDescription": "公開出金およびnear.comウォレット用ネットワーク"
     },
     "addressBookTable": {
         "emptyTitle": "受取人はまだいません",

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -1703,8 +1703,8 @@
         "incompatible": "호환되지 않음",
         "comingSoon": "곧 제공",
         "forMembersOnly": "회원 전용",
-        "nearComDescription": "near.com 및 trezu용 기밀 네트워크",
-        "nearDescription": "공개 출금을 위한 네트워크"
+        "nearComDescription": "기밀 trezu용 네트워크",
+        "nearDescription": "공개 출금 및 near.com 지갑용 네트워크"
     },
     "addressBookTable": {
         "emptyTitle": "아직 수신자가 없습니다",

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -1703,8 +1703,8 @@
         "incompatible": "Incompatível",
         "comingSoon": "Em breve",
         "forMembersOnly": "Apenas para membros",
-        "nearComDescription": "Rede confidencial da near.com e trezu",
-        "nearDescription": "Rede para saque público"
+        "nearComDescription": "Rede para trezu confidencial",
+        "nearDescription": "Rede para saque público e carteira near.com"
     },
     "addressBookTable": {
         "emptyTitle": "Nenhum destinatário ainda",

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -1703,8 +1703,8 @@
         "incompatible": "Uyumsuz",
         "comingSoon": "Yakında",
         "forMembersOnly": "Yalnızca Üyelere Özel",
-        "nearComDescription": "near.com ve trezu için gizli ağ",
-        "nearDescription": "Herkese açık para çekme ağı"
+        "nearComDescription": "Gizli trezu için ağ",
+        "nearDescription": "Açık çekim ve near.com cüzdanı için ağ"
     },
     "addressBookTable": {
         "emptyTitle": "Henüz alıcı yok",

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -1703,8 +1703,8 @@
         "incompatible": "Несумісні",
         "comingSoon": "Скоро",
         "forMembersOnly": "Лише для учасників",
-        "nearComDescription": "Конфіденційна мережа near.com і trezu",
-        "nearDescription": "Мережа для публічного виведення"
+        "nearComDescription": "Мережа для конфіденційного trezu",
+        "nearDescription": "Мережа для публічного виведення та гаманця near.com"
     },
     "addressBookTable": {
         "emptyTitle": "Ще немає одержувачів",

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -1703,8 +1703,8 @@
         "incompatible": "Không tương thích",
         "comingSoon": "Sắp ra mắt",
         "forMembersOnly": "Chỉ dành cho thành viên",
-        "nearComDescription": "Mạng bảo mật của near.com và trezu",
-        "nearDescription": "Mạng dành cho rút tiền công khai"
+        "nearComDescription": "Mạng cho trezu bí mật",
+        "nearDescription": "Mạng cho rút tiền công khai và ví near.com"
     },
     "addressBookTable": {
         "emptyTitle": "Chưa có người nhận nào",

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -1703,8 +1703,8 @@
         "incompatible": "不兼容",
         "comingSoon": "即将推出",
         "forMembersOnly": "仅限成员",
-        "nearComDescription": "near.com 与 trezu 的机密网络",
-        "nearDescription": "用于公开提现的网络"
+        "nearComDescription": "机密 trezu 网络",
+        "nearDescription": "公开提现和 near.com 钱包网络"
     },
     "addressBookTable": {
         "emptyTitle": "暂无收款人",


### PR DESCRIPTION
#1055 
- Remove `near.com` from the recipient network picker on **public** treasuries
- Update `near.com` and `NEAR` description
- Simplify network ordering: add `near.com` to the list and sort alphabetically
