### PR TITLE
jobs board: show task logs in the dashboard (task spans at INFO) + regression test

### DIFF
--- a/nt-be/src/jobs/mod.rs
+++ b/nt-be/src/jobs/mod.rs
@@ -23,7 +23,9 @@ use std::sync::Arc;
 
 use apalis::layers::WorkerBuilderExt;
 use apalis::layers::sentry::SentryLayer;
-use apalis::layers::tracing::{DefaultOnFailure, TraceLayer};
+use apalis::layers::tracing::{
+    DefaultMakeSpan, DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer,
+};
 use apalis::prelude::*;
 use apalis_core::backend::TaskSink;
 use apalis_core::backend::pipe::PipeExt;
@@ -270,14 +272,23 @@ macro_rules! register_cron_worker {
                 // the task's queue / id / attempt as Sentry context, plus a
                 // per-task performance transaction. No-op when Sentry is off.
                 .layer(SentryLayer::new())
-                // Trace failures at WARN, not the default ERROR: a single
+                // The `task` span and its start/done events are created at
+                // INFO (apalis defaults them to DEBUG). Two reasons: the
+                // apalis-board dashboard only streams logs carrying a `task`
+                // span (its `/events` SSE filters `span.is_some()`), and a
+                // DEBUG span is disabled under the default `info` filter — so
+                // at INFO the span is live, task activity shows on the board,
+                // and every cycle's logs inherit the task_id/attempt context.
+                // Failures stay at WARN (not the default ERROR): a single
                 // failed cycle is retried by the next cron tick and is a
                 // warning, and this keeps the tracing→Sentry bridge
                 // (ERROR→event) from emitting a *second* event for the same
-                // failure the SentryLayer already captured. Persistent failures
-                // still surface via Sentry + the board.
+                // failure the SentryLayer already captured.
                 .layer(
                     TraceLayer::new()
+                        .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO))
+                        .on_request(DefaultOnRequest::new().level(tracing::Level::INFO))
+                        .on_response(DefaultOnResponse::new().level(tracing::Level::INFO))
                         .on_failure(DefaultOnFailure::new().level(tracing::Level::WARN)),
                 )
                 .concurrency(1)

--- a/nt-be/src/observability.rs
+++ b/nt-be/src/observability.rs
@@ -283,6 +283,46 @@ fn truncate_sanitized_text(mut text: String) -> String {
 mod tests {
     use super::*;
 
+    /// The apalis-board layer must forward events emitted inside an apalis
+    /// `task` span to the broadcaster — that's what the dashboard's `/events`
+    /// SSE endpoint streams. It filters to `span.is_some()`, so only
+    /// task-span logs reach the pane; this pins that the wiring produces them.
+    #[tokio::test]
+    async fn board_layer_streams_task_span_logs() {
+        use futures::StreamExt;
+
+        let broadcaster = TracingBroadcaster::create();
+        let mut client = broadcaster.lock().unwrap().new_client();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new("info"))
+            .with(TracingSubscriber::new(&broadcaster).layer());
+
+        tracing::subscriber::with_default(subscriber, || {
+            // Mirrors the span apalis' TraceLayer opens per task.
+            let span = tracing::info_span!("task", task_id = "t-1", attempt = 0_i64);
+            span.in_scope(|| tracing::info!("inside a task"));
+            // A log outside any task span (general app log).
+            tracing::info!("outside any span");
+        });
+
+        let mut with_span = 0;
+        let mut without_span = 0;
+        while let Ok(Some(Ok(entry))) =
+            tokio::time::timeout(std::time::Duration::from_millis(500), client.next()).await
+        {
+            if entry.span.is_some() {
+                with_span += 1;
+            } else {
+                without_span += 1;
+            }
+        }
+        // The task-span log is captured (the SSE endpoint keeps it); the
+        // spanless one is captured too but would be dropped by the endpoint's
+        // `span.is_some()` filter — the board only shows task logs by design.
+        assert_eq!(with_span, 1, "task-span log must reach the broadcaster");
+        assert_eq!(without_span, 1);
+    }
+
     #[test]
     fn sentry_dsn_from_env_value_requires_non_empty_value() {
         assert_eq!(sentry_dsn_from_env_value(None), None);


### PR DESCRIPTION
Makes the apalis-board dashboard actually show task logs, plus a regression test. Follow-up to #1087 (which wired the broadcaster).

## The fix
Ran the backend and hit `/api/v1/events` — it was still empty. Root cause: the endpoint only streams entries with a task span (`.filter(|s| e.span.is_some())`), and apalis' `TraceLayer` creates that `task` span — and its `task.start`/`task.done` events — at **DEBUG** by default. Under the default `info` filter a DEBUG span is disabled, so `span.enter()` is a no-op, every log carries `span: None`, and the endpoint drops them all.

Build the task span + its start/done events at **INFO** (failures stay WARN). Verified against a running backend:
```
data: {"span":{"attempt":3,"task_id":"01KXC0XT...","name":"task"},"level":"INFO",
       "target":"apalis::layers::tracing::on_request","fields":{"message":"task.start"}}
```
`/api/v1/events` now streams `task.start` / `task.done` / `task.failed` per cycle.

Trade-off: task lifecycle now logs at INFO on the console too (one start + one done per task run) — deliberate operational visibility for a jobs backend.

## Also
Regression test (`board_layer_streams_task_span_logs`) pinning that the tracing layer forwards task-span logs to the broadcaster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
