### PR TITLE
Fix deposit, login Offline badge, assets layout, and warnings admin

### DIFF
--- a/nt-be/src/handlers/status/monitor.rs
+++ b/nt-be/src/handlers/status/monitor.rs
@@ -386,7 +386,7 @@ async fn process_service(state: &Arc<AppState>, service: &str) {
     };
 
     let check_name = check.name.as_str();
-    let unhealthy = oh_dear::is_unhealthy_status(&check.status);
+    let unhealthy = oh_dear::is_unhealthy_for_monitor(service, &check.status);
 
     if unhealthy {
         let status = incident_status(&check.status);

--- a/nt-be/src/handlers/status/oh_dear.rs
+++ b/nt-be/src/handlers/status/oh_dear.rs
@@ -304,11 +304,17 @@ pub async fn run_service_check(state: &AppState, service: &str) -> Option<OhDear
     })
 }
 
-pub fn is_unhealthy_status(status: &OhDearStatus) -> bool {
-    matches!(
-        status,
-        OhDearStatus::Warning | OhDearStatus::Failed | OhDearStatus::Crashed
-    )
+/// Whether the status-monitor should treat a check result as an incident.
+///
+/// Soft `warning` is only actionable for `near-intents` (maintenance). Other
+/// services' warnings (e.g. near-protocol summary, near-rpc syncing/stale) are
+/// treated as healthy so they do not open incidents or page Telegram.
+pub fn is_unhealthy_for_monitor(service: &str, status: &OhDearStatus) -> bool {
+    match status {
+        OhDearStatus::Failed | OhDearStatus::Crashed => true,
+        OhDearStatus::Warning => service == "near-intents",
+        OhDearStatus::Ok | OhDearStatus::Skipped => false,
+    }
 }
 
 pub async fn get_status(
@@ -1712,6 +1718,41 @@ mod tests {
 
         assert_check(&json, "neardata.api", "failed");
         assert_eq!(json["checkResults"][0]["meta"]["http_status"], 503);
+    }
+
+    #[test]
+    fn monitor_treats_non_intents_warnings_as_healthy() {
+        assert!(!is_unhealthy_for_monitor(
+            "near-protocol",
+            &OhDearStatus::Warning
+        ));
+        assert!(!is_unhealthy_for_monitor(
+            "near-rpc",
+            &OhDearStatus::Warning
+        ));
+        assert!(!is_unhealthy_for_monitor(
+            "exchange",
+            &OhDearStatus::Warning
+        ));
+        assert!(!is_unhealthy_for_monitor("backend", &OhDearStatus::Ok));
+        assert!(!is_unhealthy_for_monitor("backend", &OhDearStatus::Skipped));
+    }
+
+    #[test]
+    fn monitor_treats_near_intents_warning_and_hard_failures_as_unhealthy() {
+        assert!(is_unhealthy_for_monitor(
+            "near-intents",
+            &OhDearStatus::Warning
+        ));
+        assert!(is_unhealthy_for_monitor(
+            "near-protocol",
+            &OhDearStatus::Failed
+        ));
+        assert!(is_unhealthy_for_monitor("near-rpc", &OhDearStatus::Crashed));
+        assert!(is_unhealthy_for_monitor(
+            "near-intents",
+            &OhDearStatus::Failed
+        ));
     }
 
     #[test]

--- a/nt-be/src/handlers/warnings/admin.html
+++ b/nt-be/src/handlers/warnings/admin.html
@@ -1361,14 +1361,19 @@
       });
       if (!res.ok && res.status !== 204) {
         let msg;
+        let existingId = null;
         try {
           const json = await res.json();
           msg = json.error || JSON.stringify(json);
+          if (json.existingId != null) existingId = Number(json.existingId);
         } catch {
           msg = await res.text().catch(() => '') || `Request failed (${res.status})`;
         }
         showFormError(msg);
-        throw new Error(msg);
+        const err = new Error(msg);
+        err.status = res.status;
+        err.existingId = existingId;
+        throw err;
       }
       if (res.status === 204) return null;
       return res.json();
@@ -1480,7 +1485,7 @@
         || w.internalNote;
 
       return `
-          <article class="card ${w.response || 'notice'}">
+          <article class="card ${w.response || 'notice'}" data-warning-id="${w.id}"${isGroup && w.groupId ? ` data-group-id="${escapeHtml(w.groupId)}"` : ''}>
             <div class="card-header">
               <h3>${title}</h3>
               <div class="actions">
@@ -2373,7 +2378,9 @@
             useCustomMessage: Boolean(body.useCustomMessage),
             groupId: groupId || '',
           };
-          if (s === 'login') {
+          if (wantLogin && s === 'login') {
+            // Auto-paired companion from "Also pause login" — use catalog defaults.
+            // Standalone situation #11 edits must keep the admin's custom copy.
             payload = {
               ...payload,
               situation: 'wallet_login_unavailable',
@@ -2392,7 +2399,27 @@
             targetId = editId;
           }
           if (!targetId) {
-            targetId = findExistingWarning(s, payload.token, payload.network)?.id;
+            const existing = findExistingWarning(s, payload.token, payload.network);
+            if (existing) {
+              if (editId) {
+                // Group edit: update the existing companion row for this slot.
+                targetId = existing.id;
+              } else {
+                // New warning — never silently overwrite an existing slot.
+                setSaving(false);
+                if (confirm(
+                  `A warning already exists for ${slotLabel(s)} (#${existing.id}). Open it for editing instead?`
+                )) {
+                  hideWarningForm(true);
+                  await editWarning(existing.id);
+                } else {
+                  showFormError(
+                    `A warning already exists for this slot (#${existing.id}). Edit or delete it first.`
+                  );
+                }
+                return;
+              }
+            }
           }
           if (targetId) {
             await api(`/internal/api/warnings/${targetId}`, { method: 'PUT', body: JSON.stringify(payload) });
@@ -2412,7 +2439,13 @@
         hideWarningForm(true);
         await loadWarnings();
       } catch (e) {
-        // error already shown by api()
+        if (e.existingId && confirm(
+          `A warning already exists (#${e.existingId}). Open it for editing instead?`
+        )) {
+          hideWarningForm(true);
+          await editWarning(e.existingId);
+        }
+        // otherwise error already shown by api()
       } finally {
         setSaving(false);
       }
@@ -2425,7 +2458,37 @@
       return 'grp-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
     }
 
+    let deleteInFlight = false;
+
+    function setWarningActionsDisabled(ids, groupId, disabled, deletingLabel) {
+      const cards = [];
+      if (groupId) {
+        document.querySelectorAll(`.card[data-group-id="${CSS.escape(groupId)}"]`)
+          .forEach(el => cards.push(el));
+      }
+      for (const id of ids) {
+        const el = document.querySelector(`.card[data-warning-id="${id}"]`);
+        if (el && !cards.includes(el)) cards.push(el);
+      }
+      for (const card of cards) {
+        card.querySelectorAll('[data-action="edit-warning"], [data-action="delete-warning"]')
+          .forEach(btn => {
+            btn.disabled = disabled;
+            if (btn.dataset.action === 'delete-warning') {
+              if (disabled && deletingLabel) {
+                if (!btn.dataset.savedLabel) btn.dataset.savedLabel = btn.innerHTML;
+                btn.innerHTML = deletingLabel;
+              } else if (!disabled && btn.dataset.savedLabel) {
+                btn.innerHTML = btn.dataset.savedLabel;
+                delete btn.dataset.savedLabel;
+              }
+            }
+          });
+      }
+    }
+
     async function deleteWarning(id) {
+      if (deleteInFlight) return;
       const target = warningsCache.find(x => x.id === id);
       const groupMembers = target?.groupId
         ? warningsCache.filter(x => x.groupId === target.groupId)
@@ -2434,6 +2497,8 @@
       const idsToDelete = groupMembers.length > 1
         ? groupMembers.map(m => m.id)
         : [id];
+      deleteInFlight = true;
+      setWarningActionsDisabled(idsToDelete, target?.groupId, true, 'Deleting…');
       try {
         for (const wid of idsToDelete) {
           await api(`/internal/api/warnings/${wid}`, { method: 'DELETE' });
@@ -2441,6 +2506,9 @@
         await loadWarnings();
       } catch (e) {
         showPageError(e.message);
+        setWarningActionsDisabled(idsToDelete, target?.groupId, false);
+      } finally {
+        deleteInFlight = false;
       }
     }
 
@@ -2822,8 +2890,12 @@
       switch (action) {
         case 'hide-form':      hideWarningForm(); break;
         case 'save-warning':   saveWarning(id, btn); break;
-        case 'edit-warning':   editWarning(id); break;
-        case 'delete-warning': deleteWarning(id); break;
+        case 'edit-warning':
+          if (!deleteInFlight) editWarning(id);
+          break;
+        case 'delete-warning':
+          deleteWarning(id);
+          break;
       }
     });
 

--- a/nt-be/src/handlers/warnings/admin.rs
+++ b/nt-be/src/handlers/warnings/admin.rs
@@ -39,6 +39,8 @@ pub struct AdminError {
     status: StatusCode,
     message: String,
     headers: Option<Box<HeaderMap>>,
+    /// Extra JSON fields merged into the error body (e.g. `existingId` on conflict).
+    extra: Option<Value>,
 }
 
 impl AdminError {
@@ -47,6 +49,7 @@ impl AdminError {
             status,
             message: message.into(),
             headers: None,
+            extra: None,
         }
     }
 
@@ -55,13 +58,28 @@ impl AdminError {
             status,
             message: message.into(),
             headers: Some(Box::new(headers)),
+            extra: None,
+        }
+    }
+
+    fn conflict_existing(existing_id: i32) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            message: "A warning with the same slot, token, and network combination already exists. Edit the existing one instead, or delete it first.".to_string(),
+            headers: None,
+            extra: Some(json!({ "existingId": existing_id })),
         }
     }
 }
 
 impl IntoResponse for AdminError {
     fn into_response(self) -> Response {
-        let body = json!({ "error": self.message });
+        let mut body = json!({ "error": self.message });
+        if let Some(Value::Object(extra)) = self.extra
+            && let Some(obj) = body.as_object_mut()
+        {
+            obj.extend(extra);
+        }
         let mut response = (self.status, Json(body)).into_response();
         if let Some(headers) = self.headers {
             for (key, value) in headers.as_ref().iter() {
@@ -464,22 +482,18 @@ pub async fn create_warning(
         )
     })?;
 
-    db::delete_conflicting_warnings_with_audit(
-        &mut tx,
-        None,
-        &slot,
-        &token,
-        &network,
-        &admin.username,
-        "upsert_replace",
-    )
-    .await
-    .map_err(|_| {
-        AdminError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to create warning.",
-        )
-    })?;
+    if let Some(existing_id) =
+        db::find_conflicting_warning_id(&mut *tx, None, &slot, &token, &network)
+            .await
+            .map_err(|_| {
+                AdminError::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to create warning.",
+                )
+            })?
+    {
+        return Err(AdminError::conflict_existing(existing_id));
+    }
 
     let warning = sqlx::query_as::<_, AdminWarning>(&format!(
         r#"
@@ -517,9 +531,15 @@ pub async fn create_warning(
         if let sqlx::Error::Database(db_err) = &e
             && db_err.constraint().is_some()
         {
-            return AdminError::new(StatusCode::CONFLICT, "A warning with the same slot, token, and network combination already exists. Edit the existing one instead, or delete it first.");
+            return AdminError::new(
+                StatusCode::CONFLICT,
+                "A warning with the same slot, token, and network combination already exists. Edit the existing one instead, or delete it first.",
+            );
         }
-        AdminError::new(StatusCode::INTERNAL_SERVER_ERROR, "Failed to create warning. Please try again.")
+        AdminError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to create warning. Please try again.",
+        )
     })?;
 
     let action = if show_from.is_some() || ends_at.is_some() {
@@ -747,22 +767,18 @@ pub async fn update_warning(
         )
     })?;
 
-    db::delete_conflicting_warnings_with_audit(
-        &mut tx,
-        Some(id),
-        &slot,
-        &token,
-        &network,
-        &admin.username,
-        "upsert_replace",
-    )
-    .await
-    .map_err(|_| {
-        AdminError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to update warning.",
-        )
-    })?;
+    if let Some(existing_id) =
+        db::find_conflicting_warning_id(&mut *tx, Some(id), &slot, &token, &network)
+            .await
+            .map_err(|_| {
+                AdminError::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to update warning.",
+                )
+            })?
+    {
+        return Err(AdminError::conflict_existing(existing_id));
+    }
 
     let updated = sqlx::query_as::<_, AdminWarning>(&format!(
         r#"
@@ -817,7 +833,7 @@ pub async fn update_warning(
         {
             return AdminError::new(
                 StatusCode::CONFLICT,
-                "A warning with the same slot, token, and network combination already exists.",
+                "A warning with the same slot, token, and network combination already exists. Edit the existing one instead, or delete it first.",
             );
         }
         AdminError::new(
@@ -900,11 +916,12 @@ pub async fn delete_warning(
     .bind(id)
     .fetch_optional(&state.db_pool)
     .await
-    .map_err(|_| AdminError::new(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load warning."))?
-    .ok_or(AdminError::new(
-        StatusCode::NOT_FOUND,
-        "Warning not found — it may have been deleted already.",
-    ))?;
+    .map_err(|_| AdminError::new(StatusCode::INTERNAL_SERVER_ERROR, "Failed to load warning."))?;
+
+    // Idempotent: already-deleted ids succeed so duplicate clicks don't error.
+    let Some(existing) = existing else {
+        return Ok(StatusCode::NO_CONTENT);
+    };
 
     let mut extra = json!({});
     if let Some(ref gid) = existing.group_id {

--- a/nt-be/src/handlers/warnings/db.rs
+++ b/nt-be/src/handlers/warnings/db.rs
@@ -24,14 +24,6 @@ impl AuditAction {
     }
 }
 
-#[derive(Debug, sqlx::FromRow)]
-struct ConflictingWarning {
-    id: i32,
-    slot: Option<String>,
-    token: Option<String>,
-    network: Option<String>,
-}
-
 pub async fn invalidate_warnings_cache(state: &AppState) {
     invalidate_warnings_cache_for(&state.cache).await;
 }
@@ -90,48 +82,33 @@ pub async fn delete_warning_with_audit_in_tx(
     Ok(())
 }
 
-pub async fn delete_conflicting_warnings_with_audit(
-    tx: &mut Transaction<'_, Postgres>,
+pub async fn find_conflicting_warning_id<'e, E>(
+    executor: E,
     except_id: Option<i32>,
     slot: &Option<String>,
     token: &Option<String>,
     network: &Option<String>,
-    changed_by: &str,
-    source: &str,
-) -> Result<(), sqlx::Error> {
-    let rows = sqlx::query_as::<_, ConflictingWarning>(
+) -> Result<Option<i32>, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
+    sqlx::query_scalar(
         r#"
-        SELECT id, slot, token, network
+        SELECT id
         FROM warning_slots
         WHERE ($1::int IS NULL OR id != $1)
           AND COALESCE(slot, '') = COALESCE($2, '')
           AND COALESCE(token, '') = COALESCE($3, '')
           AND COALESCE(network, '') = COALESCE($4, '')
+        LIMIT 1
         "#,
     )
     .bind(except_id)
     .bind(slot)
     .bind(token)
     .bind(network)
-    .fetch_all(&mut **tx)
-    .await?;
-
-    for row in rows {
-        let changes = audit_delete_changes(
-            row.id,
-            row.slot.clone(),
-            row.token.clone(),
-            row.network.clone(),
-            json!({ "source": source }),
-        );
-        sqlx::query("DELETE FROM warning_slots WHERE id = $1")
-            .bind(row.id)
-            .execute(&mut **tx)
-            .await?;
-        insert_audit_log(&mut **tx, None, AuditAction::Deleted, changed_by, changes).await?;
-    }
-
-    Ok(())
+    .fetch_optional(executor)
+    .await
 }
 
 pub fn audit_delete_changes(

--- a/nt-be/src/handlers/warnings/tests.rs
+++ b/nt-be/src/handlers/warnings/tests.rs
@@ -381,3 +381,173 @@ async fn test_multiple_admin_users_are_recorded_in_audit_log(pool: PgPool) {
         "Audit log should record the authenticated admin username"
     );
 }
+
+#[sqlx::test]
+async fn test_create_warning_rejects_duplicate_slot_without_overwrite(pool: PgPool) {
+    let state = test_state(pool.clone());
+    let app = create_routes(state.clone());
+    let auth = primary_admin_auth(&state);
+
+    sqlx::query("DELETE FROM warning_slots")
+        .execute(&pool)
+        .await
+        .expect("Should clear warnings");
+
+    let create_body = json!({
+        "slot": "login",
+        "isActive": true,
+        "response": "paused",
+        "severity": "high",
+        "situation": "wallet_login_unavailable",
+        "userMessage": "### Original\nFirst warning",
+        "useCustomMessage": true,
+    })
+    .to_string();
+
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/internal/api/warnings")
+                .header(header::AUTHORIZATION, &auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(create_body.clone()))
+                .expect("Should build first create request"),
+        )
+        .await
+        .expect("First create should complete");
+    assert_eq!(first.status(), StatusCode::OK);
+    let created = response_json(first).await;
+    let existing_id = created
+        .get("id")
+        .and_then(Value::as_i64)
+        .expect("Created warning should have id");
+
+    let second = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/internal/api/warnings")
+                .header(header::AUTHORIZATION, &auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "slot": "login",
+                        "isActive": true,
+                        "response": "paused",
+                        "severity": "high",
+                        "situation": "wallet_login_unavailable",
+                        "userMessage": "### Replacement\nShould not overwrite",
+                        "useCustomMessage": true,
+                    })
+                    .to_string(),
+                ))
+                .expect("Should build duplicate create request"),
+        )
+        .await
+        .expect("Duplicate create should complete");
+
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+    let conflict = response_json(second).await;
+    assert_eq!(
+        conflict.get("existingId").and_then(Value::as_i64),
+        Some(existing_id)
+    );
+
+    let remaining: Vec<(Option<String>, bool)> = sqlx::query_as(
+        r#"
+        SELECT user_message, use_custom_message
+        FROM warning_slots
+        WHERE COALESCE(slot, '') = 'login'
+        "#,
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("Should load remaining login warnings");
+
+    assert_eq!(
+        remaining.len(),
+        1,
+        "Duplicate create must not insert a second row"
+    );
+    assert_eq!(
+        remaining[0].0.as_deref(),
+        Some("### Original\nFirst warning"),
+        "Original custom message must be preserved"
+    );
+    assert!(remaining[0].1, "use_custom_message must stay true");
+}
+
+#[sqlx::test]
+async fn test_delete_warning_is_idempotent(pool: PgPool) {
+    let state = test_state(pool.clone());
+    let app = create_routes(state.clone());
+    let auth = primary_admin_auth(&state);
+
+    sqlx::query("DELETE FROM warning_slots")
+        .execute(&pool)
+        .await
+        .expect("Should clear warnings");
+
+    let create = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/internal/api/warnings")
+                .header(header::AUTHORIZATION, &auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "slot": "exchange",
+                        "isActive": true,
+                        "response": "notice",
+                        "severity": "high",
+                        "userMessage": "Exchange issue",
+                    })
+                    .to_string(),
+                ))
+                .expect("Should build create request"),
+        )
+        .await
+        .expect("Create should complete");
+    assert_eq!(create.status(), StatusCode::OK);
+    let created = response_json(create).await;
+    let warning_id = created
+        .get("id")
+        .and_then(Value::as_i64)
+        .expect("Created warning should have id");
+
+    let first_delete = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/internal/api/warnings/{warning_id}"))
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .expect("Should build first delete"),
+        )
+        .await
+        .expect("First delete should complete");
+    assert_eq!(first_delete.status(), StatusCode::NO_CONTENT);
+
+    let second_delete = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/internal/api/warnings/{warning_id}"))
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .expect("Should build second delete"),
+        )
+        .await
+        .expect("Second delete should complete");
+    assert_eq!(
+        second_delete.status(),
+        StatusCode::NO_CONTENT,
+        "Deleting an already-removed warning should succeed"
+    );
+}

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -18,6 +18,7 @@ import { AuthButton } from "@/components/auth-button";
 import { Button } from "@/components/button";
 import { PageCard } from "@/components/card";
 import { EmptyState } from "@/components/empty-state";
+import { ScrollContainer } from "@/components/scroll-container";
 import { Tooltip } from "@/components/tooltip";
 import {
     DropdownMenu,
@@ -666,45 +667,52 @@ export default function BalanceWithGraph({
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent
                                     align="end"
-                                    className="max-h-[300px] min-w-[140px] overflow-y-auto"
+                                    className="min-w-[140px] p-0"
                                 >
-                                    <DropdownMenuItem
-                                        onSelect={() => setSelectedToken("all")}
-                                        className="flex items-center justify-between gap-2"
-                                    >
-                                        <span className="flex items-center gap-2">
-                                            <Coins className="size-4" />
-                                            <span>{t("allTokens")}</span>
-                                        </span>
-                                        {selectedToken === "all" && (
-                                            <Check className="size-4" />
-                                        )}
-                                    </DropdownMenuItem>
-                                    {groupedTokens.map((group) => (
+                                    <ScrollContainer className="max-h-[300px] p-1">
                                         <DropdownMenuItem
-                                            key={group.symbol}
                                             onSelect={() =>
-                                                setSelectedToken(group.symbol)
+                                                setSelectedToken("all")
                                             }
                                             className="flex items-center justify-between gap-2"
                                         >
                                             <span className="flex items-center gap-2">
-                                                {group.icon && (
-                                                    <img
-                                                        src={group.icon}
-                                                        alt={group.symbol}
-                                                        width={16}
-                                                        height={16}
-                                                        className="rounded-full"
-                                                    />
-                                                )}
-                                                <span>{group.symbol}</span>
+                                                <Coins className="size-4" />
+                                                <span>{t("allTokens")}</span>
                                             </span>
-                                            {selectedToken === group.symbol && (
+                                            {selectedToken === "all" && (
                                                 <Check className="size-4" />
                                             )}
                                         </DropdownMenuItem>
-                                    ))}
+                                        {groupedTokens.map((group) => (
+                                            <DropdownMenuItem
+                                                key={group.symbol}
+                                                onSelect={() =>
+                                                    setSelectedToken(
+                                                        group.symbol,
+                                                    )
+                                                }
+                                                className="flex items-center justify-between gap-2"
+                                            >
+                                                <span className="flex items-center gap-2">
+                                                    {group.icon && (
+                                                        <img
+                                                            src={group.icon}
+                                                            alt={group.symbol}
+                                                            width={16}
+                                                            height={16}
+                                                            className="rounded-full"
+                                                        />
+                                                    )}
+                                                    <span>{group.symbol}</span>
+                                                </span>
+                                                {selectedToken ===
+                                                    group.symbol && (
+                                                    <Check className="size-4" />
+                                                )}
+                                            </DropdownMenuItem>
+                                        ))}
+                                    </ScrollContainer>
                                 </DropdownMenuContent>
                             </DropdownMenu>
                             <DropdownMenu>

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -47,6 +47,8 @@ import {
 import { usePopularAssetsByActivity } from "@/hooks/use-treasury-queries";
 import { type BridgeNetwork, useBridgeTokens } from "@/hooks/use-bridge-tokens";
 import { useTreasury } from "@/hooks/use-treasury";
+import { useNear } from "@/stores/near-store";
+import { isAxiosErrorWithStatus } from "@/lib/query-retry";
 import Big from "@/lib/big";
 import { fetchDepositAddress } from "@/lib/bridge-api";
 import { getNetworkDisplayCaseClass } from "@/lib/intents-network";
@@ -333,10 +335,12 @@ export function DepositModal({
         [t],
     );
     const { treasuryId, isConfidential, isGuestTreasury } = useTreasury();
-    // Guests on confidential treasuries can only use the NEAR direct network;
-    // other networks are shown as "for members only" and disabled. When network
-    // selection is restricted like this, we must not auto-select a network.
-    const isNetworkSelectionRestricted = isConfidential && isGuestTreasury;
+    const { accountId } = useNear();
+    // Guests (and logged-out users) on confidential treasuries cannot select any
+    // network — all options are shown as "for members only". Include !accountId
+    // so logout doesn't wait on the guest-config reload race.
+    const isNetworkSelectionRestricted =
+        isConfidential && (isGuestTreasury || !accountId);
     const router = useRouter();
     const pathname = usePathname();
     const searchParams = useSearchParams();
@@ -429,6 +433,26 @@ export function DepositModal({
         }
     }, [selectedAsset?.id, selectedNetwork?.id, treasuryId]);
 
+    // After logout (or when guest restrictions apply), clear any selected
+    // network/address so we don't keep calling authenticated deposit APIs.
+    useEffect(() => {
+        if (!isNetworkSelectionRestricted) return;
+        if (!selectedNetwork) return;
+
+        invalidatePendingAddressRequest();
+        setDepositInfo(null);
+        setSingleUseExpiresAt(null);
+        setHasAcknowledgedSingleUse(false);
+        setAddressSourceTab("public");
+        form.setValue("network", null);
+        form.clearErrors("network");
+    }, [
+        isNetworkSelectionRestricted,
+        selectedNetwork,
+        invalidatePendingAddressRequest,
+        form,
+    ]);
+
     useEffect(() => {
         const params = new URLSearchParams(searchParams.toString());
         const nextToken = selectedAsset?.id || null;
@@ -480,13 +504,8 @@ export function DepositModal({
     }, [selectedAsset, selectedNetwork, bridgeAssets]);
 
     const networkSections = useMemo(() => {
-        if (isConfidential && isGuestTreasury) {
+        if (isNetworkSelectionRestricted) {
             return buildSectionedOptions(filteredNetworks, [
-                {
-                    title: t("sections.available"),
-                    filter: (network) =>
-                        network.id === NEAR_COM_DIRECT_NETWORK_ID,
-                },
                 {
                     title: t("sections.forMembersOnly"),
                     filter: () => true,
@@ -543,8 +562,7 @@ export function DepositModal({
     }, [
         filteredNetworks,
         selectedNetworkBalances,
-        isConfidential,
-        isGuestTreasury,
+        isNetworkSelectionRestricted,
         t,
     ]);
 
@@ -822,6 +840,12 @@ export function DepositModal({
                 networkToSelect = availableNetworks[0];
             }
 
+            // Guests (and logged-out users) on confidential treasuries may not
+            // select or restore any network.
+            if (isNetworkSelectionRestricted) {
+                networkToSelect = null;
+            }
+
             if (networkToSelect) {
                 form.setValue("network", networkToSelect);
             } else {
@@ -848,6 +872,8 @@ export function DepositModal({
         prefillTokenId,
         prefillNetworkId,
         popularAssets,
+        isNetworkSelectionRestricted,
+        accountId,
     ]);
 
     // Handle asset selection - show all assets but update network list
@@ -920,6 +946,14 @@ export function DepositModal({
                 return;
             }
 
+            // Guests on confidential treasuries cannot use any network.
+            if (isNetworkSelectionRestricted) {
+                setDepositInfo(null);
+                setSingleUseExpiresAt(null);
+                setIsLoadingAddress(false);
+                return;
+            }
+
             const isNearNetwork = (
                 selectedNetwork.chainId ?? selectedNetwork.id
             )
@@ -969,6 +1003,16 @@ export function DepositModal({
                 }
             }
 
+            // Intents deposit addresses require an authenticated session.
+            // Safety net for mid-logout races — clear quietly.
+            if (!accountId) {
+                if (requestId !== latestAddressRequestRef.current) return;
+                setDepositInfo(null);
+                setSingleUseExpiresAt(null);
+                setIsLoadingAddress(false);
+                return;
+            }
+
             setIsLoadingAddress(true);
             form.clearErrors("network");
 
@@ -1002,11 +1046,24 @@ export function DepositModal({
                         message: t("errors.addressUnavailable"),
                     });
                 }
-            } catch (err: any) {
+            } catch (err: unknown) {
                 if (requestId !== latestAddressRequestRef.current) return;
+                // Auth errors after logout: clear quietly (network already reset).
+                if (
+                    isAxiosErrorWithStatus(err, 401) ||
+                    isAxiosErrorWithStatus(err, 403)
+                ) {
+                    setDepositInfo(null);
+                    setSingleUseExpiresAt(null);
+                    form.clearErrors("network");
+                    return;
+                }
                 form.setError("network", {
                     type: "manual",
-                    message: err.message || t("errors.fetchFailed"),
+                    message:
+                        err instanceof Error
+                            ? err.message
+                            : t("errors.fetchFailed"),
                 });
                 setDepositInfo(null);
                 setSingleUseExpiresAt(null);
@@ -1032,6 +1089,9 @@ export function DepositModal({
         t,
         treasuryId,
         invalidatePendingAddressRequest,
+        accountId,
+        isNetworkSelectionRestricted,
+        form,
     ]);
 
     const isNearNetworkSelected = isNearNetworkId(

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/export/page.tsx
@@ -57,6 +57,7 @@ import {
     TabsTrigger,
 } from "@/components/underline-tabs";
 import { EmptyState } from "@/components/empty-state";
+import { ScrollContainer } from "@/components/scroll-container";
 import { toast } from "sonner";
 import { useFormatHistoryDuration } from "@/features/activity";
 import { format } from "date-fns";
@@ -907,68 +908,72 @@ export default function ExportActivityPage() {
                                                         </Button>
                                                     </DropdownMenuTrigger>
                                                     <DropdownMenuContent
-                                                        className="min-w-(--radix-dropdown-menu-trigger-width) text-foreground max-h-[300px] overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-muted-foreground/40"
+                                                        className="min-w-(--radix-dropdown-menu-trigger-width) text-foreground p-0"
                                                         align="start"
                                                     >
-                                                        <DropdownMenuCheckboxItem
-                                                            checked={selectedAssets.includes(
-                                                                "all",
-                                                            )}
-                                                            onCheckedChange={() =>
-                                                                toggleAsset(
+                                                        <ScrollContainer className="max-h-[300px] p-1">
+                                                            <DropdownMenuCheckboxItem
+                                                                checked={selectedAssets.includes(
                                                                     "all",
-                                                                )
-                                                            }
-                                                            onSelect={(e) =>
-                                                                e.preventDefault()
-                                                            }
-                                                        >
-                                                            <div className="flex items-center">
-                                                                <Coins className="w-4 h-4 mr-2" />
-                                                                {tExport(
-                                                                    "fields.allAssets",
                                                                 )}
-                                                            </div>
-                                                        </DropdownMenuCheckboxItem>
-                                                        {aggregatedTokens.map(
-                                                            (token: any) => (
-                                                                <DropdownMenuCheckboxItem
-                                                                    key={
-                                                                        token.id
-                                                                    }
-                                                                    checked={selectedAssets.includes(
-                                                                        token.id,
+                                                                onCheckedChange={() =>
+                                                                    toggleAsset(
+                                                                        "all",
+                                                                    )
+                                                                }
+                                                                onSelect={(e) =>
+                                                                    e.preventDefault()
+                                                                }
+                                                            >
+                                                                <div className="flex items-center">
+                                                                    <Coins className="w-4 h-4 mr-2" />
+                                                                    {tExport(
+                                                                        "fields.allAssets",
                                                                     )}
-                                                                    onCheckedChange={() =>
-                                                                        toggleAsset(
+                                                                </div>
+                                                            </DropdownMenuCheckboxItem>
+                                                            {aggregatedTokens.map(
+                                                                (
+                                                                    token: any,
+                                                                ) => (
+                                                                    <DropdownMenuCheckboxItem
+                                                                        key={
+                                                                            token.id
+                                                                        }
+                                                                        checked={selectedAssets.includes(
                                                                             token.id,
-                                                                        )
-                                                                    }
-                                                                    onSelect={(
-                                                                        e,
-                                                                    ) =>
-                                                                        e.preventDefault()
-                                                                    }
-                                                                >
-                                                                    <div className="flex items-center">
-                                                                        {token.icon && (
-                                                                            <img
-                                                                                src={
-                                                                                    token.icon
-                                                                                }
-                                                                                alt={
-                                                                                    token.name ||
-                                                                                    token.id
-                                                                                }
-                                                                                className="w-4 h-4 rounded-full mr-2"
-                                                                            />
                                                                         )}
-                                                                        {token.name ||
-                                                                            token.id}
-                                                                    </div>
-                                                                </DropdownMenuCheckboxItem>
-                                                            ),
-                                                        )}
+                                                                        onCheckedChange={() =>
+                                                                            toggleAsset(
+                                                                                token.id,
+                                                                            )
+                                                                        }
+                                                                        onSelect={(
+                                                                            e,
+                                                                        ) =>
+                                                                            e.preventDefault()
+                                                                        }
+                                                                    >
+                                                                        <div className="flex items-center">
+                                                                            {token.icon && (
+                                                                                <img
+                                                                                    src={
+                                                                                        token.icon
+                                                                                    }
+                                                                                    alt={
+                                                                                        token.name ||
+                                                                                        token.id
+                                                                                    }
+                                                                                    className="w-4 h-4 rounded-full mr-2"
+                                                                                />
+                                                                            )}
+                                                                            {token.name ||
+                                                                                token.id}
+                                                                        </div>
+                                                                    </DropdownMenuCheckboxItem>
+                                                                ),
+                                                            )}
+                                                        </ScrollContainer>
                                                     </DropdownMenuContent>
                                                 </DropdownMenu>
                                             </div>

--- a/nt-fe/app/(treasury)/[treasuryId]/settings/components/member-avatars-with-overflow.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/settings/components/member-avatars-with-overflow.tsx
@@ -15,6 +15,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@/components/ui/dialog";
+import { ScrollContainer } from "@/components/scroll-container";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { cn } from "@/lib/utils";
@@ -84,7 +85,7 @@ export function MemberAvatarsWithOverflow({
 
     // Hidden members list for the popover (desktop - only remaining members)
     const HiddenMembersList = () => (
-        <div className="max-h-[300px] overflow-y-auto">
+        <ScrollContainer className="max-h-[300px]">
             <div className="space-y-2 p-1">
                 {hiddenMembers.map((member) => (
                     <div
@@ -101,7 +102,7 @@ export function MemberAvatarsWithOverflow({
                     </div>
                 ))}
             </div>
-        </div>
+        </ScrollContainer>
     );
 
     // All members list for mobile sheet (all members with scroll)

--- a/nt-fe/components/accept-terms-modal.tsx
+++ b/nt-fe/components/accept-terms-modal.tsx
@@ -10,6 +10,7 @@ import {
     DialogTitle,
 } from "@/components/modal";
 import { Button } from "@/components/button";
+import { ScrollContainer } from "@/components/scroll-container";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { useNear } from "@/stores/near-store";
@@ -60,7 +61,7 @@ export function AcceptTermsModal({ open, variant }: AcceptTermsModalProps) {
                     </DialogTitle>
                 </DialogHeader>
 
-                <div className="flex-1 min-h-0 overflow-y-auto -mx-3 px-3">
+                <ScrollContainer className="flex-1 min-h-0 -mx-3 px-3">
                     {isReturningUser ? (
                         <DialogDescription asChild>
                             <div className="space-y-3 text-sm">
@@ -116,7 +117,7 @@ export function AcceptTermsModal({ open, variant }: AcceptTermsModalProps) {
                             </div>
                         </DialogDescription>
                     )}
-                </div>
+                </ScrollContainer>
 
                 <DialogFooter className="flex-col gap-3 items-stretch sm:flex-col  pt-0">
                     <div className="flex items-start gap-3">

--- a/nt-fe/components/assets-table.tsx
+++ b/nt-fe/components/assets-table.tsx
@@ -662,7 +662,7 @@ function AvailableView({
                             key={networkRowKey(asset.id, "available", network)}
                             className="bg-muted/30 group"
                         >
-                            <TableCell className="p-4 pl-16">
+                            <TableCell className="p-4 pl-16 overflow-hidden">
                                 <NetworkDisplay
                                     asset={network}
                                     subLabel={
@@ -800,24 +800,24 @@ function LockedView({
     if (!isExpanded) {
         return (
             <>
-                <TableCell className="p-4 text-right hidden sm:table-cell">
+                <TableCell className="p-4 text-right overflow-hidden hidden sm:table-cell">
                     <BalanceCell
                         balance={lockedAmount ?? Big(0)}
                         symbol={asset.id}
                         balanceUSD={lockedUsd ?? 0}
                     />
                 </TableCell>
-                <TableCell className="p-4 text-right">
+                <TableCell className="p-4 text-right overflow-hidden">
                     <BalanceCell
                         balance={unlockedAmount ?? Big(0)}
                         symbol={asset.id}
                         balanceUSD={unlockedUsd ?? 0}
                     />
                 </TableCell>
-                <TableCell className="p-4 text-right font-medium hidden sm:table-cell">
+                <TableCell className="p-4 text-right font-medium overflow-hidden hidden sm:table-cell">
                     {formatCurrencyWithSubCent(asset.price)}
                 </TableCell>
-                <TableCell className="p-4 text-right hidden sm:table-cell">
+                <TableCell className="p-4 text-right overflow-hidden hidden sm:table-cell">
                     <BalanceCell
                         balance={totalAllocatedAmount ?? Big(0)}
                         symbol={asset.id}
@@ -901,51 +901,49 @@ function LockedView({
                 const lockedRawNetwork = networkLockedRaw(network);
                 const unlockedRawNetwork = networkAvailableRaw(network);
                 const totalAllocated = lockedRawNetwork.add(unlockedRawNetwork);
+                const lockupInstanceLabel =
+                    (ftLockupInstanceCount ?? 0) > 1 && network.lockupInstanceId
+                        ? network.lockupInstanceId.replace(
+                              /\.ft-lockup\.near$/,
+                              "",
+                          )
+                        : null;
                 return (
                     <TableRow
                         key={networkRowKey(asset.id, "locked", network)}
                         className="bg-muted/30 cursor-pointer hover:bg-muted/50 group"
                         onClick={() => onSelectLockup?.(network)}
                     >
-                        <TableCell className="p-4 pl-16">
-                            <div className="space-y-1">
-                                <div className="flex items-center gap-3">
-                                    {network.icon ? (
-                                        <img
-                                            src={network.icon}
-                                            alt={network.symbol}
-                                            className="size-6 rounded-full"
-                                        />
-                                    ) : (
-                                        <div className="size-6 rounded-full bg-brand-blue flex items-center justify-center text-white text-xs font-normal">
-                                            {network.symbol
-                                                .charAt(0)
-                                                .toUpperCase()}
-                                        </div>
-                                    )}
-                                    <div className="flex flex-col text-left">
-                                        <span className="font-semibold">
-                                            {network.symbol}
-                                        </span>
-                                        <span className="text-xs text-muted-foreground">
-                                            Locked Token
-                                            {(ftLockupInstanceCount ?? 0) > 1 &&
-                                                network.lockupInstanceId && (
-                                                    <span>
-                                                        {" "}
-                                                        -{" "}
-                                                        {network.lockupInstanceId.replace(
-                                                            ".ft-lockup.near",
-                                                            "",
-                                                        )}
-                                                    </span>
-                                                )}
-                                        </span>
+                        <TableCell className="p-4 pl-16 overflow-hidden">
+                            <div className="flex items-center gap-3 min-w-0">
+                                {network.icon ? (
+                                    <img
+                                        src={network.icon}
+                                        alt={network.symbol}
+                                        className="size-6 shrink-0 rounded-full"
+                                    />
+                                ) : (
+                                    <div className="size-6 shrink-0 rounded-full bg-brand-blue flex items-center justify-center text-white text-xs font-normal">
+                                        {network.symbol.charAt(0).toUpperCase()}
                                     </div>
+                                )}
+                                <div className="flex min-w-0 flex-col text-left">
+                                    <span className="truncate font-semibold">
+                                        {network.symbol}
+                                    </span>
+                                    <span className="truncate text-xs text-muted-foreground">
+                                        {t("lockedToken")}
+                                        {lockupInstanceLabel && (
+                                            <span>
+                                                {" "}
+                                                - {lockupInstanceLabel}
+                                            </span>
+                                        )}
+                                    </span>
                                 </div>
                             </div>
                         </TableCell>
-                        <TableCell className="p-4 text-right">
+                        <TableCell className="p-4 text-right overflow-hidden">
                             <BalanceCell
                                 balance={displayAmount(
                                     lockedRawNetwork,
@@ -959,7 +957,7 @@ function LockedView({
                                 )}
                             />
                         </TableCell>
-                        <TableCell className="p-4 text-right">
+                        <TableCell className="p-4 text-right overflow-hidden">
                             <BalanceCell
                                 balance={displayAmount(
                                     unlockedRawNetwork,
@@ -974,7 +972,7 @@ function LockedView({
                             />
                         </TableCell>
                         <TableCell />
-                        <TableCell className="p-4 text-right">
+                        <TableCell className="p-4 text-right overflow-hidden">
                             <BalanceCell
                                 balance={displayAmount(
                                     totalAllocated,
@@ -1118,8 +1116,8 @@ function EarningView({
                                         onSelectPool?.(network, pool.poolId)
                                     }
                                 >
-                                    <TableCell className="p-4 pl-16">
-                                        <div className="font-medium text-sm">
+                                    <TableCell className="p-4 pl-16 overflow-hidden">
+                                        <div className="font-medium text-sm truncate">
                                             {pool.poolId}
                                         </div>
                                     </TableCell>
@@ -1183,8 +1181,8 @@ function EarningView({
                                 onSelectPool?.(network, lockupPoolId)
                             }
                         >
-                            <TableCell className="p-4 pl-16">
-                                <div className="font-medium text-sm">
+                            <TableCell className="p-4 pl-16 overflow-hidden">
+                                <div className="font-medium text-sm truncate">
                                     {lockupPoolId}
                                 </div>
                             </TableCell>
@@ -1706,11 +1704,14 @@ export function AssetsTable({ aggregatedTokens }: Props) {
             )}
 
             <div className={cn(hasLockedOrEarning && "p-4 pt-0")}>
-                <Table>
+                <Table className="table-fixed">
                     <TableHeader className="bg-transparent border-t-0">
                         <TableRow className="hover:bg-transparent">
                             {renderSortableHead("token", t("columnToken"), {
-                                headClassName: "pl-0 sm:pl-4",
+                                headClassName: cn(
+                                    "pl-0 sm:pl-4 overflow-hidden",
+                                    view === "locked" ? "w-[24%]" : "w-[34%]",
+                                ),
                                 buttonClassName: cn("justify-start"),
                             })}
                             {view === "available" && (
@@ -1719,7 +1720,7 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                         "balance",
                                         t("balance"),
                                         {
-                                            headClassName: "text-right",
+                                            headClassName: "text-right w-[18%]",
                                             buttonClassName: "ml-auto",
                                         },
                                     )}
@@ -1728,13 +1729,13 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                         t("coinPrice"),
                                         {
                                             headClassName:
-                                                "text-right hidden sm:table-cell",
+                                                "text-right w-[16%] hidden sm:table-cell",
                                             buttonClassName: "ml-auto",
                                         },
                                     )}
                                     {renderSortableHead("weight", t("weight"), {
                                         headClassName:
-                                            "text-right hidden sm:table-cell",
+                                            "text-right w-[20%] hidden sm:table-cell",
                                         buttonClassName: "ml-auto",
                                     })}
                                 </>
@@ -1745,7 +1746,8 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                         "locked",
                                         t("columnLocked"),
                                         {
-                                            headClassName: "text-right",
+                                            headClassName:
+                                                "text-right w-[16%] overflow-hidden",
                                             buttonClassName: "ml-auto",
                                         },
                                     )}
@@ -1754,7 +1756,7 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                         t("columnUnlocked"),
                                         {
                                             headClassName:
-                                                "text-right hidden sm:table-cell",
+                                                "text-right w-[16%] overflow-hidden hidden sm:table-cell",
                                             buttonClassName: "ml-auto",
                                         },
                                     )}
@@ -1763,7 +1765,7 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                         t("coinPrice"),
                                         {
                                             headClassName:
-                                                "text-right hidden sm:table-cell",
+                                                "text-right w-[12%] overflow-hidden hidden sm:table-cell",
                                             buttonClassName: "ml-auto",
                                         },
                                     )}
@@ -1772,7 +1774,7 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                         t("columnTotalAllocated"),
                                         {
                                             headClassName:
-                                                "text-right hidden sm:table-cell",
+                                                "text-right w-[16%] overflow-hidden hidden sm:table-cell",
                                             buttonClassName: "ml-auto",
                                         },
                                     )}
@@ -1784,7 +1786,7 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                         "earningTotal",
                                         t("totalBalance"),
                                         {
-                                            headClassName: "text-right",
+                                            headClassName: "text-right w-[18%]",
                                             buttonClassName: "ml-auto",
                                         },
                                     )}
@@ -1793,7 +1795,7 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                         t("coinPrice"),
                                         {
                                             headClassName:
-                                                "text-right hidden sm:table-cell",
+                                                "text-right w-[16%] hidden sm:table-cell",
                                             buttonClassName: "ml-auto",
                                         },
                                     )}
@@ -1802,7 +1804,7 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                         t("columnAvailableToWithdraw"),
                                         {
                                             headClassName:
-                                                "text-right hidden sm:table-cell",
+                                                "text-right w-[20%] hidden sm:table-cell",
                                             buttonClassName: "ml-auto",
                                         },
                                     )}
@@ -1970,18 +1972,18 @@ export function AssetsTable({ aggregatedTokens }: Props) {
                                             }));
                                         }}
                                     >
-                                        <TableCell className="py-4 pr-4 pl-0 sm:p-4 sm:pl-4">
-                                            <div className="flex items-center gap-3">
+                                        <TableCell className="py-4 pr-4 pl-0 sm:p-4 sm:pl-4 overflow-hidden">
+                                            <div className="flex items-center gap-3 min-w-0">
                                                 <img
                                                     src={asset.icon}
                                                     alt={asset.name}
-                                                    className="h-8 w-8 rounded-full"
+                                                    className="h-8 w-8 shrink-0 rounded-full"
                                                 />
-                                                <div>
-                                                    <p className="font-semibold">
+                                                <div className="min-w-0">
+                                                    <p className="font-semibold truncate">
                                                         {asset.id}
                                                     </p>
-                                                    <p className="text-xs text-muted-foreground">
+                                                    <p className="text-xs text-muted-foreground truncate">
                                                         {asset.name}
                                                     </p>
                                                 </div>

--- a/nt-fe/components/connect-wallet-selector.tsx
+++ b/nt-fe/components/connect-wallet-selector.tsx
@@ -33,6 +33,7 @@ import {
     resolveManifestWalletId,
 } from "@/lib/wallets";
 import { cn } from "@/lib/utils";
+import { stripMessageForTooltip } from "@/lib/warnings";
 import { useNear } from "@/stores/near-store";
 
 type WalletPickerType = "near";
@@ -216,7 +217,9 @@ export function ConnectWalletSelector({
                 return {
                     label: offlineBadgeLabel,
                     tooltip:
-                        resolveWarningMessage(walletWarning, slot) ?? undefined,
+                        stripMessageForTooltip(
+                            resolveWarningMessage(walletWarning, slot),
+                        ) || undefined,
                     isOffline: true,
                 };
             }
@@ -239,7 +242,9 @@ export function ConnectWalletSelector({
                 return {
                     label: offlineBadgeLabel,
                     tooltip:
-                        resolveWarningMessage(walletWarning, slot) ?? undefined,
+                        stripMessageForTooltip(
+                            resolveWarningMessage(walletWarning, slot),
+                        ) || undefined,
                     isOffline: true,
                 };
             }
@@ -319,43 +324,56 @@ export function ConnectWalletSelector({
                     </div>
                 )}
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                    {WALLET_OPTIONS.map((wallet) => (
-                        <Button
-                            key={wallet.id}
-                            type="button"
-                            variant="secondary"
-                            className="h-26 items-start justify-start rounded-xl border border-border p-4 text-left hover:bg-muted"
-                            onClick={() => handleWalletChoice(wallet)}
-                            disabled={
-                                isConnectingWallet ||
-                                isWalletChoiceBlocked(wallet.id)
-                            }
-                        >
-                            <div className="flex w-full flex-col gap-2">
-                                <div className="flex items-center justify-between">
-                                    <WalletOptionIcon wallet={wallet} />
-                                    {(() => {
-                                        const badge = getTopLevelBadge(wallet);
-                                        if (!badge) return null;
-                                        return (
-                                            <Pill
-                                                title={badge.label}
-                                                info={badge.tooltip}
-                                                className={
-                                                    badge.isOffline
-                                                        ? "bg-general-warning-background-faded text-general-warning-foreground"
-                                                        : "bg-general-success-background-faded text-general-success-foreground"
-                                                }
-                                            />
-                                        );
-                                    })()}
+                    {WALLET_OPTIONS.map((wallet) => {
+                        // Use aria-disabled (not disabled) when offline so the
+                        // Offline badge tooltip can still receive hover events.
+                        const isOfflineBlocked = isWalletChoiceBlocked(
+                            wallet.id,
+                        );
+                        return (
+                            <Button
+                                key={wallet.id}
+                                type="button"
+                                variant="secondary"
+                                className={cn(
+                                    "h-26 items-start justify-start rounded-xl border border-border p-4 text-left hover:bg-muted",
+                                    isOfflineBlocked &&
+                                        !isConnectingWallet &&
+                                        "cursor-not-allowed opacity-50 hover:bg-secondary",
+                                )}
+                                onClick={() => handleWalletChoice(wallet)}
+                                disabled={isConnectingWallet}
+                                aria-disabled={
+                                    isConnectingWallet || isOfflineBlocked
+                                }
+                            >
+                                <div className="flex w-full flex-col gap-2">
+                                    <div className="flex items-center justify-between">
+                                        <WalletOptionIcon wallet={wallet} />
+                                        {(() => {
+                                            const badge =
+                                                getTopLevelBadge(wallet);
+                                            if (!badge) return null;
+                                            return (
+                                                <Pill
+                                                    title={badge.label}
+                                                    info={badge.tooltip}
+                                                    className={
+                                                        badge.isOffline
+                                                            ? "bg-general-warning-background-faded text-general-warning-foreground"
+                                                            : "bg-general-success-background-faded text-general-success-foreground"
+                                                    }
+                                                />
+                                            );
+                                        })()}
+                                    </div>
+                                    <div className="text-lg font-semibold">
+                                        {wallet.label}
+                                    </div>
                                 </div>
-                                <div className="text-lg font-semibold">
-                                    {wallet.label}
-                                </div>
-                            </div>
-                        </Button>
-                    ))}
+                            </Button>
+                        );
+                    })}
                 </div>
                 <Dialog
                     open={walletPickerOpen !== null}
@@ -378,49 +396,66 @@ export function ConnectWalletSelector({
                         </DialogHeader>
                         <SlotWarning slot="login" className="mb-2" />
                         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                            {walletPickerChoices.map((wallet) => (
-                                <div key={wallet.id}>
-                                    <Button
-                                        type="button"
-                                        variant="secondary"
-                                        className="h-26 w-full items-start justify-start rounded-xl border border-border p-4 text-left hover:bg-muted"
-                                        onClick={() =>
-                                            handleWalletChoice(wallet)
-                                        }
-                                        disabled={
-                                            isConnectingWallet ||
-                                            isWalletChoiceBlocked(wallet.id)
-                                        }
-                                    >
-                                        <div className="flex w-full flex-col gap-2">
-                                            <div className="flex items-center justify-between">
-                                                <WalletOptionIcon
-                                                    wallet={wallet}
-                                                />
-                                                {(() => {
-                                                    const badge =
-                                                        getModalBadge(wallet);
-                                                    if (!badge) return null;
-                                                    return (
-                                                        <Pill
-                                                            title={badge.label}
-                                                            info={badge.tooltip}
-                                                            className={
-                                                                badge.isOffline
-                                                                    ? "bg-general-warning-background-faded text-general-warning-foreground"
-                                                                    : "bg-general-success-background-faded text-general-success-foreground"
-                                                            }
-                                                        />
-                                                    );
-                                                })()}
+                            {walletPickerChoices.map((wallet) => {
+                                const isOfflineBlocked = isWalletChoiceBlocked(
+                                    wallet.id,
+                                );
+                                return (
+                                    <div key={wallet.id}>
+                                        <Button
+                                            type="button"
+                                            variant="secondary"
+                                            className={cn(
+                                                "h-26 w-full items-start justify-start rounded-xl border border-border p-4 text-left hover:bg-muted",
+                                                isOfflineBlocked &&
+                                                    !isConnectingWallet &&
+                                                    "cursor-not-allowed opacity-50 hover:bg-secondary",
+                                            )}
+                                            onClick={() =>
+                                                handleWalletChoice(wallet)
+                                            }
+                                            disabled={isConnectingWallet}
+                                            aria-disabled={
+                                                isConnectingWallet ||
+                                                isOfflineBlocked
+                                            }
+                                        >
+                                            <div className="flex w-full flex-col gap-2">
+                                                <div className="flex items-center justify-between">
+                                                    <WalletOptionIcon
+                                                        wallet={wallet}
+                                                    />
+                                                    {(() => {
+                                                        const badge =
+                                                            getModalBadge(
+                                                                wallet,
+                                                            );
+                                                        if (!badge) return null;
+                                                        return (
+                                                            <Pill
+                                                                title={
+                                                                    badge.label
+                                                                }
+                                                                info={
+                                                                    badge.tooltip
+                                                                }
+                                                                className={
+                                                                    badge.isOffline
+                                                                        ? "bg-general-warning-background-faded text-general-warning-foreground"
+                                                                        : "bg-general-success-background-faded text-general-success-foreground"
+                                                                }
+                                                            />
+                                                        );
+                                                    })()}
+                                                </div>
+                                                <div className="text-lg font-semibold">
+                                                    {wallet.label}
+                                                </div>
                                             </div>
-                                            <div className="text-lg font-semibold">
-                                                {wallet.label}
-                                            </div>
-                                        </div>
-                                    </Button>
-                                </div>
-                            ))}
+                                        </Button>
+                                    </div>
+                                );
+                            })}
                         </div>
                     </DialogContent>
                 </Dialog>

--- a/nt-fe/components/csv-upload-panel.tsx
+++ b/nt-fe/components/csv-upload-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useId } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/button";
+import { ScrollContainer } from "@/components/scroll-container";
 import { Textarea } from "@/components/textarea";
 import { Upload, FileText, X } from "lucide-react";
 import {
@@ -246,7 +247,7 @@ export function CsvUploadPanel({
 
                     {/* Errors below file upload */}
                     {activeTab === "upload" && hasErrors && (
-                        <div className="space-y-1 max-h-48 overflow-y-auto">
+                        <ScrollContainer className="space-y-1 max-h-48">
                             {errors.map((error, idx) => (
                                 <div
                                     key={idx}
@@ -255,7 +256,7 @@ export function CsvUploadPanel({
                                     {error.message}
                                 </div>
                             ))}
-                        </div>
+                        </ScrollContainer>
                     )}
                 </div>
             </TabsContent>
@@ -284,7 +285,7 @@ export function CsvUploadPanel({
 
                     {/* Errors below textarea */}
                     {hasErrors && (
-                        <div className="space-y-1 max-h-48 overflow-y-auto">
+                        <ScrollContainer className="space-y-1 max-h-48">
                             {errors.map((error, idx) => (
                                 <div
                                     key={idx}
@@ -293,7 +294,7 @@ export function CsvUploadPanel({
                                     {error.message}
                                 </div>
                             ))}
-                        </div>
+                        </ScrollContainer>
                     )}
                 </div>
             </TabsContent>

--- a/nt-fe/components/pill.tsx
+++ b/nt-fe/components/pill.tsx
@@ -44,9 +44,11 @@ export function Pill({
         </div>
     );
     if (info) {
+        // pointer-events-auto so hover still works when the Pill sits inside a
+        // disabled control (e.g. Offline wallet cards use disabled:pointer-events-none).
         return (
             <Tooltip content={info} side={side}>
-                {pill}
+                <div className="pointer-events-auto">{pill}</div>
             </Tooltip>
         );
     }

--- a/nt-fe/components/scroll-container.tsx
+++ b/nt-fe/components/scroll-container.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared thin scrollbar styles — transparent track, muted thumb.
+ *
+ * Prefer `ScrollContainer` whenever you can wrap the scrollable content.
+ * Use this class only when the host element must own overflow itself
+ * (e.g. Radix `SelectContent`, whose viewport can't be replaced by a wrapper).
+ */
+export const scrollbarClassName =
+    "scrollbar-thin scrollbar-track-transparent scrollbar-thumb-muted-foreground/40";
+
+type ScrollOrientation = "vertical" | "horizontal" | "both";
+
+export interface ScrollContainerProps extends React.ComponentProps<"div"> {
+    /** Scroll axis. Defaults to vertical. */
+    orientation?: ScrollOrientation;
+}
+
+/**
+ * Drop-in scrollable container with the app-standard thin scrollbar.
+ * Prefer this over raw `overflow-y-auto` so scrollbars stay consistent.
+ */
+export function ScrollContainer({
+    className,
+    orientation = "vertical",
+    ...props
+}: ScrollContainerProps) {
+    return (
+        <div
+            data-slot="scroll-container"
+            className={cn(
+                orientation === "vertical" &&
+                    "overflow-y-auto overflow-x-hidden",
+                orientation === "horizontal" &&
+                    "overflow-x-auto overflow-y-hidden",
+                orientation === "both" && "overflow-auto",
+                scrollbarClassName,
+                className,
+            )}
+            {...props}
+        />
+    );
+}

--- a/nt-fe/components/token-display.tsx
+++ b/nt-fe/components/token-display.tsx
@@ -168,17 +168,17 @@ export const NetworkDisplay = ({
     const image = asset.chainIcons ? asset.chainIcons.icon : asset.icon;
 
     return (
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 min-w-0">
             <img
                 src={image}
                 alt={`${asset.chainName} network`}
-                className="size-6"
+                className="size-6 shrink-0"
             />
-            <div className="flex flex-col text-left">
-                <span className="font-semibold capitalize">
+            <div className="flex min-w-0 flex-col text-left">
+                <span className="truncate font-semibold capitalize">
                     {asset.chainName}
                 </span>
-                <span className="text-xs text-muted-foreground">
+                <span className="truncate text-xs text-muted-foreground">
                     {subLabel ?? type}
                 </span>
             </div>
@@ -196,11 +196,11 @@ export const BalanceCell = ({
     balanceUSD: number;
 }) => {
     return (
-        <div className="text-right">
-            <div className="font-medium text-sm">
+        <div className="min-w-0 max-w-full overflow-hidden text-right">
+            <div className="truncate font-medium text-sm">
                 {formatCurrencyWithSubCent(balanceUSD)}
             </div>
-            <div className="text-xxs text-muted-foreground">
+            <div className="truncate text-xxs text-muted-foreground">
                 {formatSmartAmount(balance)} {symbol}
             </div>
         </div>

--- a/nt-fe/components/ui/scroll-area.tsx
+++ b/nt-fe/components/ui/scroll-area.tsx
@@ -49,7 +49,7 @@ function ScrollBar({
         >
             <ScrollAreaPrimitive.ScrollAreaThumb
                 data-slot="scroll-area-thumb"
-                className="bg-muted-foreground/10 relative flex-1 rounded-full"
+                className="bg-muted-foreground/40 relative flex-1 rounded-full"
             />
         </ScrollAreaPrimitive.ScrollAreaScrollbar>
     );

--- a/nt-fe/components/ui/select.tsx
+++ b/nt-fe/components/ui/select.tsx
@@ -5,6 +5,7 @@ import * as SelectPrimitive from "@radix-ui/react-select";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { scrollbarClassName } from "@/components/scroll-container";
 
 function Select({
     ...props
@@ -63,6 +64,7 @@ function SelectContent({
                 data-slot="select-content"
                 className={cn(
                     "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+                    scrollbarClassName,
                     position === "popper" &&
                         "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
                     className,

--- a/nt-fe/features/proposals/components/checkbox-filter-content.tsx
+++ b/nt-fe/features/proposals/components/checkbox-filter-content.tsx
@@ -1,3 +1,4 @@
+import { ScrollContainer } from "@/components/scroll-container";
 import { Checkbox } from "@/components/ui/checkbox";
 import { BaseFilterPopover } from "./base-filter-popover";
 import { useFilterState } from "../hooks/use-filter-state";
@@ -71,7 +72,7 @@ export function CheckboxFilterContent({
             onDelete={handleDelete}
             className={className}
         >
-            <div className="max-h-60 overflow-y-auto">
+            <ScrollContainer className="max-h-60">
                 {options.map((option) => (
                     <label
                         key={option.value}
@@ -86,7 +87,7 @@ export function CheckboxFilterContent({
                         <span className="text-sm">{option.label}</span>
                     </label>
                 ))}
-            </div>
+            </ScrollContainer>
         </BaseFilterPopover>
     );
 }

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -43,16 +43,16 @@ import {
     useSwapStatus,
 } from "@/hooks/use-proposals";
 import { useTreasury } from "@/hooks/use-treasury";
-import { useProposalApproveBlock, useSlotBlock } from "@/hooks/use-warnings";
+import { useProposalApproveBlock } from "@/hooks/use-warnings";
 import { isNearComPaymentRoute } from "@/lib/intents-network";
 import Big from "@/lib/big";
 import { getApproversAndThreshold } from "@/lib/config-utils";
 import type { Proposal } from "@/lib/proposals-api";
 import { cn, getIntentsExplorerUrl, nanosToMs } from "@/lib/utils";
-import { stripMessageForTooltip } from "@/lib/warnings";
 import { useNear } from "@/stores/near-store";
 import type { Policy } from "@/types/policy";
 import { NotEnoughBalance } from "../../not-enough-balance";
+import { useVoteActionSlots } from "@/features/proposals/hooks/use-vote-action-slots";
 import { UserVote } from "../../user-vote";
 import { VotingDurationImpactModal } from "../../voting-duration-impact-modal";
 
@@ -285,24 +285,11 @@ export function ProposalSidebar({
     const approveBlock = useProposalApproveBlock([proposal]);
     const approveBlocked = approveBlock.anyBlocked;
     const approveBlockedWarning = approveBlock.blockedWarnings[0] ?? null;
-    // Approve and reject are independent slots, so ops can pause approving while
-    // rejection keeps working (approvals_paused) — or pause everything.
-    const approveSlot = useSlotBlock("action.approve");
-    const rejectSlot = useSlotBlock("action.reject");
-    // One banner covers the vote actions: the approve copy already explains
-    // rejection still works, so it takes precedence; reject is the fallback.
-    const voteBannerSlot = approveSlot.blocked
-        ? "action.approve"
-        : rejectSlot.blocked
-          ? "action.reject"
-          : null;
-    // A slot warning is shown inline via <SlotWarning>, so a button tooltip is
-    // only the fallback for an app-wide block (nothing in the sidebar explains
-    // why the button is disabled).
-    const approveBlockIsAppLevel =
-        approveSlot.blocked && approveSlot.warning?.slot !== "action.approve";
-    const rejectBlockIsAppLevel =
-        rejectSlot.blocked && rejectSlot.warning?.slot !== "action.reject";
+    const {
+        approve: approveSlot,
+        reject: rejectSlot,
+        voteBannerSlot,
+    } = useVoteActionSlots();
     const isPending = status === "Pending";
     const isExecuted = status === "Executed";
     const isExchangeProposal = proposalType === "Exchange";
@@ -682,8 +669,8 @@ export function ProposalSidebar({
                         onClick={() => onVote("Reject")}
                         disabled={isUserVoter || rejectSlot.blocked}
                         tooltip={
-                            rejectBlockIsAppLevel
-                                ? stripMessageForTooltip(rejectSlot.message)
+                            rejectSlot.inlineTooltip
+                                ? rejectSlot.inlineTooltip
                                 : isUserVoter
                                   ? noVoteMessage
                                   : undefined
@@ -724,10 +711,8 @@ export function ProposalSidebar({
                                 insufficientBalanceInfo.hasInsufficientBalance
                             }
                             tooltip={
-                                approveBlockIsAppLevel
-                                    ? stripMessageForTooltip(
-                                          approveSlot.message,
-                                      )
+                                approveSlot.inlineTooltip
+                                    ? approveSlot.inlineTooltip
                                     : isUserVoter
                                       ? noVoteMessage
                                       : undefined

--- a/nt-fe/features/proposals/components/pending-requests/index.tsx
+++ b/nt-fe/features/proposals/components/pending-requests/index.tsx
@@ -7,8 +7,7 @@ import {
 import { PageCard } from "@/components/card";
 import { NumberBadge } from "@/components/number-badge";
 import { SlotWarning } from "@/components/warning-message";
-import { useProposalApproveBlock, useSlotBlock } from "@/hooks/use-warnings";
-import { stripMessageForTooltip } from "@/lib/warnings";
+import { useProposalApproveBlock } from "@/hooks/use-warnings";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useProposals } from "@/hooks/use-proposals";
 import { Proposal } from "@/lib/proposals-api";
@@ -21,6 +20,7 @@ import { TransactionCell } from "../transaction-cell";
 import { getProposalUIKind } from "../../utils/proposal-utils";
 import { useProposalKindLabel } from "../../hooks/use-proposal-kind-label";
 import { useProposalInsufficientBalance } from "../../hooks/use-proposal-insufficient-balance";
+import { useVoteActionSlots } from "../../hooks/use-vote-action-slots";
 import { VoteModal } from "../vote-modal";
 import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
@@ -97,21 +97,11 @@ export function PendingRequestItem({
     const approveBlock = useProposalApproveBlock([proposal]);
     const approveBlocked = approveBlock.anyBlocked;
     const approveBlockedWarning = approveBlock.blockedWarnings[0] ?? null;
-    // Approve and reject are independent slots (same pattern as proposal sidebar).
-    const approveSlot = useSlotBlock("action.approve");
-    const rejectSlot = useSlotBlock("action.reject");
-    // One banner covers the vote actions: approve copy takes precedence.
-    const voteBannerSlot = approveSlot.blocked
-        ? "action.approve"
-        : rejectSlot.blocked
-          ? "action.reject"
-          : null;
-    // SlotWarning is shown inline, so a button tooltip is only the fallback for
-    // an app-wide block (nothing on the card explains why the button is disabled).
-    const approveBlockIsAppLevel =
-        approveSlot.blocked && approveSlot.warning?.slot !== "action.approve";
-    const rejectBlockIsAppLevel =
-        rejectSlot.blocked && rejectSlot.warning?.slot !== "action.reject";
+    const {
+        approve: approveSlot,
+        reject: rejectSlot,
+        voteBannerSlot,
+    } = useVoteActionSlots();
     const title = useMemo(() => {
         if (type === "Confidential Request") {
             return extractConfidentialRequestData(proposal, treasuryId).title;
@@ -177,10 +167,8 @@ export function PendingRequestItem({
                                     }}
                                     disabled={isUserVoter || rejectSlot.blocked}
                                     tooltip={
-                                        rejectBlockIsAppLevel
-                                            ? stripMessageForTooltip(
-                                                  rejectSlot.message,
-                                              )
+                                        rejectSlot.inlineTooltip
+                                            ? rejectSlot.inlineTooltip
                                             : isUserVoter
                                               ? noVoteMessage
                                               : undefined
@@ -225,10 +213,8 @@ export function PendingRequestItem({
                                             insufficientBalanceInfo.hasInsufficientBalance
                                         }
                                         tooltip={
-                                            approveBlockIsAppLevel
-                                                ? stripMessageForTooltip(
-                                                      approveSlot.message,
-                                                  )
+                                            approveSlot.inlineTooltip
+                                                ? approveSlot.inlineTooltip
                                                 : isUserVoter
                                                   ? noVoteMessage
                                                   : undefined

--- a/nt-fe/features/proposals/components/proposals-table.tsx
+++ b/nt-fe/features/proposals/components/proposals-table.tsx
@@ -71,6 +71,7 @@ import {
 } from "@/features/proposals/utils/receipt-utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { useVoteActionSlots } from "@/features/proposals/hooks/use-vote-action-slots";
 
 const columnHelper = createColumnHelper<Proposal>();
 
@@ -172,6 +173,9 @@ export function ProposalsTable({
     const { treasuryId } = useTreasury();
     const { isMobile } = useResponsiveSidebar();
     const router = useRouter();
+    // Global action.approve / action.reject pause all requests — disable bulk
+    // CTAs instead of opening the vote modal only to show the warning.
+    const { approve: approveSlot, reject: rejectSlot } = useVoteActionSlots();
     const columns = useMemo<ColumnDef<Proposal, any>[]>(
         () => [
             columnHelper.display({
@@ -533,6 +537,8 @@ export function ProposalsTable({
                             <Button
                                 variant="secondary"
                                 onClick={() => handleBulkVote("Reject")}
+                                disabled={rejectSlot.blocked}
+                                tooltipContent={rejectSlot.blockedTooltip}
                             >
                                 <X className="h-4 w-4" />
                                 {tCommon("reject")}
@@ -541,12 +547,16 @@ export function ProposalsTable({
                             <Button
                                 variant="default"
                                 tooltipContent={
-                                    allSelectedHaveInsufficientBalance
+                                    approveSlot.blockedTooltip ??
+                                    (allSelectedHaveInsufficientBalance
                                         ? tT("bulkApproveDisabled")
-                                        : undefined
+                                        : undefined)
                                 }
                                 onClick={() => handleBulkVote("Approve")}
-                                disabled={allSelectedHaveInsufficientBalance}
+                                disabled={
+                                    allSelectedHaveInsufficientBalance ||
+                                    approveSlot.blocked
+                                }
                             >
                                 <Check className="h-4 w-4" />
                                 {tCommon("approve")}

--- a/nt-fe/features/proposals/components/vote-modal.tsx
+++ b/nt-fe/features/proposals/components/vote-modal.tsx
@@ -17,6 +17,7 @@ import { useTreasury } from "@/hooks/use-treasury";
 import { useProposalApproveBlock, useSlotBlock } from "@/hooks/use-warnings";
 import type { Proposal } from "@/lib/proposals-api";
 import { stripMessageForTooltip } from "@/lib/warnings";
+import { isAppLevelSlotBlock } from "@/features/proposals/hooks/use-vote-action-slots";
 import { useNear } from "@/stores/near-store";
 
 interface VoteModalProps {
@@ -51,8 +52,11 @@ export function VoteModal({
     // The slot warning is already shown inline via <SlotWarning>, so the button
     // tooltip is only the fallback for an app-wide block (nothing visible in the
     // modal explains why the button is disabled).
-    const voteBlockIsAppLevel =
-        voteSlotBlocked && voteWarning?.slot !== voteSlot;
+    const voteBlockIsAppLevel = isAppLevelSlotBlock(
+        voteSlot,
+        voteSlotBlocked,
+        voteWarning,
+    );
     const approveBlock = useProposalApproveBlock(proposals);
     const [isSubmitting, setIsSubmitting] = useState(false);
 

--- a/nt-fe/features/proposals/hooks/use-vote-action-slots.ts
+++ b/nt-fe/features/proposals/hooks/use-vote-action-slots.ts
@@ -1,0 +1,73 @@
+import { useSlotBlock, type Warning } from "@/hooks/use-warnings";
+import { stripMessageForTooltip } from "@/lib/warnings";
+
+export type VoteActionSlot = "action.approve" | "action.reject";
+
+export interface VoteActionSlotState {
+    blocked: boolean;
+    message: string | null;
+    warning: Warning | null;
+    /** True when the block comes from an app-level pause, not this vote slot. */
+    isAppLevel: boolean;
+    /**
+     * Tooltip for buttons that already show `<SlotWarning>` nearby — only
+     * needed for app-level blocks (nothing else explains the disable).
+     */
+    inlineTooltip?: string;
+    /**
+     * Tooltip for CTAs with no nearby banner (e.g. bulk approve/reject bar).
+     */
+    blockedTooltip?: string;
+}
+
+export interface VoteActionSlots {
+    approve: VoteActionSlotState;
+    reject: VoteActionSlotState;
+    /** Single banner slot covering vote actions; approve takes precedence. */
+    voteBannerSlot: VoteActionSlot | null;
+}
+
+/** App-level pause blocks the slot even when the slot itself has no warning. */
+export function isAppLevelSlotBlock(
+    slot: string,
+    blocked: boolean,
+    warning: Warning | null | undefined,
+): boolean {
+    return blocked && warning?.slot !== slot;
+}
+
+function toVoteActionSlotState(
+    slot: VoteActionSlot,
+    block: ReturnType<typeof useSlotBlock>,
+): VoteActionSlotState {
+    const isAppLevel = isAppLevelSlotBlock(slot, block.blocked, block.warning);
+    const stripped = stripMessageForTooltip(block.message) || undefined;
+
+    return {
+        blocked: block.blocked,
+        message: block.message,
+        warning: block.warning,
+        isAppLevel,
+        inlineTooltip: isAppLevel ? stripped : undefined,
+        blockedTooltip: block.blocked ? stripped : undefined,
+    };
+}
+
+/**
+ * Shared approve/reject pause state for pending cards, sidebar, and bulk bar.
+ */
+export function useVoteActionSlots(): VoteActionSlots {
+    const approveBlock = useSlotBlock("action.approve");
+    const rejectBlock = useSlotBlock("action.reject");
+
+    const approve = toVoteActionSlotState("action.approve", approveBlock);
+    const reject = toVoteActionSlotState("action.reject", rejectBlock);
+
+    const voteBannerSlot: VoteActionSlot | null = approve.blocked
+        ? "action.approve"
+        : reject.blocked
+          ? "action.reject"
+          : null;
+
+    return { approve, reject, voteBannerSlot };
+}

--- a/nt-fe/hooks/use-treasury.ts
+++ b/nt-fe/hooks/use-treasury.ts
@@ -40,9 +40,15 @@ export function useTreasury() {
         useTreasuryConfig(shouldLoadGuestConfig ? treasuryId : null);
 
     // A treasury can be in the list because user saved it, but still be a guest.
+    // Logged-out viewers are always guests. While guest config is loading after
+    // logout/cache clear, treat as guest so member-only UI/API paths don't flash.
     const isGuestTreasury =
         !!treasuryId &&
-        (currentTreasury ? !currentTreasury.isMember : !!guestTreasuryConfig);
+        (currentTreasury
+            ? !currentTreasury.isMember
+            : !accountId ||
+              !!guestTreasuryConfig ||
+              (shouldLoadGuestConfig && isLoadingGuestConfig));
     const isLoading =
         isInitializing ||
         (accountId ? isLoadingTreasuries : false) ||

--- a/nt-fe/lib/utils.ts
+++ b/nt-fe/lib/utils.ts
@@ -343,7 +343,7 @@ export function formatUserDate(
         }
 
         const formatter = new Intl.DateTimeFormat("en-US", formatOptions);
-        return formatter.format(dateObj).replace("GMT", "UTC");
+        return normalizeUtcTimezoneLabel(formatter.format(dateObj));
     } catch (error) {
         console.error("Error formatting date with Intl:", error);
 
@@ -361,7 +361,7 @@ export function formatUserDate(
             const offsetHours = Math.abs(Math.floor(timezoneOffset / 60));
             const offsetMinutes = Math.abs(timezoneOffset % 60);
 
-            let timezoneStr = "UTC";
+            let timezoneStr = "UTC+00:00";
             if (timezoneOffset !== 0) {
                 const sign = timezoneOffset > 0 ? "-" : "+";
                 timezoneStr = `UTC${sign}${offsetHours}${offsetMinutes > 0 ? `:${offsetMinutes.toString().padStart(2, "0")}` : ""}`;
@@ -369,9 +369,15 @@ export function formatUserDate(
             formattedDate += ` ${timezoneStr}`;
         }
 
-        // return formattedDate;
-        return dateObj.toUTCString().replace("GMT", "UTC");
+        return formattedDate;
     }
+}
+
+/** Prefer UTC+00:00 over bare GMT/UTC so zero-offset times show an explicit offset. */
+function normalizeUtcTimezoneLabel(formatted: string): string {
+    return formatted
+        .replace("GMT", "UTC")
+        .replace(/\bUTC\b(?![+-])/, "UTC+00:00");
 }
 
 export function formatGas(gas: string): string {

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, one {Investor} other {Investoren}}",
         "poolBreakdown": "Pool-Aufschlüsselung",
         "unlockedToken": "Entsperrtes Token",
+        "lockedToken": "Gesperrtes Token",
         "lockupStakingPool": "Lockup-Staking-Pool",
         "exchange": "Tauschen",
         "send": "Senden",

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, one {Investor} other {Investors}}",
         "poolBreakdown": "Pool Breakdown",
         "unlockedToken": "Unlocked Token",
+        "lockedToken": "Locked Token",
         "lockupStakingPool": "Lockup staking pool",
         "exchange": "Exchange",
         "send": "Send",

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, one {Inversor} other {Inversores}}",
         "poolBreakdown": "Desglose por pool",
         "unlockedToken": "Token desbloqueado",
+        "lockedToken": "Token bloqueado",
         "lockupStakingPool": "Pool de staking del lockup",
         "exchange": "Intercambiar",
         "send": "Enviar",

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, one {Investisseur} other {Investisseurs}}",
         "poolBreakdown": "Détail du pool",
         "unlockedToken": "Token déverrouillé",
+        "lockedToken": "Token verrouillé",
         "lockupStakingPool": "Pool de staking de lockup",
         "exchange": "Échanger",
         "send": "Envoyer",

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, one {משקיע} two {משקיעים} many {משקיעים} other {משקיעים}}",
         "poolBreakdown": "פירוט מאגר",
         "unlockedToken": "טוקן לא נעול",
+        "lockedToken": "טוקן נעול",
         "lockupStakingPool": "מאגר סטייקינג של נעילה",
         "exchange": "החלפה",
         "send": "שליחה",

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, other {Investor}}",
         "poolBreakdown": "Rincian Pool",
         "unlockedToken": "Token Tidak Terkunci",
+        "lockedToken": "Token Terkunci",
         "lockupStakingPool": "Pool staking lockup",
         "exchange": "Tukar",
         "send": "Kirim",

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, other {投資家}}",
         "poolBreakdown": "プール内訳",
         "unlockedToken": "アンロック済みトークン",
+        "lockedToken": "ロック済みトークン",
         "lockupStakingPool": "ロックアップステーキングプール",
         "exchange": "交換",
         "send": "送金",

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, other {투자자}}",
         "poolBreakdown": "풀 세부 내역",
         "unlockedToken": "잠금 해제된 토큰",
+        "lockedToken": "잠긴 토큰",
         "lockupStakingPool": "락업 스테이킹 풀",
         "exchange": "교환",
         "send": "보내기",

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, one {Investidor} other {Investidores}}",
         "poolBreakdown": "Detalhamento do pool",
         "unlockedToken": "Token desbloqueado",
+        "lockedToken": "Token bloqueado",
         "lockupStakingPool": "Pool de staking de lockup",
         "exchange": "Trocar",
         "send": "Enviar",

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -2054,6 +2054,7 @@
         "investors": "{count, plural, one {Yatırımcı} other {Yatırımcılar}}",
         "poolBreakdown": "Havuz Dökümü",
         "unlockedToken": "Kilitsiz Token",
+        "lockedToken": "Kilitli Token",
         "lockupStakingPool": "Lockup staking havuzu",
         "exchange": "Takas",
         "send": "Gönder",

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -2037,6 +2037,7 @@
         "investors": "{count, plural, one {Інвестор} few {Інвестори} many {Інвесторів} other {Інвесторів}}",
         "poolBreakdown": "Розбивка за пулами",
         "unlockedToken": "Розблокований токен",
+        "lockedToken": "Заблокований токен",
         "lockupStakingPool": "Пул стейкінгу лок-апу",
         "exchange": "Обміняти",
         "send": "Надіслати",

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -2037,6 +2037,7 @@
         "investors": "{count, plural, other {Nhà đầu tư}}",
         "poolBreakdown": "Phân tích Pool",
         "unlockedToken": "Token đã mở khóa",
+        "lockedToken": "Token đã khóa",
         "lockupStakingPool": "Pool staking lockup",
         "exchange": "Trao đổi",
         "send": "Gửi",

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -2037,6 +2037,7 @@
         "investors": "{count, plural, other {投资者}}",
         "poolBreakdown": "矿池明细",
         "unlockedToken": "已解锁代币",
+        "lockedToken": "已锁定代币",
         "lockupStakingPool": "锁仓质押池",
         "exchange": "兑换",
         "send": "发送",


### PR DESCRIPTION
- Clear deposit network/address after logout on confidential treasuries, and don’t keep calling authenticated deposit APIs #1062
- Make Offline wallet badge tooltip hoverable
- Stop expand/long token names from shifting balance/price columns #1078
- Add reusable `ScrollContainer` and use it in dropdowns/modals/lists for consistent scrollbars #1086
- Update UTC to UTC+00:00 #953
- Disable bulk approve/reject when vote actions are paused #1015 

**Warnings admin**
- Stop silent overwrite on duplicate warning slots; return conflict with `existingId` and offer edit #1082
- Make delete idempotent and prevent double-delete races in the admin UI #1083
- Keep custom copy on standalone login situation edits #1081

**Status monitor**
- Only treat Oh Dear `warning` as an incident for `near-intents`; other service warnings no longer page Telegram
