### PR TITLE
bulk activation: don't block the payment form when the monitored flag/row lags

### DIFF
--- a/nt-be/src/handlers/intents/confidential/bulk_activation.rs
+++ b/nt-be/src/handlers/intents/confidential/bulk_activation.rs
@@ -79,15 +79,23 @@ fn parse_dao_id(dao_id: &str) -> Result<AccountId, (StatusCode, String)> {
     })
 }
 
-/// Confirms the account is a monitored confidential treasury; returns
-/// whether the bulk-payment JWT is already stored.
+/// Whether the bulk-payment JWT is already stored for this treasury (i.e. bulk
+/// payments are active).
+///
+/// Keyed only on the token's presence. It deliberately does NOT require the
+/// monitored row to exist or `is_confidential_account` to be set: those lag
+/// behind (a freshly created treasury may not be flagged/synced yet, or the
+/// creation-time bulk setup stored the token before the flag was set), and
+/// hard-erroring there made the status endpoint 4xx and blocked the bulk
+/// payment form even when activation had actually completed. The caller
+/// already gates on confidential membership.
 async fn load_bulk_token_state(
     state: &AppState,
     dao_id: &str,
 ) -> Result<bool, (StatusCode, String)> {
-    let row: Option<(bool, Option<String>)> = sqlx::query_as(
+    let token: Option<Option<String>> = sqlx::query_scalar(
         r#"
-        SELECT is_confidential_account, bulk_payment_access_token
+        SELECT bulk_payment_access_token
         FROM monitored_accounts
         WHERE account_id = $1
         "#,
@@ -102,17 +110,7 @@ async fn load_bulk_token_state(
         )
     })?;
 
-    match row {
-        Some((true, token)) => Ok(token.is_some()),
-        Some((false, _)) => Err((
-            StatusCode::BAD_REQUEST,
-            format!("{} is not a confidential treasury", dao_id),
-        )),
-        None => Err((
-            StatusCode::NOT_FOUND,
-            format!("Treasury {} not found", dao_id),
-        )),
-    }
+    Ok(token.flatten().is_some())
 }
 
 /// Whether the activation proposal for `payload_hash` still exists on-chain


### PR DESCRIPTION
Follow-up after #1095 merged: bulk payments were still blocked for confidential treasuries that are actually activated (freshly created with bulk provisioned, or old ones whose activation proposal was approved).

## Cause
`load_bulk_token_state` (which drives status `active`) **hard-errored** — `400 "not a confidential treasury"` when `monitored_accounts.is_confidential_account` wasn't set, or `404 "not found"` when the monitored row didn't exist yet. Those lag behind reality (a freshly created treasury isn't synced/flagged immediately; creation-time bulk setup can store the token before the flag is set). The error propagated out of the status endpoint as a 4xx, the frontend's `getBulkActivationStatus` threw, and the card rendered its **error state** — blocking the bulk payment form even though activation had completed and the JWT was stored.

## Fix
Bulk payments are active **iff** `bulk_payment_access_token` is present — so key the check purely on that. A missing row / unset flag now means "not active yet" (→ the activation flow), never a hard error. The caller already gates on confidential membership (`verify_member_if_confidential`).

## Note
If a treasury is still blocked after this, the JWT itself isn't being stored (relay/creation auth issue) — please check `monitored_accounts.bulk_payment_access_token` for a blocked DAO so we can chase the write side. This change removes the false block; it can't conjure a token that was never written.

## Verification
`cargo clippy --lib --bins -- -D warnings` + `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
