### PR TITLE
bulk activation: fix the subaccount auth signing path (JWT was never issued)

### DIFF
--- a/nt-be/src/handlers/intents/confidential/bulk_activation.rs
+++ b/nt-be/src/handlers/intents/confidential/bulk_activation.rs
@@ -261,7 +261,7 @@ pub async fn prepare_bulk_activation(
 
     // 2. Build the auth proposal the multisig must approve.
     let (proposal, auth_payload) =
-        build_bulk_payment_auth_proposal(&state, sub_id.as_str()).await?;
+        build_bulk_payment_auth_proposal(&state, sub_id.as_str(), dao_id.as_str()).await?;
     let payload_hash = compute_nep413_hash(&auth_payload).ok_or_else(|| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/nt-be/src/handlers/intents/confidential/prepare_auth.rs
+++ b/nt-be/src/handlers/intents/confidential/prepare_auth.rs
@@ -187,15 +187,20 @@ pub(crate) async fn build_auth_proposal(
 }
 
 /// Thin wrapper: build an auth proposal for the DAO's bulk-payment subaccount.
-/// DAO signs as proposal predecessor (path = "") while the JWT is issued for the sub.
+/// The JWT is issued for the sub (`signer_id`), but the multisig signs with the
+/// DAO's own key — `path = dao_id`, the same key `bootstrap` registered under
+/// the sub on intents.near. (Signing with `path = ""` derives a different key
+/// that isn't registered for the sub, so 1Click rejects the auth and no JWT is
+/// stored — the bug this fixes.)
 pub(crate) async fn build_bulk_payment_auth_proposal(
     state: &Arc<AppState>,
     bulk_sub_id: &str,
+    dao_id: &str,
 ) -> Result<(serde_json::Value, serde_json::Value), (StatusCode, String)> {
     build_auth_proposal_with_signer(
         state,
         bulk_sub_id,
-        "",
+        dao_id,
         "Authenticate bulk-payment subaccount for confidential intents",
     )
     .await

--- a/nt-be/src/handlers/relay/confidential.rs
+++ b/nt-be/src/handlers/relay/confidential.rs
@@ -437,16 +437,13 @@ pub async fn try_auto_submit_intent(
         }
     };
 
-    // Fetch the DAO's derived MPC public key from v1.signer. Bulk-payment
-    // auth proposals sign with an empty path (the JWT is issued for the
-    // subaccount; the DAO signs as predecessor); everything else uses the
-    // DAO self path.
-    let mpc_path = if intent_type == "bulk_auth" {
-        ""
-    } else {
-        treasury_id
-    };
-    let mpc_public_key = match fetch_mpc_public_key(state, treasury_id, mpc_path).await {
+    // Fetch the DAO's derived MPC public key from v1.signer. Both `auth` and
+    // `bulk_auth` sign with the DAO self path (`dao_id`): that's the key
+    // `bootstrap` registered under the bulk subaccount on intents.near, so it's
+    // the one 1Click must verify against — the JWT is still issued for the sub
+    // via the auth message's `signer_id`. (Fetching the empty-path key here
+    // gave 1Click the wrong key and the bulk JWT was never issued/stored.)
+    let mpc_public_key = match fetch_mpc_public_key(state, treasury_id, treasury_id).await {
         Ok(key) => key,
         Err(e) => {
             tracing::error!(

--- a/nt-be/src/handlers/treasury/confidential_setup.rs
+++ b/nt-be/src/handlers/treasury/confidential_setup.rs
@@ -372,9 +372,10 @@ async fn setup_bulk_payment_subaccount(
 ) -> Result<(), (StatusCode, String)> {
     let (sub_id, dao_mpc_public_key) = ensure_bulk_subaccount(state, treasury_id).await?;
 
-    // 3. Build + submit auth proposal (DAO signs, JWT issued for sub).
+    // 3. Build + submit auth proposal (DAO signs with its own key/path, JWT
+    //    issued for sub).
     let (auth_proposal, auth_payload) =
-        build_bulk_payment_auth_proposal(state, sub_id.as_str()).await?;
+        build_bulk_payment_auth_proposal(state, sub_id.as_str(), treasury_id.as_str()).await?;
 
     let (proposal_id, vote_result_debug) =
         submit_and_approve_proposal(state, treasury_id, auth_proposal).await?;


### PR DESCRIPTION
## Root cause (confirmed: `bulk_payment_access_token` NULL even after approval)
The bulk-payment subaccount's 1Click authentication was signing with the **wrong key**, so 1Click rejected it and no JWT was ever issued/stored — on **both** paths (creation-time provisioning and the manual activation proposal). That's why freshly created *and* approved-activation treasuries stayed blocked.

`bootstrap` registers the DAO's own MPC key — `derive(dao, dao_id)` — under the `<prefix>.bulkpayment.near` subaccount on intents.near (the same key the DAO uses for its own confidential auth). But:
- `build_bulk_payment_auth_proposal` signed the `v1.signer` request with `path = ""` → `derive(dao, "")`, a key **not** registered for the sub.
- the vote relay fetched the empty-path MPC key to hand to 1Click for `bulk_auth`.

So the signature/public-key didn't match what intents.near/1Click expected → auth failed → the token-store `if let Some(accessToken)…` was skipped → column stayed NULL.

## Fix
Sign the bulk auth with `path = dao_id` (the JWT is still issued for the sub via the auth message's `signer_id`), and have the relay fetch the DAO-path MPC key for `bulk_auth` too. This matches the flow already documented in `ensure_bulk_subaccount` ("path=<dao_id> … valid for <sub> because bootstrap registered the DAO's pubkey under <sub>").

Touches `build_bulk_payment_auth_proposal` + its two callers (prepare, creation setup) and the relay's `mpc_path`.

## Note
Existing treasuries stuck with a NULL token just need to re-run activation (Start activation → approve) after this ships — the retry now authenticates with the correct key. Complements #1097 (which stopped the status endpoint from falsely blocking the form).

## Verification
`cargo clippy --lib --bins -- -D warnings` + `cargo fmt` clean. (End-to-end auth is validated by the bulk-payment E2E, which exercises the sandbox activation path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
