### PR TITLE
Fix AURORA symbol override and post-approval execution timestamp N/A

### DIFF
--- a/nt-be/src/constants/intents_tokens.rs
+++ b/nt-be/src/constants/intents_tokens.rs
@@ -108,7 +108,11 @@ pub fn get_defuse_tokens_map() -> &'static HashMap<String, BaseTokenInfo> {
         let mut map = HashMap::new();
         for unified_token in tokens {
             for base_token in unified_token.grouped_tokens {
-                map.insert(base_token.defuse_asset_id.clone(), base_token);
+                // or_insert so unified tokens (processed first) take priority
+                // over synthetic standalone duplicates (e.g. "AURORA" wins over
+                // "AURORA (omni)" when both share the same defuseAssetId).
+                map.entry(base_token.defuse_asset_id.clone())
+                    .or_insert(base_token);
             }
         }
         map

--- a/nt-be/src/handlers/token/metadata.rs
+++ b/nt-be/src/handlers/token/metadata.rs
@@ -18,6 +18,7 @@ use crate::{
         intents_chains::{ChainIcons, get_chain_metadata_by_name},
         intents_tokens::{
             find_token_by_defuse_asset_id, find_token_by_defuse_asset_id_and_address,
+            find_unified_asset_id, get_tokens_map,
         },
     },
     utils::cache::{Cache, CacheKey, CacheTier},
@@ -481,6 +482,36 @@ pub fn metadata_lookup_candidates(token_id: &str) -> Vec<String> {
     build_metadata_lookup_candidates(token_id).all
 }
 
+/// Prefer the unified asset's display symbol/name/icon when a defuse id maps to
+/// a real unified group. Standalone catalog duplicates (e.g. `AURORA (omni)`)
+/// share the same defuseAssetId but should not win for user-facing labels.
+fn apply_unified_display_override(meta: &mut TokenMetadata) {
+    let stripped = meta
+        .token_id
+        .strip_prefix("intents.near:")
+        .unwrap_or(meta.token_id.as_str());
+    let with_nep141 = if stripped.starts_with("nep141:") || stripped.starts_with("nep245:") {
+        stripped.to_string()
+    } else {
+        format!("nep141:{stripped}")
+    };
+
+    for defuse_id in [stripped, with_nep141.as_str()] {
+        let Some(unified_id) = find_unified_asset_id(defuse_id) else {
+            continue;
+        };
+        let Some(unified) = get_tokens_map().get(&unified_id.to_lowercase()) else {
+            continue;
+        };
+        meta.symbol = unified.symbol.clone();
+        meta.name = unified.name.clone();
+        if meta.icon.is_none() {
+            meta.icon = Some(unified.icon.clone());
+        }
+        return;
+    }
+}
+
 fn tokens_json_metadata_for_defuse(
     defuse_id: &str,
     address_candidates: &[String],
@@ -530,7 +561,7 @@ fn tokens_json_metadata_for_defuse(
     };
     let selected_chain = deployment_chain_name.unwrap_or_else(|| token.origin_chain_name.clone());
     let chain_metadata = get_chain_metadata_by_name(&selected_chain);
-    Some(TokenMetadata {
+    let mut meta = TokenMetadata {
         token_id: output_token_id.to_string(),
         name: token.name.clone(),
         symbol: token.symbol.clone(),
@@ -541,13 +572,15 @@ fn tokens_json_metadata_for_defuse(
         network: Some(selected_chain),
         chain_name: chain_metadata.as_ref().map(|m| m.name.clone()),
         chain_icons: chain_metadata.map(|m| m.icon),
-    })
+    };
+    apply_unified_display_override(&mut meta);
+    Some(meta)
 }
 
 fn chaindefuser_item_to_metadata(item: &ChaindefuserToken, output_token_id: &str) -> TokenMetadata {
     let static_token = find_token_by_defuse_asset_id(&item.defuse_asset_id);
     let chain_metadata = get_chain_metadata_by_name(&item.blockchain);
-    TokenMetadata {
+    let mut meta = TokenMetadata {
         token_id: output_token_id.to_string(),
         name: static_token
             .map(|t| t.name.clone())
@@ -563,7 +596,9 @@ fn chaindefuser_item_to_metadata(item: &ChaindefuserToken, output_token_id: &str
             .map(|m| m.name.clone())
             .or(Some(item.blockchain.clone())),
         chain_icons: chain_metadata.map(|m| m.icon),
-    }
+    };
+    apply_unified_display_override(&mut meta);
+    meta
 }
 
 fn merge_missing_fields(into: &mut TokenMetadata, from: &TokenMetadata) {
@@ -796,6 +831,7 @@ pub async fn fetch_tokens_with_fallback(
         }
 
         if let Some(mut meta) = metadata {
+            apply_unified_display_override(&mut meta);
             meta.apply_near_symbol_name_override();
             result.insert(token_id, meta);
         } else {
@@ -1045,7 +1081,8 @@ pub async fn search_token_by_symbol(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_metadata_lookup_candidates, metadata_lookup_candidates, nearblocks_lookup_candidate,
+        TokenMetadata, apply_unified_display_override, build_metadata_lookup_candidates,
+        find_token_by_defuse_asset_id, metadata_lookup_candidates, nearblocks_lookup_candidate,
         tokens_json_metadata_for_defuse,
     };
 
@@ -1121,6 +1158,43 @@ mod tests {
         let resolved = tokens_json_metadata_for_defuse(defuse_id, &near_contract, defuse_id)
             .expect("expected token resolution from tokens.json");
         assert_eq!(resolved.network.as_deref(), Some("near"));
+        assert_eq!(
+            resolved.symbol, "AURORA",
+            "near deployment must resolve to unified AURORA, not standalone AURORA (omni)"
+        );
+    }
+
+    #[test]
+    fn unified_display_override_replaces_omni_duplicate_symbol() {
+        let mut meta = TokenMetadata {
+            token_id:
+                "intents.near:nep141:aaaaaa20d9e0e2461697782ef11675f668207961.factory.bridge.near"
+                    .to_string(),
+            name: "Aurora".to_string(),
+            symbol: "AURORA (omni)".to_string(),
+            decimals: 18,
+            icon: None,
+            price: None,
+            price_updated_at: None,
+            network: Some("near".to_string()),
+            chain_name: Some("NEAR".to_string()),
+            chain_icons: None,
+        };
+        apply_unified_display_override(&mut meta);
+        assert_eq!(meta.symbol, "AURORA");
+        assert_eq!(meta.name, "Aurora");
+    }
+
+    #[test]
+    fn defuse_tokens_map_prefers_unified_aurora_over_omni_duplicate() {
+        let token = find_token_by_defuse_asset_id(
+            "nep141:aaaaaa20d9e0e2461697782ef11675f668207961.factory.bridge.near",
+        )
+        .expect("expected aurora defuse entry");
+        assert_eq!(
+            token.symbol, "AURORA",
+            "get_defuse_tokens_map must keep unified AURORA over standalone AURORA (omni)"
+        );
     }
 
     #[test]

--- a/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
@@ -33,10 +33,8 @@ import {
 import { extractProposalData } from "@/features/proposals/utils/proposal-extractors";
 import {
     extractReceiptProposalData,
-    getProposalExecutedDate,
-    isExecutionTimestampPending,
     isReceiptEligibleProposalKind,
-    isTerminalSwapStatus,
+    resolveExecutionTimestamp,
 } from "@/features/proposals/utils/receipt-utils";
 import { NetworkIconDisplay } from "@/components/token-display";
 import {
@@ -762,7 +760,17 @@ export default function RequestReceiptPage({
         !shouldUseSwapExecutionDate ||
         (!isConfidential && isGuestTreasury) ||
         swapStatus?.status === "SUCCESS";
-    const transactionDate = getProposalExecutedDate(swapStatus, transaction);
+    const {
+        executedDate: transactionDate,
+        isDateLoading: resolvedTransactionDateLoading,
+    } = resolveExecutionTimestamp({
+        swapStatus,
+        transaction,
+        shouldUseSwapDate: shouldUseSwapExecutionDate,
+        isLoadingSwapStatus,
+        isLoadingTransaction,
+        isAwaitingTransaction,
+    });
     const isExchangeProposal = receiptProposalVariant === "exchange";
     const hasDepositAddress = !!depositAddress;
     const isNearComDestination = isNearComPaymentRoute({
@@ -930,25 +938,10 @@ export default function RequestReceiptPage({
             destinationToken?.symbol,
         ],
     );
-    const isAwaitingSwapDate =
-        shouldUseSwapExecutionDate &&
-        !swapStatus?.updatedAt &&
-        !isTerminalSwapStatus(swapStatus?.status);
-    const isTransactionDateLoading = isExecutionTimestampPending({
-        executedDate: transactionDate,
-        isQueryLoading:
-            isExecutableReceipt &&
-            isSingleReceiptProposal &&
-            (shouldUseSwapExecutionDate
-                ? isLoadingSwapStatus
-                : isLoadingTransaction),
-        isAwaitingResolution:
-            isExecutableReceipt &&
-            isSingleReceiptProposal &&
-            (shouldUseSwapExecutionDate
-                ? isAwaitingSwapDate
-                : isAwaitingTransaction),
-    });
+    const isTransactionDateLoading =
+        isExecutableReceipt &&
+        isSingleReceiptProposal &&
+        resolvedTransactionDateLoading;
     const isRateLoading = hasDepositAddress
         ? isSingleReceiptProposal &&
           !isConfidentialRequestProposal &&

--- a/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/requests/[id]/receipt/page.tsx
@@ -34,7 +34,9 @@ import { extractProposalData } from "@/features/proposals/utils/proposal-extract
 import {
     extractReceiptProposalData,
     getProposalExecutedDate,
+    isExecutionTimestampPending,
     isReceiptEligibleProposalKind,
+    isTerminalSwapStatus,
 } from "@/features/proposals/utils/receipt-utils";
 import { NetworkIconDisplay } from "@/components/token-display";
 import {
@@ -736,13 +738,16 @@ export default function RequestReceiptPage({
     const isExecutableReceipt = status === "Executed";
     const shouldUseSwapExecutionDate = isExecutableReceipt && !!depositAddress;
 
-    const { data: transaction, isLoading: isLoadingTransaction } =
-        useProposalTransaction(
-            treasuryId,
-            proposal,
-            policy,
-            !isHidden && !!proposal && !!policy,
-        );
+    const {
+        data: transaction,
+        isLoading: isLoadingTransaction,
+        isAwaitingTransaction,
+    } = useProposalTransaction(
+        treasuryId,
+        proposal,
+        policy,
+        !isHidden && !!proposal && !!policy,
+    );
     const { data: swapStatus, isLoading: isLoadingSwapStatus } = useSwapStatus(
         depositAddress,
         undefined,
@@ -925,12 +930,25 @@ export default function RequestReceiptPage({
             destinationToken?.symbol,
         ],
     );
-    const isTransactionDateLoading =
-        isExecutableReceipt &&
-        isSingleReceiptProposal &&
-        (shouldUseSwapExecutionDate
-            ? isLoadingSwapStatus
-            : isLoadingTransaction);
+    const isAwaitingSwapDate =
+        shouldUseSwapExecutionDate &&
+        !swapStatus?.updatedAt &&
+        !isTerminalSwapStatus(swapStatus?.status);
+    const isTransactionDateLoading = isExecutionTimestampPending({
+        executedDate: transactionDate,
+        isQueryLoading:
+            isExecutableReceipt &&
+            isSingleReceiptProposal &&
+            (shouldUseSwapExecutionDate
+                ? isLoadingSwapStatus
+                : isLoadingTransaction),
+        isAwaitingResolution:
+            isExecutableReceipt &&
+            isSingleReceiptProposal &&
+            (shouldUseSwapExecutionDate
+                ? isAwaitingSwapDate
+                : isAwaitingTransaction),
+    });
     const isRateLoading = hasDepositAddress
         ? isSingleReceiptProposal &&
           !isConfidentialRequestProposal &&

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -35,7 +35,9 @@ import {
 import {
     extractReceiptProposalData,
     getProposalExecutedDate,
+    isExecutionTimestampPending,
     isReceiptEligibleProposalKind,
+    isTerminalSwapStatus,
 } from "@/features/proposals/utils/receipt-utils";
 import {
     useProposals,
@@ -364,14 +366,16 @@ export function ProposalSidebar({
 
     // Fetch transaction data for non-intents proposals, or for statuses
     // whose resolved date/link should come from the chain transaction.
-    const { data: transaction, isLoading: isLoadingTransaction } =
-        useProposalTransaction(
-            treasuryId,
-            proposal,
-            policy,
-            shouldUseTransactionDate &&
-                (!hasDepositAddress || !shouldUseSwapDate),
-        );
+    const {
+        data: transaction,
+        isLoading: isLoadingTransaction,
+        isAwaitingTransaction,
+    } = useProposalTransaction(
+        treasuryId,
+        proposal,
+        policy,
+        shouldUseTransactionDate && (!hasDepositAddress || !shouldUseSwapDate),
+    );
 
     // Fetch swap status for executed intents proposals (exchange or payment).
     const shouldFetchSwapStatus = isExecuted && hasDepositAddress;
@@ -391,9 +395,25 @@ export function ProposalSidebar({
     const isSwapSuccessReady = shouldRequireSwapSuccess
         ? isPublicTreasuryGuestViewer || swapStatus?.status === "SUCCESS"
         : true;
+    const executedDate =
+        confidentialExecutedAt ??
+        getProposalExecutedDate(swapStatus, transaction) ??
+        null;
+    const isAwaitingSwapDate =
+        shouldUseSwapDate &&
+        !swapStatus?.updatedAt &&
+        !isTerminalSwapStatus(swapStatus?.status);
     const isResolvedDateLoading =
         isExecuted &&
-        (shouldUseSwapDate ? isLoadingSwapStatus : isLoadingTransaction);
+        isExecutionTimestampPending({
+            executedDate,
+            isQueryLoading: shouldUseSwapDate
+                ? isLoadingSwapStatus
+                : isLoadingTransaction,
+            isAwaitingResolution: shouldUseSwapDate
+                ? isAwaitingSwapDate
+                : isAwaitingTransaction,
+        });
     const isHidden = isConfidential && isGuestTreasury;
 
     // Confidential exchange (a confidential request that is not a payment).

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -34,10 +34,8 @@ import {
 } from "@/features/proposals/utils/proposal-utils";
 import {
     extractReceiptProposalData,
-    getProposalExecutedDate,
-    isExecutionTimestampPending,
     isReceiptEligibleProposalKind,
-    isTerminalSwapStatus,
+    resolveExecutionTimestamp,
 } from "@/features/proposals/utils/receipt-utils";
 import {
     useProposals,
@@ -395,25 +393,17 @@ export function ProposalSidebar({
     const isSwapSuccessReady = shouldRequireSwapSuccess
         ? isPublicTreasuryGuestViewer || swapStatus?.status === "SUCCESS"
         : true;
-    const executedDate =
-        confidentialExecutedAt ??
-        getProposalExecutedDate(swapStatus, transaction) ??
-        null;
-    const isAwaitingSwapDate =
-        shouldUseSwapDate &&
-        !swapStatus?.updatedAt &&
-        !isTerminalSwapStatus(swapStatus?.status);
-    const isResolvedDateLoading =
-        isExecuted &&
-        isExecutionTimestampPending({
-            executedDate,
-            isQueryLoading: shouldUseSwapDate
-                ? isLoadingSwapStatus
-                : isLoadingTransaction,
-            isAwaitingResolution: shouldUseSwapDate
-                ? isAwaitingSwapDate
-                : isAwaitingTransaction,
+    const { executedDate, isDateLoading: resolvedDateLoading } =
+        resolveExecutionTimestamp({
+            swapStatus,
+            transaction,
+            shouldUseSwapDate,
+            isLoadingSwapStatus,
+            isLoadingTransaction,
+            isAwaitingTransaction,
+            fallbackDate: confidentialExecutedAt ?? publicExecutedAt,
         });
+    const isResolvedDateLoading = isExecuted && resolvedDateLoading;
     const isHidden = isConfidential && isGuestTreasury;
 
     // Confidential exchange (a confidential request that is not a payment).
@@ -469,11 +459,7 @@ export function ProposalSidebar({
             break;
 
         default:
-            timestamp =
-                confidentialExecutedAt ??
-                publicExecutedAt ??
-                getProposalExecutedDate(swapStatus, transaction) ??
-                undefined;
+            timestamp = executedDate ?? undefined;
             break;
     }
     const createdAt =

--- a/nt-fe/features/proposals/components/proposals-table.tsx
+++ b/nt-fe/features/proposals/components/proposals-table.tsx
@@ -67,9 +67,7 @@ import { useProposalsInsufficientBalance } from "../hooks/use-proposals-insuffic
 import { useProposalTransaction, useSwapStatus } from "@/hooks/use-proposals";
 import {
     extractReceiptProposalData,
-    getProposalExecutedDate,
-    isExecutionTimestampPending,
-    isTerminalSwapStatus,
+    resolveExecutionTimestamp,
 } from "@/features/proposals/utils/receipt-utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
@@ -137,19 +135,13 @@ function ProposalTimelineDate({
         );
     }
 
-    const executedDate = getProposalExecutedDate(swapStatus, transaction);
-    const isAwaitingSwapDate =
-        shouldUseSwapDate &&
-        !swapStatus?.updatedAt &&
-        !isTerminalSwapStatus(swapStatus?.status);
-    const isDateLoading = isExecutionTimestampPending({
-        executedDate,
-        isQueryLoading: shouldUseSwapDate
-            ? isLoadingSwapStatus
-            : isLoadingTransaction,
-        isAwaitingResolution: shouldUseSwapDate
-            ? isAwaitingSwapDate
-            : isAwaitingTransaction,
+    const { executedDate, isDateLoading } = resolveExecutionTimestamp({
+        swapStatus,
+        transaction,
+        shouldUseSwapDate,
+        isLoadingSwapStatus,
+        isLoadingTransaction,
+        isAwaitingTransaction,
     });
     if (isDateLoading) {
         return <Skeleton className="h-3.5 w-24" />;

--- a/nt-fe/features/proposals/components/proposals-table.tsx
+++ b/nt-fe/features/proposals/components/proposals-table.tsx
@@ -68,6 +68,8 @@ import { useProposalTransaction, useSwapStatus } from "@/hooks/use-proposals";
 import {
     extractReceiptProposalData,
     getProposalExecutedDate,
+    isExecutionTimestampPending,
+    isTerminalSwapStatus,
 } from "@/features/proposals/utils/receipt-utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
@@ -107,13 +109,16 @@ function ProposalTimelineDate({
     )?.depositAddress;
     const shouldUseSwapDate = isProposalExecuted && !!depositAddress;
 
-    const { data: transaction, isLoading: isLoadingTransaction } =
-        useProposalTransaction(
-            treasuryId,
-            proposal,
-            policy,
-            isProposalExecuted && !shouldUseSwapDate,
-        );
+    const {
+        data: transaction,
+        isLoading: isLoadingTransaction,
+        isAwaitingTransaction,
+    } = useProposalTransaction(
+        treasuryId,
+        proposal,
+        policy,
+        isProposalExecuted && !shouldUseSwapDate,
+    );
     const { data: swapStatus, isLoading: isLoadingSwapStatus } = useSwapStatus(
         depositAddress || null,
         undefined,
@@ -132,14 +137,24 @@ function ProposalTimelineDate({
         );
     }
 
-    const isDateLoading = shouldUseSwapDate
-        ? isLoadingSwapStatus
-        : isLoadingTransaction;
+    const executedDate = getProposalExecutedDate(swapStatus, transaction);
+    const isAwaitingSwapDate =
+        shouldUseSwapDate &&
+        !swapStatus?.updatedAt &&
+        !isTerminalSwapStatus(swapStatus?.status);
+    const isDateLoading = isExecutionTimestampPending({
+        executedDate,
+        isQueryLoading: shouldUseSwapDate
+            ? isLoadingSwapStatus
+            : isLoadingTransaction,
+        isAwaitingResolution: shouldUseSwapDate
+            ? isAwaitingSwapDate
+            : isAwaitingTransaction,
+    });
     if (isDateLoading) {
         return <Skeleton className="h-3.5 w-24" />;
     }
 
-    const executedDate = getProposalExecutedDate(swapStatus, transaction);
     if (!executedDate) {
         return (
             <FormattedDate

--- a/nt-fe/features/proposals/utils/receipt-utils.ts
+++ b/nt-fe/features/proposals/utils/receipt-utils.ts
@@ -49,6 +49,24 @@ export function getProposalExecutedDate(
     return null;
 }
 
+/**
+ * Whether the UI should keep showing a loading state for the execution
+ * timestamp instead of "N/A". NearBlocks / swap status can lag briefly after
+ * approval; callers poll until a timestamp appears.
+ */
+export function isExecutionTimestampPending({
+    executedDate,
+    isQueryLoading,
+    isAwaitingResolution,
+}: {
+    executedDate: Date | null;
+    isQueryLoading: boolean;
+    isAwaitingResolution: boolean;
+}): boolean {
+    if (executedDate) return false;
+    return isQueryLoading || isAwaitingResolution;
+}
+
 function toPaymentReceiptData(data: PaymentRequestData): ReceiptProposalData {
     return {
         variant: "payment",

--- a/nt-fe/features/proposals/utils/receipt-utils.ts
+++ b/nt-fe/features/proposals/utils/receipt-utils.ts
@@ -50,21 +50,46 @@ export function getProposalExecutedDate(
 }
 
 /**
- * Whether the UI should keep showing a loading state for the execution
- * timestamp instead of "N/A". NearBlocks / swap status can lag briefly after
- * approval; callers poll until a timestamp appears.
+ * Shared execution-timestamp resolution for table / sidebar / receipt.
+ * Keeps swap-vs-NearBlocks loading rules in one place so call sites can't drift.
  */
-export function isExecutionTimestampPending({
-    executedDate,
-    isQueryLoading,
-    isAwaitingResolution,
+export function resolveExecutionTimestamp({
+    swapStatus,
+    transaction,
+    shouldUseSwapDate,
+    isLoadingSwapStatus,
+    isLoadingTransaction,
+    isAwaitingTransaction,
+    fallbackDate,
 }: {
-    executedDate: Date | null;
-    isQueryLoading: boolean;
-    isAwaitingResolution: boolean;
-}): boolean {
-    if (executedDate) return false;
-    return isQueryLoading || isAwaitingResolution;
+    swapStatus: SwapStatusResponse | null | undefined;
+    transaction: { timestamp: number } | null | undefined;
+    shouldUseSwapDate: boolean;
+    isLoadingSwapStatus: boolean;
+    isLoadingTransaction: boolean;
+    isAwaitingTransaction: boolean;
+    /** e.g. confidential metadata executedAt */
+    fallbackDate?: Date | null;
+}): { executedDate: Date | null; isDateLoading: boolean } {
+    const executedDate =
+        fallbackDate ??
+        getProposalExecutedDate(swapStatus, transaction) ??
+        null;
+
+    if (executedDate) {
+        return { executedDate, isDateLoading: false };
+    }
+
+    const isAwaitingSwapDate =
+        shouldUseSwapDate &&
+        !swapStatus?.updatedAt &&
+        !isTerminalSwapStatus(swapStatus?.status);
+
+    const isDateLoading =
+        (shouldUseSwapDate ? isLoadingSwapStatus : isLoadingTransaction) ||
+        (shouldUseSwapDate ? isAwaitingSwapDate : isAwaitingTransaction);
+
+    return { executedDate, isDateLoading };
 }
 
 function toPaymentReceiptData(data: PaymentRequestData): ReceiptProposalData {

--- a/nt-fe/hooks/use-proposals.ts
+++ b/nt-fe/hooks/use-proposals.ts
@@ -1,4 +1,4 @@
-import { useQuery, type Query } from "@tanstack/react-query";
+import { useQuery, useQueryClient, type Query } from "@tanstack/react-query";
 import {
     getProposals,
     ProposalFilters,
@@ -101,38 +101,67 @@ export function useProposal(
     });
 }
 
+/** NearBlocks indexes shortly after execution — poll until the tx appears. */
+const PROPOSAL_TX_POLL_MS = 5_000;
+const PROPOSAL_TX_MAX_POLLS = 12; // ~1 minute
+
 export function useProposalTransaction(
     daoId: string | null | undefined,
     proposal: Proposal | null | undefined,
     policy: Policy | null | undefined,
     enabled: boolean = true,
 ) {
+    const queryClient = useQueryClient();
     const canReadProposalQueries = useCanReadProposalQueries(daoId);
-    return useQuery({
-        queryKey: [
-            "proposal-transaction",
-            daoId,
-            proposal?.id,
-            proposal?.status,
-            proposal?.submission_time,
-            policy?.proposal_period,
-        ],
+    // Only executed proposals (on-chain Approved) have an execution tx to wait
+    // for. Rejected/Removed should surface N/A rather than keep polling.
+    const expectsTransaction = proposal?.status === "Approved";
+    const isQueryEnabled =
+        enabled && canReadProposalQueries && !!daoId && !!proposal && !!policy;
+    const queryKey = [
+        "proposal-transaction",
+        daoId,
+        proposal?.id,
+        proposal?.status,
+        proposal?.submission_time,
+        policy?.proposal_period,
+    ] as const;
+
+    const query = useQuery({
+        queryKey,
         queryFn: () => getProposalTransaction(daoId!, proposal!, policy!),
-        enabled:
-            enabled &&
-            canReadProposalQueries &&
-            !!daoId &&
-            !!proposal &&
-            !!policy,
-        staleTime: 1000 * 60 * 5, // 5 minutes (transaction data is more stable)
+        enabled: isQueryEnabled,
+        staleTime: 1000 * 60 * 5, // 5 minutes once we have the transaction
+        refetchInterval: (q) => {
+            // Keep polling while NearBlocks has not indexed the execution tx yet.
+            if (!expectsTransaction) return false;
+            if (q.state.data) return false;
+            if (q.state.dataUpdateCount >= PROPOSAL_TX_MAX_POLLS) return false;
+            return PROPOSAL_TX_POLL_MS;
+        },
         retry: (failureCount, error) => {
-            // Don't retry on 404 (not found) errors
+            // Don't retry on 404 (not found) errors — polling handles indexer lag.
             if (isAxiosErrorWithStatus(error, 404)) {
                 return false;
             }
             return failureCount < 3;
         },
     });
+
+    const dataUpdateCount =
+        queryClient.getQueryState(queryKey)?.dataUpdateCount ?? 0;
+
+    // True while we still expect a transaction (including between poll intervals),
+    // so callers can show a skeleton instead of "N/A".
+    const isAwaitingTransaction =
+        isQueryEnabled &&
+        expectsTransaction &&
+        !query.data &&
+        (query.isLoading ||
+            query.isFetching ||
+            dataUpdateCount < PROPOSAL_TX_MAX_POLLS);
+
+    return { ...query, isAwaitingTransaction };
 }
 
 /**

--- a/nt-fe/hooks/use-proposals.ts
+++ b/nt-fe/hooks/use-proposals.ts
@@ -115,7 +115,8 @@ export function useProposalTransaction(
     const canReadProposalQueries = useCanReadProposalQueries(daoId);
     // Only executed proposals (on-chain Approved) have an execution tx to wait
     // for. Rejected/Removed should surface N/A rather than keep polling.
-    const expectsTransaction = proposal?.status === "Approved";
+    const expectsTransaction =
+        proposal?.status === "Approved" || proposal?.status === "Failed";
     const isQueryEnabled =
         enabled && canReadProposalQueries && !!daoId && !!proposal && !!policy;
     const queryKey = [

--- a/nt-fe/stores/near-store.ts
+++ b/nt-fe/stores/near-store.ts
@@ -841,7 +841,7 @@ export const useNear = () => {
                     queryKey: [
                         "proposal-transaction",
                         treasuryId,
-                        vote.proposalId.toString(),
+                        vote.proposalId,
                     ],
                 }),
             ),


### PR DESCRIPTION
- Prefer the unified AURORA display symbol/name over the standalone `AURORA (omni)` catalog duplicate in token metadata. #1101 
- After a request is executed, poll NearBlocks for the execution tx and keep a loading state instead of showing "N/A" until the timestamp resolves. #954 
