### PR TITLE
fix(bulk-payment): use `EXACT_OUTPUT` quotes so recipients receive the full amount

### DIFF
--- a/nt-be/src/handlers/intents/confidential/bulk_payment_prepare.rs
+++ b/nt-be/src/handlers/intents/confidential/bulk_payment_prepare.rs
@@ -106,7 +106,7 @@ fn build_recipient_quote_body(
 
     let mut body = json!({
         "dry": false,
-        "swapType": "EXACT_INPUT",
+        "swapType": "EXACT_OUTPUT",
         "slippageTolerance": slippage,
         "originAsset": origin_asset,
         "depositType": "CONFIDENTIAL_INTENTS",
@@ -139,7 +139,7 @@ fn build_header_quote_body(
 ) -> Value {
     let mut body = json!({
         "dry": false,
-        "swapType": "EXACT_INPUT",
+        "swapType": "EXACT_OUTPUT",
         "slippageTolerance": 100,
         "originAsset": origin_asset,
         "depositType": "CONFIDENTIAL_INTENTS",


### PR DESCRIPTION
This PR addresses transfer fees silently eating into bulk payment amounts, so recipients received less than the DAO approved.

### Example

DAO bulk-pays 5 USDC to each of two Solana recipients, where each cross-chain transfer costs ~0.4 USDC in fees.

#### Before

With `EXACT_INPUT`, fees were deducted from the transfer amount: the DAO paid 10, but each recipient received `5 − 0.4 = 4.6` — 8% less than the approved amount.

#### After

With `EXACT_OUTPUT`, fees are added on top: each leg quotes `amountIn = 5.4`, the header funds the subaccount with exactly `5.4 + 5.4 = 10.8`, the DAO pays 10.8, and each recipient receives exactly 5.