### PR TITLE
fix: show confidential guest pending count

### DIFF
--- a/nt-be/src/auth/middleware.rs
+++ b/nt-be/src/auth/middleware.rs
@@ -224,59 +224,42 @@ impl FromRequestParts<Arc<AppState>> for AuthUser {
 pub struct OptionalAuthUser(pub Option<AuthUser>);
 
 impl OptionalAuthUser {
-    /// Verify that the caller may view count-only data for a confidential treasury.
+    /// Verify that the caller may view count-only data for a treasury.
     ///
     /// Members always have access. Non-members must have explicitly saved the
     /// treasury, which is the authenticated guest-viewer relationship used by
     /// the treasury selector.
-    pub async fn verify_confidential_guest_access(
+    pub async fn verify_guest_treasury_access(
         &self,
         db: &sqlx::PgPool,
         dao_id: &AccountIdRef,
     ) -> Result<(), (StatusCode, String)> {
+        let user = self.0.as_ref().ok_or((
+            StatusCode::UNAUTHORIZED,
+            "Authentication required for pending proposal counts".to_string(),
+        ))?;
+
         let row = sqlx::query!(
             r#"
             SELECT
-                ma.is_confidential_account,
-                dm.is_policy_member AS "is_policy_member?",
-                dm.is_saved AS "is_saved?"
-            FROM monitored_accounts ma
-            LEFT JOIN dao_members dm
-                ON dm.dao_id = ma.account_id
-                AND dm.account_id = $2
-            WHERE ma.account_id = $1
+                is_policy_member AS "is_policy_member!",
+                is_saved AS "is_saved!"
+            FROM dao_members
+            WHERE dao_id = $1 AND account_id = $2
             "#,
             dao_id.as_str(),
-            self.0.as_ref().map(|user| user.account_id.as_str()),
+            user.account_id.as_str(),
         )
         .fetch_optional(db)
         .await
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to check confidential status: {}", e),
+                format!("Failed to check treasury access: {}", e),
             )
         })?;
 
-        let is_confidential = row
-            .as_ref()
-            .and_then(|r| r.is_confidential_account)
-            .unwrap_or(false);
-
-        if !is_confidential {
-            return Ok(());
-        }
-
-        if self.0.is_none() {
-            return Err((
-                StatusCode::UNAUTHORIZED,
-                "Authentication required for confidential treasury".to_string(),
-            ));
-        }
-
-        let has_guest_access = row.as_ref().is_some_and(|row| {
-            row.is_policy_member.unwrap_or(false) || row.is_saved.unwrap_or(false)
-        });
+        let has_guest_access = row.is_some_and(|row| row.is_policy_member || row.is_saved);
         if !has_guest_access {
             return Err((
                 StatusCode::FORBIDDEN,
@@ -419,24 +402,16 @@ mod tests {
     /// this would miss the cache and RPC a non-existent test DAO and error — so a passing assertion
     /// also proves the seed and fetch keys agree.
     #[sqlx::test]
-    async fn confidential_guest_access_requires_a_saved_treasury(pool: sqlx::PgPool) {
+    async fn guest_treasury_access_requires_a_saved_treasury(pool: sqlx::PgPool) {
         let dao: AccountId = "confidential-dao.sputnik-dao.near".parse().unwrap();
         let guest = AuthUser {
             account_id: "guest.near".parse().unwrap(),
         };
         let unauthorized = OptionalAuthUser(Some(guest.clone()));
 
-        sqlx::query!(
-            "INSERT INTO monitored_accounts (account_id, is_confidential_account) VALUES ($1, true)",
-            dao.as_str(),
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
-
         assert_eq!(
             unauthorized
-                .verify_confidential_guest_access(&pool, &dao)
+                .verify_guest_treasury_access(&pool, &dao)
                 .await
                 .unwrap_err()
                 .0,
@@ -453,13 +428,13 @@ mod tests {
         .unwrap();
 
         OptionalAuthUser(Some(guest))
-            .verify_confidential_guest_access(&pool, &dao)
+            .verify_guest_treasury_access(&pool, &dao)
             .await
             .unwrap();
 
         assert_eq!(
             OptionalAuthUser(None)
-                .verify_confidential_guest_access(&pool, &dao)
+                .verify_guest_treasury_access(&pool, &dao)
                 .await
                 .unwrap_err()
                 .0,

--- a/nt-be/src/auth/middleware.rs
+++ b/nt-be/src/auth/middleware.rs
@@ -224,11 +224,69 @@ impl FromRequestParts<Arc<AppState>> for AuthUser {
 pub struct OptionalAuthUser(pub Option<AuthUser>);
 
 impl OptionalAuthUser {
-    /// If the given account is a confidential treasury, verify that the caller
-    /// is an authenticated DAO policy member.
+    /// Verify that the caller may view count-only data for a confidential treasury.
     ///
-    /// Returns `true` if the account is confidential, `false` otherwise.
-    /// Fails with 401/403 when confidential but the caller is missing or not a member.
+    /// Members always have access. Non-members must have explicitly saved the
+    /// treasury, which is the authenticated guest-viewer relationship used by
+    /// the treasury selector.
+    pub async fn verify_confidential_guest_access(
+        &self,
+        db: &sqlx::PgPool,
+        dao_id: &AccountIdRef,
+    ) -> Result<(), (StatusCode, String)> {
+        let row = sqlx::query!(
+            r#"
+            SELECT
+                ma.is_confidential_account,
+                dm.is_policy_member AS "is_policy_member?",
+                dm.is_saved AS "is_saved?"
+            FROM monitored_accounts ma
+            LEFT JOIN dao_members dm
+                ON dm.dao_id = ma.account_id
+                AND dm.account_id = $2
+            WHERE ma.account_id = $1
+            "#,
+            dao_id.as_str(),
+            self.0.as_ref().map(|user| user.account_id.as_str()),
+        )
+        .fetch_optional(db)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to check confidential status: {}", e),
+            )
+        })?;
+
+        let is_confidential = row
+            .as_ref()
+            .and_then(|r| r.is_confidential_account)
+            .unwrap_or(false);
+
+        if !is_confidential {
+            return Ok(());
+        }
+
+        if self.0.is_none() {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                "Authentication required for confidential treasury".to_string(),
+            ));
+        }
+
+        let has_guest_access = row.as_ref().is_some_and(|row| {
+            row.is_policy_member.unwrap_or(false) || row.is_saved.unwrap_or(false)
+        });
+        if !has_guest_access {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Treasury has not been saved by this user".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
     pub async fn verify_member_if_confidential(
         &self,
         db: &sqlx::PgPool,
@@ -360,6 +418,55 @@ mod tests {
     /// touching the network. If the seeded key didn't match `fetch_treasury_policy_cached`'s key,
     /// this would miss the cache and RPC a non-existent test DAO and error — so a passing assertion
     /// also proves the seed and fetch keys agree.
+    #[sqlx::test]
+    async fn confidential_guest_access_requires_a_saved_treasury(pool: sqlx::PgPool) {
+        let dao: AccountId = "confidential-dao.sputnik-dao.near".parse().unwrap();
+        let guest = AuthUser {
+            account_id: "guest.near".parse().unwrap(),
+        };
+        let unauthorized = OptionalAuthUser(Some(guest.clone()));
+
+        sqlx::query!(
+            "INSERT INTO monitored_accounts (account_id, is_confidential_account) VALUES ($1, true)",
+            dao.as_str(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            unauthorized
+                .verify_confidential_guest_access(&pool, &dao)
+                .await
+                .unwrap_err()
+                .0,
+            StatusCode::FORBIDDEN
+        );
+
+        sqlx::query!(
+            "INSERT INTO dao_members (dao_id, account_id, is_policy_member, is_saved, is_hidden) VALUES ($1, $2, false, true, false)",
+            dao.as_str(),
+            guest.account_id.as_str(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        OptionalAuthUser(Some(guest))
+            .verify_confidential_guest_access(&pool, &dao)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            OptionalAuthUser(None)
+                .verify_confidential_guest_access(&pool, &dao)
+                .await
+                .unwrap_err()
+                .0,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
     #[sqlx::test]
     async fn seeded_policy_is_served_from_cache(pool: sqlx::PgPool) {
         let state = Arc::new(build_test_state(pool));

--- a/nt-be/src/handlers/proposals/get_proposals.rs
+++ b/nt-be/src/handlers/proposals/get_proposals.rs
@@ -224,16 +224,16 @@ pub async fn get_pending_proposals_count(
     Path(dao_id): Path<AccountId>,
 ) -> Result<(StatusCode, Json<PendingProposalsCount>), (StatusCode, String)> {
     auth_user
-        .verify_confidential_guest_access(&state.db_pool, dao_id.as_ref())
+        .verify_guest_treasury_access(&state.db_pool, dao_id.as_ref())
         .await?;
 
-    let cache_key = CacheKey::new("dao-proposals").with(&dao_id).build();
-    let (proposals, _policy): (Vec<Proposal>, Policy) = state
+    let cache_key = CacheKey::new("dao-pending-proposals-count")
+        .with(&dao_id)
+        .build();
+    let proposals: Vec<Proposal> = state
         .cache
         .cached_contract_call(CacheTier::ShortTerm, cache_key, async {
-            let proposals = fetch_proposals(&state.network, &dao_id).await?;
-            let policy = fetch_policy(&state.network, &dao_id).await?;
-            Ok((proposals, policy))
+            fetch_proposals(&state.network, &dao_id).await
         })
         .await?;
 
@@ -397,13 +397,6 @@ mod tests {
         };
 
         sqlx::query!(
-            "INSERT INTO monitored_accounts (account_id, is_confidential_account) VALUES ($1, true)",
-            dao.as_str(),
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
-        sqlx::query!(
             "INSERT INTO dao_members (dao_id, account_id, is_policy_member, is_saved, is_hidden) VALUES ($1, $2, false, true, false)",
             dao.as_str(),
             guest.account_id.as_str(),
@@ -412,23 +405,13 @@ mod tests {
         .await
         .unwrap();
 
-        let policy: Policy = serde_json::from_value(serde_json::json!({
-            "roles": [],
-            "default_vote_policy": {},
-            "proposal_bond": "0",
-            "proposal_period": "0",
-            "bounty_bond": "0",
-            "bounty_forgiveness_period": "0"
-        }))
-        .unwrap();
-        let cache_key = CacheKey::new("dao-proposals").with(&dao).build();
+        let cache_key = CacheKey::new("dao-pending-proposals-count")
+            .with(&dao)
+            .build();
         state
             .cache
             .short_term
-            .insert(
-                cache_key,
-                serde_json::to_value((Vec::<Proposal>::new(), policy)).unwrap(),
-            )
+            .insert(cache_key, serde_json::to_value(Vec::<Proposal>::new()).unwrap())
             .await;
 
         let response = get_pending_proposals_count(
@@ -450,14 +433,6 @@ mod tests {
     async fn pending_count_rejects_unauthenticated_confidential_guests(pool: sqlx::PgPool) {
         let dao: AccountId = "count-private-dao.sputnik-dao.near".parse().unwrap();
         let state = Arc::new(build_test_state(pool.clone()));
-
-        sqlx::query!(
-            "INSERT INTO monitored_accounts (account_id, is_confidential_account) VALUES ($1, true)",
-            dao.as_str(),
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
 
         assert_eq!(
             get_pending_proposals_count(State(state), OptionalAuthUser(None), Path(dao))

--- a/nt-be/src/handlers/proposals/get_proposals.rs
+++ b/nt-be/src/handlers/proposals/get_proposals.rs
@@ -220,8 +220,13 @@ pub async fn get_proposals(
 
 pub async fn get_pending_proposals_count(
     State(state): State<Arc<AppState>>,
+    auth_user: OptionalAuthUser,
     Path(dao_id): Path<AccountId>,
 ) -> Result<(StatusCode, Json<PendingProposalsCount>), (StatusCode, String)> {
+    auth_user
+        .verify_confidential_guest_access(&state.db_pool, dao_id.as_ref())
+        .await?;
+
     let cache_key = CacheKey::new("dao-proposals").with(&dao_id).build();
     let (proposals, _policy): (Vec<Proposal>, Policy) = state
         .cache
@@ -371,6 +376,97 @@ pub async fn get_dao_approvers(
     };
 
     Ok((StatusCode::OK, Json(response)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        auth::{AuthUser, OptionalAuthUser},
+        utils::test_utils::build_test_state,
+    };
+
+    #[sqlx::test]
+    async fn pending_count_allows_saved_confidential_guests_and_returns_no_proposals(
+        pool: sqlx::PgPool,
+    ) {
+        let dao: AccountId = "count-test-dao.sputnik-dao.near".parse().unwrap();
+        let state = Arc::new(build_test_state(pool.clone()));
+        let guest = AuthUser {
+            account_id: "count-guest.near".parse().unwrap(),
+        };
+
+        sqlx::query!(
+            "INSERT INTO monitored_accounts (account_id, is_confidential_account) VALUES ($1, true)",
+            dao.as_str(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query!(
+            "INSERT INTO dao_members (dao_id, account_id, is_policy_member, is_saved, is_hidden) VALUES ($1, $2, false, true, false)",
+            dao.as_str(),
+            guest.account_id.as_str(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let policy: Policy = serde_json::from_value(serde_json::json!({
+            "roles": [],
+            "default_vote_policy": {},
+            "proposal_bond": "0",
+            "proposal_period": "0",
+            "bounty_bond": "0",
+            "bounty_forgiveness_period": "0"
+        }))
+        .unwrap();
+        let cache_key = CacheKey::new("dao-proposals").with(&dao).build();
+        state
+            .cache
+            .short_term
+            .insert(
+                cache_key,
+                serde_json::to_value((Vec::<Proposal>::new(), policy)).unwrap(),
+            )
+            .await;
+
+        let response = get_pending_proposals_count(
+            State(state),
+            OptionalAuthUser(Some(guest)),
+            Path(dao),
+        )
+        .await
+        .unwrap()
+        .1
+        .0;
+
+        let response_value = serde_json::to_value(response).unwrap();
+        assert_eq!(response_value, serde_json::json!({ "count": 0 }));
+        assert!(response_value.get("proposals").is_none());
+    }
+
+    #[sqlx::test]
+    async fn pending_count_rejects_unauthenticated_confidential_guests(pool: sqlx::PgPool) {
+        let dao: AccountId = "count-private-dao.sputnik-dao.near".parse().unwrap();
+        let state = Arc::new(build_test_state(pool.clone()));
+
+        sqlx::query!(
+            "INSERT INTO monitored_accounts (account_id, is_confidential_account) VALUES ($1, true)",
+            dao.as_str(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            get_pending_proposals_count(State(state), OptionalAuthUser(None), Path(dao))
+                .await
+                .unwrap_err()
+                .0,
+            StatusCode::UNAUTHORIZED
+        );
+    }
 }
 
 /// Enrich confidential proposals (v1.signer) with quote_metadata, status, and

--- a/nt-be/src/handlers/proposals/get_proposals.rs
+++ b/nt-be/src/handlers/proposals/get_proposals.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use crate::handlers::proposals::{
     filters::{ProposalFilters, SortBy},
     scraper::{
-        Policy, Proposal, extract_from_description, extract_payload_hash_from_kind, fetch_policy,
-        fetch_proposal, fetch_proposals,
+        Policy, Proposal, ProposalStatus, extract_from_description, extract_payload_hash_from_kind,
+        fetch_policy, fetch_proposal, fetch_proposals,
     },
 };
 use crate::{
@@ -65,6 +65,11 @@ pub struct PaginatedProposals {
     pub total: usize,
     pub page: usize,
     pub page_size: usize,
+}
+
+#[derive(serde::Serialize)]
+pub struct PendingProposalsCount {
+    pub count: usize,
 }
 
 #[derive(sqlx::FromRow)]
@@ -211,6 +216,28 @@ pub async fn get_proposals(
     };
 
     Ok((StatusCode::OK, Json(response)))
+}
+
+pub async fn get_pending_proposals_count(
+    State(state): State<Arc<AppState>>,
+    Path(dao_id): Path<AccountId>,
+) -> Result<(StatusCode, Json<PendingProposalsCount>), (StatusCode, String)> {
+    let cache_key = CacheKey::new("dao-proposals").with(&dao_id).build();
+    let (proposals, _policy): (Vec<Proposal>, Policy) = state
+        .cache
+        .cached_contract_call(CacheTier::ShortTerm, cache_key, async {
+            let proposals = fetch_proposals(&state.network, &dao_id).await?;
+            let policy = fetch_policy(&state.network, &dao_id).await?;
+            Ok((proposals, policy))
+        })
+        .await?;
+
+    let count = proposals
+        .iter()
+        .filter(|proposal| proposal.status == ProposalStatus::InProgress)
+        .count();
+
+    Ok((StatusCode::OK, Json(PendingProposalsCount { count })))
 }
 
 pub async fn get_proposal(

--- a/nt-be/src/routes/mod.rs
+++ b/nt-be/src/routes/mod.rs
@@ -205,6 +205,10 @@ pub fn create_routes(state: Arc<AppState>) -> Router {
             get(handlers::proposals::get_proposals::get_proposals),
         )
         .route(
+            "/api/proposals/{dao_id}/pending-count",
+            get(handlers::proposals::get_proposals::get_pending_proposals_count),
+        )
+        .route(
             "/api/proposal/{dao_id}/{proposal_id}",
             get(handlers::proposals::get_proposals::get_proposal),
         )

--- a/nt-fe/features/proposals/components/pending-requests/index.tsx
+++ b/nt-fe/features/proposals/components/pending-requests/index.tsx
@@ -9,7 +9,10 @@ import { NumberBadge } from "@/components/number-badge";
 import { SlotWarning } from "@/components/warning-message";
 import { useProposalApproveBlock } from "@/hooks/use-warnings";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useProposals } from "@/hooks/use-proposals";
+import {
+    usePendingProposalsCount,
+    useProposals,
+} from "@/hooks/use-proposals";
 import { Proposal } from "@/lib/proposals-api";
 import { useTreasury } from "@/hooks/use-treasury";
 import { useTreasuryPolicy } from "@/hooks/use-treasury-queries";
@@ -240,6 +243,10 @@ export function PendingRequests() {
     const { treasuryId, isConfidential, isGuestTreasury } = useTreasury();
     const isHidden = isConfidential && isGuestTreasury;
     const router = useRouter();
+    const { data: pendingProposalsCount } = usePendingProposalsCount(
+        treasuryId,
+        isHidden,
+    );
     const { data: policy } = useTreasuryPolicy(treasuryId);
     const [isVoteModalOpen, setIsVoteModalOpen] = useState(false);
     const [voteInfo, setVoteInfo] = useState<{
@@ -268,6 +275,11 @@ export function PendingRequests() {
                         <h1 className="font-semibold text-nowrap">
                             {t("title")}
                         </h1>
+                        {(pendingProposalsCount?.count ?? 0) > 0 && (
+                            <NumberBadge
+                                number={pendingProposalsCount?.count ?? 0}
+                            />
+                        )}
                     </div>
                 </div>
                 <ConfidentialState skeleton={<PendingRequestsGridSkeleton />} />

--- a/nt-fe/hooks/use-proposals.ts
+++ b/nt-fe/hooks/use-proposals.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient, type Query } from "@tanstack/react-query";
 import {
+    getPendingProposalsCount,
     getProposals,
     ProposalFilters,
     ProposalsResponse,
@@ -63,6 +64,18 @@ export function useProposals(
         staleTime: 1000 * 10, // 10 seconds (proposals can change frequently)
         refetchOnMount: options?.refetchOnMount,
         refetchInterval: options?.refetchInterval,
+    });
+}
+
+export function usePendingProposalsCount(
+    daoId: string | null | undefined,
+    enabled: boolean = true,
+) {
+    return useQuery({
+        queryKey: ["pending-proposals-count", daoId],
+        queryFn: () => getPendingProposalsCount(daoId!),
+        enabled: enabled && !!daoId,
+        staleTime: 1000 * 10,
     });
 }
 

--- a/nt-fe/lib/proposals-api.ts
+++ b/nt-fe/lib/proposals-api.ts
@@ -300,6 +300,10 @@ export interface ProposalsResponse {
     proposals: Proposal[];
 }
 
+export interface PendingProposalsCountResponse {
+    count: number;
+}
+
 /**
  * Sputnik unit-variant kinds (only `Vote` today) serialize to plain JSON
  * strings in the contract state the backend passes through verbatim.
@@ -468,6 +472,24 @@ export async function getProposals(
     } catch (error) {
         console.error(`Error getting proposals for DAO ${daoId}`, error);
         return { page: 0, page_size: 0, total: 0, proposals: [] };
+    }
+}
+
+export async function getPendingProposalsCount(
+    daoId: string,
+): Promise<PendingProposalsCountResponse> {
+    if (!daoId) {
+        return { count: 0 };
+    }
+
+    try {
+        const response = await axios.get<PendingProposalsCountResponse>(
+            `${BACKEND_API_BASE}/proposals/${daoId}/pending-count`,
+        );
+        return response.data;
+    } catch (error) {
+        console.error(`Error getting pending proposals count for DAO ${daoId}`, error);
+        return { count: 0 };
     }
 }
 

--- a/nt-fe/lib/proposals-api.ts
+++ b/nt-fe/lib/proposals-api.ts
@@ -485,6 +485,7 @@ export async function getPendingProposalsCount(
     try {
         const response = await axios.get<PendingProposalsCountResponse>(
             `${BACKEND_API_BASE}/proposals/${daoId}/pending-count`,
+            { withCredentials: true },
         );
         return response.data;
     } catch (error) {


### PR DESCRIPTION
# fix: show confidential guest pending count

## Summary

Authenticated guest viewers who have saved a confidential treasury could not see the number of pending requests on the dashboard. This adds a count-only backend endpoint restricted to treasury members and saved guests, then renders its result in the existing confidential state without fetching or displaying request records.

Fixes #1129

## Changes

- Add a cached endpoint that returns only the number of `InProgress` proposals to authenticated members and saved guests.
- Query that endpoint with session credentials only for confidential treasury guests, then render the existing count badge.
- Preserve the confidential overlay and avoid exposing proposal details or navigation to requests.
- Cover saved-guest access and anonymous/unsaved-user denial in the backend authorization tests.

## Testing

- `git diff --check` — passed.
- `sandbox-run "cd nt-be && cargo test pending_count_allows_saved_confidential_guests_and_returns_no_proposals pending_count_rejects_unauthenticated_confidential_guests confidential_guest_access_requires_a_saved_treasury"` — could not run because the supplied sandbox image has no `cargo` binary.
- `sandbox-run "cd nt-be && cargo fmt --check"` — could not run because the supplied sandbox image has no `cargo` binary.
- `sandbox-run "cd nt-fe && bunx biome check features/proposals/components/pending-requests/index.tsx hooks/use-proposals.ts lib/proposals-api.ts"` — could not run because the supplied sandbox image has no `bunx` binary.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
