### PR TITLE
fix: recipient address fields as plain text (no iOS autocapitalize / address autofill)

### DIFF
--- a/nt-fe/components/large-input.tsx
+++ b/nt-fe/components/large-input.tsx
@@ -108,6 +108,8 @@ export function LargeInput({
                 ref={inputRef}
                 autoComplete="off"
                 autoCorrect="off"
+                autoCapitalize="none"
+                spellCheck={false}
                 {...props}
                 value={value}
                 style={suffix ? { paddingRight: suffixWidth } : undefined}


### PR DESCRIPTION
## Problem
On iOS, the recipient/account **address** input autocapitalized the first character and showed physical-address autofill suggestions in the QuickType bar — neither valid for a crypto/NEAR address.

## Fix
`LargeInput` backs the recipient and account address fields. It already sets `autoComplete="off"` / `autoCorrect="off"`; extend those defaults with `autoCapitalize="none"` and `spellCheck={false}` so the fields behave as plain text.

Single-line change to a shared component; callers can still override via props. Covers recipient-input, account-input, account-id-input (and amount/search inputs, for which the same "off" behavior is already correct).

## Checks
`bun run format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)