### PR TITLE
Job-health watchdog, supervised bronze workers, and relay Sentry alerts

### DIFF
--- a/nt-be/src/handlers/public_history/bronze/jobs/mod.rs
+++ b/nt-be/src/handlers/public_history/bronze/jobs/mod.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use apalis::prelude::Monitor;
+
 use crate::AppState;
 
 pub mod model;
@@ -8,14 +10,25 @@ mod scheduler;
 mod worker;
 
 pub(crate) use scheduler::run_public_history_scheduler_cycle;
+pub(crate) use worker::board_storages;
 
-pub async fn start_public_history_queue_workers(state: Arc<AppState>) -> Result<(), sqlx::Error> {
+/// Queue names of the two task queues, for watchdog registration.
+pub(crate) const QUEUE_NAMES: [&str; 2] = [
+    postgres::PUBLIC_HISTORY_LATEST_NAMESPACE,
+    postgres::PUBLIC_HISTORY_BACKFILL_NAMESPACE,
+];
+
+/// Registers the latest/backfill queue workers on the shared jobs [`Monitor`]
+/// (restart-on-exit, catch_panic, Sentry — same supervision as cron jobs).
+pub async fn start_public_history_queue_workers(
+    monitor: Monitor,
+    state: Arc<AppState>,
+) -> Result<Monitor, sqlx::Error> {
     if state.env_vars.nearblocks_api_key.is_none() {
         tracing::warn!("public history queue workers disabled: NEARBLOCKS_API_KEY missing");
-        return Ok(());
+        return Ok(monitor);
     }
 
     postgres::setup_public_history_jobs(&state.db_pool).await?;
-    worker::spawn_public_history_job_workers(state);
-    Ok(())
+    Ok(worker::register_public_history_job_workers(monitor, state))
 }

--- a/nt-be/src/handlers/public_history/bronze/jobs/worker.rs
+++ b/nt-be/src/handlers/public_history/bronze/jobs/worker.rs
@@ -493,33 +493,58 @@ async fn handle_backfill_job(
         })
 }
 
-pub(crate) fn spawn_public_history_job_workers(state: Arc<AppState>) {
+/// Registers both queue workers on the shared jobs [`Monitor`], with the same
+/// failure containment as the cron workers in `crate::jobs`: `catch_panic`
+/// turns a handler panic into a task error, `SentryLayer` captures each task
+/// failure once, the INFO-level `TraceLayer` makes task activity visible on
+/// the apalis-board live-log pane, and the Monitor's `should_restart` rebuilds
+/// a worker that exits on a terminal backend error — previously these were
+/// bare `tokio::spawn`s that died silently.
+pub(crate) fn register_public_history_job_workers(
+    mut monitor: Monitor,
+    state: Arc<AppState>,
+) -> Monitor {
+    use apalis::layers::sentry::SentryLayer;
+    use apalis::layers::tracing::{
+        DefaultMakeSpan, DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer,
+    };
+
+    // Failures stay at WARN for the same reason as the cron workers: the
+    // SentryLayer already captured the task failure, and the tracing→Sentry
+    // bridge would emit a duplicate event at ERROR.
+    fn trace_layer() -> TraceLayer {
+        TraceLayer::new()
+            .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO))
+            .on_request(DefaultOnRequest::new().level(tracing::Level::INFO))
+            .on_response(DefaultOnResponse::new().level(tracing::Level::INFO))
+            .on_failure(DefaultOnFailure::new().level(tracing::Level::WARN))
+    }
+
     let latest_state = state.clone();
-    tokio::spawn(async move {
-        let storage = latest_storage(latest_state.db_pool.clone());
-        let worker = WorkerBuilder::new("public-history-latest")
-            .backend(storage)
-            .data(JobContext::new(latest_state))
-            .enable_tracing()
+    monitor = monitor.register(move |_attempt| {
+        WorkerBuilder::new("public-history-latest")
+            .backend(latest_storage(latest_state.db_pool.clone()))
+            .data(JobContext::new(latest_state.clone()))
+            .catch_panic()
+            .layer(SentryLayer::new())
+            .layer(trace_layer())
             .concurrency(JOB_CONCURRENCY)
-            .build(handle_latest_job);
-        let result = worker.run().await;
-        if let Err(error) = result {
-            tracing::error!(error = %error, "public history latest worker stopped");
-        }
+            .build(handle_latest_job)
     });
 
-    tokio::spawn(async move {
-        let storage = backfill_storage(state.db_pool.clone());
-        let worker = WorkerBuilder::new("public-history-backfill")
-            .backend(storage)
-            .data(JobContext::new(state))
-            .enable_tracing()
+    monitor.register(move |_attempt| {
+        WorkerBuilder::new("public-history-backfill")
+            .backend(backfill_storage(state.db_pool.clone()))
+            .data(JobContext::new(state.clone()))
+            .catch_panic()
+            .layer(SentryLayer::new())
+            .layer(trace_layer())
             .concurrency(BACKFILL_JOB_CONCURRENCY)
-            .build(handle_backfill_job);
-        let result = worker.run().await;
-        if let Err(error) = result {
-            tracing::error!(error = %error, "public history backfill worker stopped");
-        }
-    });
+            .build(handle_backfill_job)
+    })
+}
+
+/// The two queue storages, typed for apalis-board registration.
+pub(crate) fn board_storages(pool: PgPool) -> Vec<PostgresStorage<PublicHistoryJob>> {
+    vec![latest_storage(pool.clone()), backfill_storage(pool)]
 }

--- a/nt-be/src/handlers/relay/parse/mod.rs
+++ b/nt-be/src/handlers/relay/parse/mod.rs
@@ -70,12 +70,20 @@ pub struct RelayResponse {
 }
 
 /// Build an error response from a status and message.
+///
+/// This is the single choke point every relay failure flows through — parse
+/// rejects, authorization, policy, registrations, and on-chain submission —
+/// so it also emits the ERROR event that the tracing→Sentry bridge turns
+/// into a Sentry alert. The message is a field (not the log message) so all
+/// relay failures group under one Sentry issue instead of one per message.
 pub fn error_response(status: StatusCode, msg: impl Into<String>) -> RelayError {
+    let msg = msg.into();
+    tracing::error!(status = %status, error = %msg, "relay request failed");
     (
         status,
         Json(RelayResponse {
             success: false,
-            error: Some(msg.into()),
+            error: Some(msg),
         }),
     )
 }

--- a/nt-be/src/handlers/relay/submit.rs
+++ b/nt-be/src/handlers/relay/submit.rs
@@ -191,8 +191,7 @@ async fn submit_relay(
         }
     };
 
-    result.map_err(|error_message| {
-        tracing::error!("Relay execution failed: {}", error_message);
-        error_response(StatusCode::INTERNAL_SERVER_ERROR, error_message)
-    })
+    // `error_response` logs the failure at ERROR (→ Sentry); no extra log
+    // here or the same failure would produce two events.
+    result.map_err(|error_message| error_response(StatusCode::INTERNAL_SERVER_ERROR, error_message))
 }

--- a/nt-be/src/jobs/mod.rs
+++ b/nt-be/src/jobs/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod context;
 pub mod handlers;
+pub mod watchdog;
 
 use std::str::FromStr;
 use std::sync::Arc;
@@ -52,6 +53,33 @@ impl JobQueues {
             .iter()
             .find(|(queue, _)| *queue == name)
             .map(|(_, storage)| storage)
+    }
+}
+
+/// Registration-time accumulator: board entries plus the watchdog specs that
+/// mirror them. Filled by `register_cron_worker!`, split apart at the end of
+/// [`spawn_all`].
+#[derive(Default)]
+struct QueueRegistry {
+    entries: Vec<(&'static str, TickStorage)>,
+    specs: Vec<watchdog::JobSpec>,
+}
+
+impl QueueRegistry {
+    fn register(&mut self, name: &'static str, storage: TickStorage, interval_secs: Option<u64>) {
+        self.entries.push((name, storage));
+        match interval_secs {
+            Some(interval_secs) => self.specs.push(watchdog::JobSpec {
+                queue: name,
+                kind: watchdog::QueueKind::Cron { interval_secs },
+            }),
+            // A schedule with fewer than two upcoming ticks can't yield a
+            // cadence; leave the queue off the watchdog rather than guess.
+            None => tracing::warn!(
+                queue = name,
+                "could not derive cron interval; queue not watched for staleness"
+            ),
+        }
     }
 }
 
@@ -261,8 +289,12 @@ async fn push_now(storage: &TickStorage, queue: &'static str) {
 macro_rules! register_cron_worker {
     ($monitor:expr, $queues:expr, $state:expr, $name:literal, $schedule:expr, $handler:path) => {{
         let store = storage(&$state.db_pool, $name);
-        $queues.push(($name, store.clone()));
         let schedule = $schedule;
+        $queues.register(
+            $name,
+            store.clone(),
+            watchdog::schedule_interval_secs(&schedule),
+        );
         let state = $state.clone();
         // `register` takes a factory `Fn(attempt) -> Worker`: the Monitor
         // calls it to (re)build the worker, so a restart gets a fresh
@@ -312,7 +344,7 @@ pub async fn spawn_all(state: Arc<AppState>) -> (JobQueues, tokio::task::JoinHan
         .await
         .expect("failed to run apalis migrations");
 
-    let mut queues: Vec<(&'static str, TickStorage)> = Vec::new();
+    let mut queues = QueueRegistry::default();
 
     // apalis's own supervisor: runs every worker, restarts one that exits
     // (backend/storage failure) via `should_restart`, and drains in-flight
@@ -368,11 +400,21 @@ pub async fn spawn_all(state: Arc<AppState>) -> (JobQueues, tokio::task::JoinHan
     }
 
     if state.env_vars.nearblocks_api_key.is_some() {
-        crate::handlers::public_history::bronze::jobs::start_public_history_queue_workers(
-            state.clone(),
-        )
-        .await
-        .expect("failed to start public history queue workers");
+        // Task-queue (non-cron) workers, supervised by the same Monitor so
+        // they get restart-on-exit, catch_panic, and Sentry like cron jobs.
+        monitor =
+            crate::handlers::public_history::bronze::jobs::start_public_history_queue_workers(
+                monitor,
+                state.clone(),
+            )
+            .await
+            .expect("failed to start public history queue workers");
+        for queue in crate::handlers::public_history::bronze::jobs::QUEUE_NAMES {
+            queues.specs.push(watchdog::JobSpec {
+                queue,
+                kind: watchdog::QueueKind::Queue,
+            });
+        }
 
         monitor = register_cron_worker!(
             monitor,
@@ -546,6 +588,7 @@ pub async fn spawn_all(state: Arc<AppState>) -> (JobQueues, tokio::task::JoinHan
         // Look the queue up by name — relying on `last()` breaks silently
         // if another queue is later registered below this block.
         if let Some(store) = queues
+            .entries
             .iter()
             .find(|(name, _)| *name == "treasury-creation-sweeper")
             .map(|(_, s)| s.clone())
@@ -660,7 +703,21 @@ pub async fn spawn_all(state: Arc<AppState>) -> (JobQueues, tokio::task::JoinHan
         handlers::apalis_prune
     );
 
-    let queues = JobQueues { entries: queues };
+    // Watchdog: alerts (ERROR → Sentry) when any registered queue stops
+    // making progress. Its registry is installed below, once every queue is
+    // known.
+    monitor = register_cron_worker!(
+        monitor,
+        queues,
+        state,
+        "job-watchdog",
+        schedule_every_secs(60),
+        watchdog::job_watchdog
+    );
+
+    let QueueRegistry { entries, specs } = queues;
+    watchdog::install(specs);
+    let queues = JobQueues { entries };
 
     // Jobs that previously ran once at startup, in addition to their cron
     // schedule. Pushed as regular tasks so they show up on the board.
@@ -670,7 +727,6 @@ pub async fn spawn_all(state: Arc<AppState>) -> (JobQueues, tokio::task::JoinHan
         "public-dashboard-refresh",
         "ft-lockup-refresh",
         "token-price-backfill",
-        "balance-changes-usd-backfill",
         "gold-public-usd-backfill",
         "gold-confidential-usd-backfill",
     ] {
@@ -792,6 +848,15 @@ pub fn board_router(queues: &JobQueues, state: Arc<AppState>) -> Router {
     let mut api = ApiBuilder::new(Router::new());
     for (_, store) in &queues.entries {
         api = api.register(store.clone());
+    }
+    // The bronze public-history task queues are not Tick-backed, so they are
+    // not in `queues`; register them separately so they show on the board.
+    if state.env_vars.nearblocks_api_key.is_some() {
+        for store in
+            crate::handlers::public_history::bronze::jobs::board_storages(state.db_pool.clone())
+        {
+            api = api.register(store);
+        }
     }
 
     // The board registers an `/api/v1/events` SSE route (apalis-board's

--- a/nt-be/src/jobs/watchdog.rs
+++ b/nt-be/src/jobs/watchdog.rs
@@ -1,0 +1,338 @@
+//! Job-health watchdog: detects background jobs that have *stopped running*.
+//!
+//! Task failures are already captured (per-task `SentryLayer`, task rows on
+//! the board), but a stalled job produces no failures at all — a dead cron
+//! stream, a stuck worker, or a queue nobody consumes is invisible until
+//! someone eyeballs every queue in the board UI. This module closes that gap:
+//!
+//! - [`spawn_all`](super::spawn_all) registers every queue here with its
+//!   expected cadence ([`QueueKind::Cron`]) or as a task queue
+//!   ([`QueueKind::Queue`]).
+//! - The `job-watchdog` cron worker calls [`evaluate`] each minute and emits
+//!   a `tracing::error!` for every stale queue (rate-limited per queue), which
+//!   the tracing→Sentry bridge turns into a Sentry event.
+//! - The `/api/jobs/health` endpoint ([`jobs_health`]) serves the same
+//!   [`evaluate`] output as JSON — one table with last success / failure /
+//!   backlog per queue — and answers 503 while anything is stale, so an
+//!   external monitor (Oh Dear) catches even a dead process or dead monitor,
+//!   which the in-process watchdog cannot report on itself.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use apalis::prelude::*;
+use apalis_cron::Tick;
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sqlx::PgPool;
+
+use crate::AppState;
+
+/// How a queue is fed, which decides how staleness is judged.
+#[derive(Debug, Clone, Copy)]
+pub enum QueueKind {
+    /// Cron-driven: a tick lands every `interval_secs`; the queue is stale
+    /// when no task has *succeeded* for well over that interval.
+    Cron { interval_secs: u64 },
+    /// Event-driven task queue: tasks arrive irregularly; the queue is stale
+    /// when waiting tasks sit unconsumed for too long (dead worker).
+    Queue,
+}
+
+/// One registered queue the watchdog knows about.
+#[derive(Debug, Clone)]
+pub struct JobSpec {
+    pub queue: &'static str,
+    pub kind: QueueKind,
+}
+
+/// Registry installed once by `spawn_all` after all queues are registered.
+/// The instant is the boot baseline: before the first success of a job, its
+/// staleness is measured from here, so a job that never manages to run still
+/// alerts (instead of "no data, no alarm").
+static REGISTRY: OnceLock<(DateTime<Utc>, Vec<JobSpec>)> = OnceLock::new();
+
+pub fn install(specs: Vec<JobSpec>) {
+    if REGISTRY.set((Utc::now(), specs)).is_err() {
+        tracing::warn!("job watchdog registry installed twice; keeping first");
+    }
+}
+
+/// Seconds between two consecutive fire times of `schedule`. All schedules
+/// used by our jobs are uniform, so the gap between the next two ticks is
+/// the cadence.
+pub fn schedule_interval_secs(schedule: &cron::Schedule) -> Option<u64> {
+    let mut upcoming = schedule.upcoming(Utc);
+    let first = upcoming.next()?;
+    let second = upcoming.next()?;
+    Some((second - first).num_seconds().max(1) as u64)
+}
+
+/// Health snapshot of one queue, serialized as-is by `/api/jobs/health`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobHealth {
+    pub queue: String,
+    pub kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interval_secs: Option<u64>,
+    pub last_success_at: Option<DateTime<Utc>>,
+    pub last_success_age_secs: Option<i64>,
+    pub last_failure_at: Option<DateTime<Utc>>,
+    pub last_error: Option<String>,
+    pub pending: i64,
+    pub running: i64,
+    /// Age of the oldest task that is due but not picked up.
+    pub oldest_waiting_secs: Option<i64>,
+    pub stale: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(sqlx::FromRow)]
+struct QueueAgg {
+    job_type: String,
+    last_success_at: Option<DateTime<Utc>>,
+    last_failure_at: Option<DateTime<Utc>>,
+    pending: i64,
+    running: i64,
+    oldest_waiting_run_at: Option<DateTime<Utc>>,
+}
+
+/// A cron queue alerts when no success for `2 × interval + 10 min`: one
+/// missed cycle is routine (a failed cycle waits for the next tick by
+/// design), two plus grace means the job is not recovering on its own.
+fn cron_staleness_threshold(interval_secs: u64) -> Duration {
+    Duration::from_secs(interval_secs * 2 + 600)
+}
+
+/// A task queue alerts when a due task has been waiting this long with no
+/// worker picking it up. Generous enough to absorb backfill bursts.
+const QUEUE_WAITING_THRESHOLD: Duration = Duration::from_secs(1800);
+
+/// Builds the health snapshot for every registered queue from `apalis.jobs`.
+pub async fn evaluate(pool: &PgPool) -> Result<Vec<JobHealth>, sqlx::Error> {
+    let Some((installed_at, specs)) = REGISTRY.get() else {
+        return Ok(Vec::new());
+    };
+
+    let aggregates: Vec<QueueAgg> = sqlx::query_as(
+        r#"
+        SELECT
+            job_type,
+            max(done_at) FILTER (WHERE status = 'Done')                AS last_success_at,
+            max(done_at) FILTER (WHERE status IN ('Failed', 'Killed')) AS last_failure_at,
+            count(*)     FILTER (WHERE status IN ('Pending', 'Queued')) AS pending,
+            count(*)     FILTER (WHERE status = 'Running')             AS running,
+            min(run_at)  FILTER (WHERE status IN ('Pending', 'Queued')
+                                   AND run_at < now())                 AS oldest_waiting_run_at
+        FROM apalis.jobs
+        GROUP BY job_type
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    // apalis stores a task's outcome in `last_result` jsonb: `{"Ok": …}` on
+    // success, `{"Err": "message"}` on failure. Pull the newest failure's
+    // message per queue.
+    let last_errors: Vec<(String, Option<String>)> = sqlx::query_as(
+        r#"
+        SELECT DISTINCT ON (job_type) job_type, last_result->>'Err' AS last_error
+        FROM apalis.jobs
+        WHERE status IN ('Failed', 'Killed') AND last_result->>'Err' IS NOT NULL
+        ORDER BY job_type, done_at DESC NULLS LAST
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut by_queue: HashMap<String, QueueAgg> = aggregates
+        .into_iter()
+        .map(|agg| (agg.job_type.clone(), agg))
+        .collect();
+    let mut errors_by_queue: HashMap<String, Option<String>> = last_errors.into_iter().collect();
+
+    let now = Utc::now();
+    let report = specs
+        .iter()
+        .map(|spec| {
+            let agg = by_queue.remove(spec.queue);
+            let last_success_at = agg.as_ref().and_then(|a| a.last_success_at);
+            let last_success_age_secs = last_success_at.map(|t| (now - t).num_seconds());
+            let oldest_waiting_secs = agg
+                .as_ref()
+                .and_then(|a| a.oldest_waiting_run_at)
+                .map(|t| (now - t).num_seconds());
+
+            let (stale, reason) = match spec.kind {
+                QueueKind::Cron { interval_secs } => {
+                    // Baseline: last success, or boot for a job that has
+                    // never succeeded this process lifetime.
+                    let baseline = last_success_at.unwrap_or(*installed_at).max(*installed_at);
+                    let threshold = cron_staleness_threshold(interval_secs);
+                    let age = (now - baseline).num_seconds();
+                    if age > threshold.as_secs() as i64 {
+                        (
+                            true,
+                            Some(format!(
+                                "no successful run for {age}s (expected every {interval_secs}s)"
+                            )),
+                        )
+                    } else {
+                        (false, None)
+                    }
+                }
+                QueueKind::Queue => match oldest_waiting_secs {
+                    Some(waiting) if waiting > QUEUE_WAITING_THRESHOLD.as_secs() as i64 => (
+                        true,
+                        Some(format!(
+                            "oldest due task waiting {waiting}s; worker appears stalled"
+                        )),
+                    ),
+                    _ => (false, None),
+                },
+            };
+
+            JobHealth {
+                queue: spec.queue.to_string(),
+                kind: match spec.kind {
+                    QueueKind::Cron { .. } => "cron",
+                    QueueKind::Queue => "queue",
+                },
+                interval_secs: match spec.kind {
+                    QueueKind::Cron { interval_secs } => Some(interval_secs),
+                    QueueKind::Queue => None,
+                },
+                last_success_at,
+                last_success_age_secs,
+                last_failure_at: agg.as_ref().and_then(|a| a.last_failure_at),
+                last_error: errors_by_queue.remove(spec.queue).flatten(),
+                pending: agg.as_ref().map_or(0, |a| a.pending),
+                running: agg.as_ref().map_or(0, |a| a.running),
+                oldest_waiting_secs,
+                stale,
+                reason,
+            }
+        })
+        .collect();
+
+    Ok(report)
+}
+
+/// Re-alert a still-stale queue at most this often.
+const ALERT_REPEAT_INTERVAL: Duration = Duration::from_secs(1800);
+
+static LAST_ALERTED: LazyLock<Mutex<HashMap<String, Instant>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// The `job-watchdog` cron task: evaluates all queues, alerts on stale ones.
+pub async fn job_watchdog(_t: Tick, state: Data<Arc<AppState>>) -> Result<String, BoxDynError> {
+    let report = evaluate(&state.db_pool).await?;
+    let total = report.len();
+    let mut stale_count = 0usize;
+
+    let mut last_alerted = LAST_ALERTED
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for job in &report {
+        if job.stale {
+            stale_count += 1;
+            let due = last_alerted
+                .get(&job.queue)
+                .is_none_or(|at| at.elapsed() >= ALERT_REPEAT_INTERVAL);
+            if due {
+                last_alerted.insert(job.queue.clone(), Instant::now());
+                // ERROR on purpose: the tracing→Sentry bridge captures
+                // ERROR-level events, so this is the Sentry alert.
+                tracing::error!(
+                    queue = %job.queue,
+                    reason = job.reason.as_deref().unwrap_or(""),
+                    last_success_at = ?job.last_success_at,
+                    last_error = job.last_error.as_deref().unwrap_or(""),
+                    pending = job.pending,
+                    running = job.running,
+                    "background job stale: not making progress"
+                );
+            }
+        } else if last_alerted.remove(&job.queue).is_some() {
+            tracing::info!(queue = %job.queue, "background job recovered");
+        }
+    }
+
+    if stale_count > 0 {
+        return Ok(format!("{total} queues checked, {stale_count} STALE"));
+    }
+    Ok(format!("{total} queues checked, all healthy"))
+}
+
+/// `GET /api/jobs/health` — admin Basic Auth; 503 while any queue is stale
+/// so an external uptime monitor can alert on the status code alone.
+pub async fn jobs_health(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    if let Err(denied) = crate::handlers::warnings::admin::require_admin(&headers, &state) {
+        return denied.into_response();
+    }
+
+    let report = match evaluate(&state.db_pool).await {
+        Ok(report) => report,
+        Err(e) => {
+            tracing::error!(error = %e, "jobs health evaluation failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "health evaluation failed" })),
+            )
+                .into_response();
+        }
+    };
+
+    let healthy = report.iter().all(|job| !job.stale);
+    let status = if healthy {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (
+        status,
+        Json(serde_json::json!({
+            "healthy": healthy,
+            "generatedAt": Utc::now(),
+            "jobs": report,
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interval_derived_from_uniform_schedules() {
+        use std::str::FromStr;
+        let minutely = cron::Schedule::from_str("0 */1 * * * *").unwrap();
+        assert_eq!(schedule_interval_secs(&minutely), Some(60));
+        let daily = cron::Schedule::from_str("0 0 0 * * *").unwrap();
+        assert_eq!(schedule_interval_secs(&daily), Some(86_400));
+        let weekly = cron::Schedule::from_str("0 0 0 * * Mon").unwrap();
+        assert_eq!(schedule_interval_secs(&weekly), Some(604_800));
+        let six_hourly = cron::Schedule::from_str("0 0 */6 * * *").unwrap();
+        assert_eq!(schedule_interval_secs(&six_hourly), Some(21_600));
+    }
+
+    #[test]
+    fn cron_threshold_has_floor_for_fast_jobs() {
+        // 2s job: 2×2+600 = 604s — brief hiccups never alert.
+        assert_eq!(cron_staleness_threshold(2), Duration::from_secs(604));
+        assert_eq!(
+            cron_staleness_threshold(86_400),
+            Duration::from_secs(173_400)
+        );
+    }
+}

--- a/nt-be/src/routes/mod.rs
+++ b/nt-be/src/routes/mod.rs
@@ -74,6 +74,9 @@ pub fn create_routes(state: Arc<AppState>) -> Router {
     Router::new()
         // Health check
         .route("/api/health", get(health_check))
+        // Background-job health: per-queue last success/failure/backlog and
+        // staleness; 503 while anything is stale. Admin Basic Auth.
+        .route("/api/jobs/health", get(crate::jobs::watchdog::jobs_health))
         .route(
             "/api/public/dashboard/aum",
             get(handlers::public_dashboard::get_public_dashboard_aum),


### PR DESCRIPTION
## Problem

apalis-board is hard to reason about at a glance, background jobs can stop running with no signal, and none of it reaches Sentry. Separately, delegation-relay failures (bad transaction or server error) were logged at WARN or not surfaced to Sentry at all.

## Changes

**1. Job-health watchdog** (`nt-be/src/jobs/watchdog.rs`)
- Every queue is registered with its cadence at spawn time; the cron interval is derived from the schedule itself.
- A `job-watchdog` cron worker evaluates `apalis.jobs` each minute. A cron queue is stale when it has had no successful run for `2×interval + 10min`; a task queue is stale when a due task has waited unconsumed for >30min (dead worker). The staleness baseline for a job that has never succeeded is process boot, so a job that never runs still alerts.
- Stale queues emit `tracing::error!` → Sentry (per-queue deduped to every 30min; logs a recovery line when a queue comes back). This catches the silent cases — stalled cron stream, dead worker, unconsumed queue — that produce zero task failures.

**2. `GET /api/jobs/health`** (admin Basic Auth)
- One JSON table: per-queue last success / last failure / backlog / staleness. Returns **503** while anything is stale, so an external uptime monitor (Oh Dear) catches even a fully dead process — which the in-process watchdog cannot report on itself.

**3. Supervised bronze public-history workers**
- The two public-history queue workers were bare `tokio::spawn` + `worker.run()`: no restart, no `catch_panic`, no Sentry — a silent-death tier. They now register on the shared apalis `Monitor` with `catch_panic` + `SentryLayer` + INFO `TraceLayer`, the same containment as the cron workers, and appear on the board and in the watchdog.

**4. Relay errors → Sentry**
- `error_response` is the single choke point every relay failure flows through (parse, auth, policy, registrations, on-chain submit). It now emits one ERROR event → Sentry, with the message as a field so all relay failures group under one issue. Removed the now-duplicate log in `submit.rs`.

Also drops a dead startup-push entry for the commented-out `balance-changes-usd-backfill` queue.

## Testing
- `cargo fmt --check`, `cargo clippy --lib --bins -- -D warnings`: clean.
- `cargo test --lib --bins`: 490 passed.
- `cargo test --tests` (integration): all passed.
- Both watchdog SQL queries validated against a live apalis schema with seeded rows; new unit tests cover interval derivation and the staleness threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRWEKUFYCcmGGhwdDYd471