### PR TITLE
feat: passkey card flex-col layout + Web3 wallets separator

### DIFF
--- a/nt-fe/components/connect-wallet-selector.tsx
+++ b/nt-fe/components/connect-wallet-selector.tsx
@@ -366,40 +366,50 @@ export function ConnectWalletSelector({
                                         isConnectingWallet || isOfflineBlocked
                                     }
                                 >
-                                    <div className="flex w-full items-start gap-3">
-                                        <WalletOptionIcon wallet={wallet} />
-                                        <div className="flex min-w-0 flex-1 flex-col gap-1">
-                                            <div className="flex items-start justify-between gap-2">
-                                                <span className="text-lg font-semibold">
-                                                    {t(
-                                                        "walletSelector.passkeyCardTitle",
-                                                    )}
-                                                </span>
-                                                <Pill
-                                                    title={badge.label}
-                                                    info={
-                                                        "tooltip" in badge
-                                                            ? badge.tooltip
-                                                            : undefined
-                                                    }
-                                                    className={
-                                                        "isOffline" in badge &&
-                                                        badge.isOffline
-                                                            ? "shrink-0 bg-general-warning-background-faded text-general-warning-foreground"
-                                                            : "shrink-0 bg-general-success-background-faded text-general-success-foreground"
-                                                    }
-                                                />
-                                            </div>
-                                            <span className="text-sm font-normal text-muted-foreground whitespace-normal">
-                                                {t(
-                                                    "walletSelector.passkeyCardSubtitle",
-                                                )}
-                                            </span>
+                                    <div className="flex w-full flex-col gap-2">
+                                        <div className="flex items-center justify-between">
+                                            <WalletOptionIcon wallet={wallet} />
+                                            <Pill
+                                                title={badge.label}
+                                                info={
+                                                    "tooltip" in badge
+                                                        ? badge.tooltip
+                                                        : undefined
+                                                }
+                                                className={
+                                                    "isOffline" in badge &&
+                                                    badge.isOffline
+                                                        ? "shrink-0 bg-general-warning-background-faded text-general-warning-foreground"
+                                                        : "shrink-0 bg-general-success-background-faded text-general-success-foreground"
+                                                }
+                                            />
                                         </div>
+                                        <div className="text-lg font-semibold">
+                                            {t(
+                                                "walletSelector.passkeyCardTitle",
+                                            )}
+                                        </div>
+                                        <span className="text-sm font-normal text-muted-foreground whitespace-normal">
+                                            {t(
+                                                "walletSelector.passkeyCardSubtitle",
+                                            )}
+                                        </span>
                                     </div>
                                 </Button>
                             );
                         })()}
+                    {passkeyOption && (
+                        <div
+                            role="separator"
+                            className="flex items-center gap-3 sm:col-span-2"
+                        >
+                            <span className="h-px flex-1 bg-border" />
+                            <span className="text-xs font-medium text-muted-foreground">
+                                {t("walletSelector.web3WalletsSeparator")}
+                            </span>
+                            <span className="h-px flex-1 bg-border" />
+                        </div>
+                    )}
                     {otherOptions.map((wallet) => {
                         // Use aria-disabled (not disabled) when offline so the
                         // Offline badge tooltip can still receive hover events.

--- a/nt-fe/messages/de.json
+++ b/nt-fe/messages/de.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Passkey für Touch ID und Face ID",
             "passkeyCardSubtitle": "Melde dich mit der Biometrie oder dem Code deines Geräts an",
-            "passkeyCardBadge": "Empfohlen für einfaches Onboarding"
+            "passkeyCardBadge": "Einfach & Sicher",
+            "web3WalletsSeparator": "Web3-Wallets"
         },
         "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten",
         "creationFailed": "Erstellung der Treasury fehlgeschlagen. Bitte erneut versuchen.",

--- a/nt-fe/messages/en.json
+++ b/nt-fe/messages/en.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Passkey for Touch ID and Face ID",
             "passkeyCardSubtitle": "Use your device biometrics or passcode to sign in",
-            "passkeyCardBadge": "Recommended for smooth onboarding"
+            "passkeyCardBadge": "Easy & Secure",
+            "web3WalletsSeparator": "Web3 wallets"
         },
         "unexpectedError": "An unexpected error occurred",
         "creationFailed": "Failed to create treasury. Please try again.",

--- a/nt-fe/messages/es.json
+++ b/nt-fe/messages/es.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Passkey para Touch ID y Face ID",
             "passkeyCardSubtitle": "Inicia sesión con la biometría o el código de tu dispositivo",
-            "passkeyCardBadge": "Recomendado para una incorporación sencilla"
+            "passkeyCardBadge": "Fácil y seguro",
+            "web3WalletsSeparator": "Monederos Web3"
         },
         "unexpectedError": "Se produjo un error inesperado",
         "creationFailed": "Error al crear la tesorería. Inténtalo de nuevo.",

--- a/nt-fe/messages/fr.json
+++ b/nt-fe/messages/fr.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Passkey pour Touch ID et Face ID",
             "passkeyCardSubtitle": "Connectez-vous avec la biométrie ou le code de votre appareil",
-            "passkeyCardBadge": "Recommandé pour une prise en main facile"
+            "passkeyCardBadge": "Simple et sécurisé",
+            "web3WalletsSeparator": "Portefeuilles Web3"
         },
         "unexpectedError": "Une erreur inattendue s'est produite",
         "creationFailed": "Échec de la création de la trésorerie. Veuillez réessayer.",

--- a/nt-fe/messages/he.json
+++ b/nt-fe/messages/he.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Passkey עבור Touch ID ו-Face ID",
             "passkeyCardSubtitle": "היכנסו באמצעות זיהוי ביומטרי או קוד המכשיר",
-            "passkeyCardBadge": "מומלץ לתחילת עבודה חלקה"
+            "passkeyCardBadge": "פשוט ומאובטח",
+            "web3WalletsSeparator": "ארנקי Web3"
         },
         "unexpectedError": "אירעה שגיאה בלתי צפויה",
         "creationFailed": "יצירת האוצר נכשלה. אנא נסה שוב.",

--- a/nt-fe/messages/id.json
+++ b/nt-fe/messages/id.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Passkey untuk Touch ID dan Face ID",
             "passkeyCardSubtitle": "Masuk dengan biometrik atau kode sandi perangkat Anda",
-            "passkeyCardBadge": "Direkomendasikan untuk orientasi yang mudah"
+            "passkeyCardBadge": "Mudah & Aman",
+            "web3WalletsSeparator": "Dompet Web3"
         },
         "unexpectedError": "Terjadi kesalahan tak terduga",
         "creationFailed": "Gagal membuat treasury. Silakan coba lagi.",

--- a/nt-fe/messages/ja.json
+++ b/nt-fe/messages/ja.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Touch ID・Face ID対応のパスキー",
             "passkeyCardSubtitle": "デバイスの生体認証またはパスコードでサインイン",
-            "passkeyCardBadge": "スムーズな導入におすすめ"
+            "passkeyCardBadge": "簡単・安全",
+            "web3WalletsSeparator": "Web3ウォレット"
         },
         "unexpectedError": "予期しないエラーが発生しました",
         "creationFailed": "トレジャリーの作成に失敗しました。もう一度お試しください。",

--- a/nt-fe/messages/ko.json
+++ b/nt-fe/messages/ko.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Touch ID 및 Face ID용 패스키",
             "passkeyCardSubtitle": "기기의 생체 인식 또는 비밀번호로 로그인하세요",
-            "passkeyCardBadge": "간편한 시작을 위해 추천"
+            "passkeyCardBadge": "쉽고 안전하게",
+            "web3WalletsSeparator": "Web3 지갑"
         },
         "unexpectedError": "예기치 않은 오류가 발생했습니다",
         "creationFailed": "트레저리 생성에 실패했습니다. 다시 시도해 주세요.",

--- a/nt-fe/messages/pt.json
+++ b/nt-fe/messages/pt.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Passkey para Touch ID e Face ID",
             "passkeyCardSubtitle": "Entre com a biometria ou o código do seu dispositivo",
-            "passkeyCardBadge": "Recomendado para uma integração simples"
+            "passkeyCardBadge": "Fácil e seguro",
+            "web3WalletsSeparator": "Carteiras Web3"
         },
         "unexpectedError": "Ocorreu um erro inesperado",
         "creationFailed": "Falha ao criar tesouraria. Por favor, tente novamente.",

--- a/nt-fe/messages/tr.json
+++ b/nt-fe/messages/tr.json
@@ -1332,7 +1332,8 @@
             },
             "passkeyCardTitle": "Touch ID ve Face ID için Passkey",
             "passkeyCardSubtitle": "Cihazınızın biyometriği veya parolasıyla oturum açın",
-            "passkeyCardBadge": "Sorunsuz başlangıç için önerilir"
+            "passkeyCardBadge": "Kolay ve Güvenli",
+            "web3WalletsSeparator": "Web3 cüzdanları"
         },
         "unexpectedError": "Beklenmedik bir hata oluştu",
         "creationFailed": "Hazine oluşturulamadı. Lütfen tekrar deneyin.",

--- a/nt-fe/messages/uk.json
+++ b/nt-fe/messages/uk.json
@@ -1315,7 +1315,8 @@
             },
             "passkeyCardTitle": "Passkey для Touch ID та Face ID",
             "passkeyCardSubtitle": "Увійдіть за допомогою біометрії або коду доступу пристрою",
-            "passkeyCardBadge": "Рекомендовано для простого старту"
+            "passkeyCardBadge": "Просто й безпечно",
+            "web3WalletsSeparator": "Web3-гаманці"
         },
         "unexpectedError": "Сталася неочікувана помилка",
         "creationFailed": "Не вдалось створити скарбницю. Спробуйте ще раз.",

--- a/nt-fe/messages/vi.json
+++ b/nt-fe/messages/vi.json
@@ -1315,7 +1315,8 @@
             },
             "passkeyCardTitle": "Passkey cho Touch ID và Face ID",
             "passkeyCardSubtitle": "Đăng nhập bằng sinh trắc học hoặc mật mã của thiết bị",
-            "passkeyCardBadge": "Được khuyến nghị để bắt đầu dễ dàng"
+            "passkeyCardBadge": "Dễ dàng & An toàn",
+            "web3WalletsSeparator": "Ví Web3"
         },
         "unexpectedError": "Đã xảy ra lỗi không mong muốn",
         "creationFailed": "Không thể tạo ngân quỹ. Vui lòng thử lại.",

--- a/nt-fe/messages/zh.json
+++ b/nt-fe/messages/zh.json
@@ -1315,7 +1315,8 @@
             },
             "passkeyCardTitle": "支持 Touch ID 和 Face ID 的通行密钥",
             "passkeyCardSubtitle": "使用设备的生物识别或密码登录",
-            "passkeyCardBadge": "推荐，轻松上手"
+            "passkeyCardBadge": "简单又安全",
+            "web3WalletsSeparator": "Web3 钱包"
         },
         "unexpectedError": "发生意外错误",
         "creationFailed": "创建金库失败。请再试一次。",


### PR DESCRIPTION
Small layout follow-up to #1140 on the "Choose how to sign in" screen.

- **Layout:** the Passkey hero card now uses the same `flex-col` content layout as the other wallet buttons — icon + chip on the top row, then the title, then the subtitle (it still spans both columns).
- **Chip:** shortened to **"Easy & Secure"**.
- **Separator:** added a labeled **"Web3 wallets"** divider between the Passkey card and the remaining wallet options.

i18n: `passkeyCardBadge` updated and new `web3WalletsSeparator` key added across all 13 locales.

## Checks (local)
`check:i18n`, `format:check`, and `tsc` (no new errors) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)