### PR TITLE
Fix apalis job wedge + slow board: handler timeout, isolated/parallel account maintenance, prune, board indexes

### DIFF
--- a/nt-be/Cargo.toml
+++ b/nt-be/Cargo.toml
@@ -57,7 +57,7 @@ bs58 = "0.5"
 url = "2"
 teloxide = { version = "0.17.0", features = ["rustls"], default-features = false }
 # Background job processing (apalis + web board)
-apalis = { version = "1.0.0-rc.9", features = ["limit", "retry", "tracing", "catch-panic", "sentry"] }
+apalis = { version = "1.0.0-rc.9", features = ["limit", "retry", "tracing", "catch-panic", "sentry", "timeout"] }
 apalis-core = { version = "1.0.0-rc.9", features = ["serde"] }
 apalis-cron = { version = "1.0.0-rc.8", features = ["serde"] }
 apalis-sql = "1.0.0-rc.8"

--- a/nt-be/src/handlers/balance_changes/account_monitor.rs
+++ b/nt-be/src/handlers/balance_changes/account_monitor.rs
@@ -1,3 +1,4 @@
+use futures::stream::StreamExt;
 use near_api::NetworkConfig;
 use sqlx::PgPool;
 use sqlx::types::chrono::{DateTime, Utc};
@@ -139,11 +140,79 @@ pub async fn run_maintenance_cycle(
         return Ok(());
     }
 
-    tracing::info!("Processing {} enabled accounts", accounts.len());
+    let concurrency = maintenance_concurrency();
+    let account_timeout = maintenance_account_timeout();
+    tracing::info!(
+        accounts = accounts.len(),
+        concurrency,
+        timeout_secs = account_timeout.as_secs(),
+        "Processing enabled accounts"
+    );
 
-    for (account_id, original_dirty_at) in &accounts {
-        tracing::info!("Processing {}", account_id);
+    // Process accounts with bounded parallelism, each isolated by a timeout.
+    // Isolation is the root-cause fix for the queue wedge: a single account
+    // whose RPC hangs (or errors) is abandoned for this cycle instead of
+    // stalling every account behind it or blocking the worker forever.
+    futures::stream::iter(accounts.iter())
+        .for_each_concurrent(concurrency, |(account_id, original_dirty_at)| async move {
+            match tokio::time::timeout(
+                account_timeout,
+                process_account(app_state, account_id, *original_dirty_at, up_to_block),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::error!(account_id = %account_id, "account maintenance failed: {e}")
+                }
+                Err(_) => tracing::warn!(
+                    account_id = %account_id,
+                    timeout_secs = account_timeout.as_secs(),
+                    "account maintenance timed out; abandoning this account for this cycle"
+                ),
+            }
+        })
+        .await;
 
+    tracing::info!("Cycle complete");
+    Ok(())
+}
+
+/// Bounded parallelism for per-account maintenance within one cycle
+/// (`ACCOUNT_MAINTENANCE_CONCURRENCY`, default 4). Kept modest so parallel
+/// accounts don't exhaust the shared DB pool (max 20) or upstream RPC budgets.
+fn maintenance_concurrency() -> usize {
+    std::env::var("ACCOUNT_MAINTENANCE_CONCURRENCY")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(4)
+}
+
+/// Per-account wall-clock budget
+/// (`ACCOUNT_MAINTENANCE_ACCOUNT_TIMEOUT_SECONDS`, default 120s). One account
+/// whose RPC hangs is abandoned for this cycle rather than wedging the worker;
+/// the next cron tick retries it. This is the inner, per-account counterpart to
+/// the outer whole-handler `job_timeout` safety net.
+fn maintenance_account_timeout() -> std::time::Duration {
+    let secs = std::env::var("ACCOUNT_MAINTENANCE_ACCOUNT_TIMEOUT_SECONDS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(120);
+    std::time::Duration::from_secs(secs)
+}
+
+/// Full per-account maintenance pipeline. All step errors stay isolated to this
+/// account (the caller logs and continues), so one account's failure can no
+/// longer abort the whole cycle as the previous `?`-in-loop did.
+async fn process_account(
+    app_state: &AppState,
+    account_id: &str,
+    original_dirty_at: Option<DateTime<Utc>>,
+    up_to_block: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    {
         {
             // Regular treasury: full on-chain pipeline
 
@@ -458,7 +527,6 @@ pub async fn run_maintenance_cycle(
         }
     }
 
-    tracing::info!("Cycle complete");
     Ok(())
 }
 

--- a/nt-be/src/handlers/public_history/bronze/jobs/worker.rs
+++ b/nt-be/src/handlers/public_history/bronze/jobs/worker.rs
@@ -525,6 +525,9 @@ pub(crate) fn register_public_history_job_workers(
         WorkerBuilder::new("public-history-latest")
             .backend(latest_storage(latest_state.db_pool.clone()))
             .data(JobContext::new(latest_state.clone()))
+            // Bounds the handler so a hung NearBlocks fetch aborts and frees
+            // its slot instead of wedging the worker (see `crate::jobs::job_timeout`).
+            .timeout(crate::jobs::job_timeout())
             .catch_panic()
             .layer(SentryLayer::new())
             .layer(trace_layer())
@@ -536,6 +539,7 @@ pub(crate) fn register_public_history_job_workers(
         WorkerBuilder::new("public-history-backfill")
             .backend(backfill_storage(state.db_pool.clone()))
             .data(JobContext::new(state.clone()))
+            .timeout(crate::jobs::job_timeout())
             .catch_panic()
             .layer(SentryLayer::new())
             .layer(trace_layer())

--- a/nt-be/src/jobs/handlers.rs
+++ b/nt-be/src/jobs/handlers.rs
@@ -477,29 +477,65 @@ pub async fn ft_lockup_refresh(
     }
 }
 
-/// Deletes finished apalis tasks older than `APALIS_TASK_RETENTION_DAYS`
-/// (default 7) so high-frequency queues don't grow unbounded.
+/// Prunes terminal apalis tasks so the high-frequency queues (~1M rows/day)
+/// don't bloat the `apalis.jobs` table — which slows every poll/keep-alive
+/// query and the board UI.
+///
+/// Retention is in **hours** (`APALIS_TASK_RETENTION_HOURS`, default 48),
+/// falling back to `APALIS_TASK_RETENTION_DAYS × 24` if only the old day-based
+/// var is set. Deletes `Done`/`Killed` **and** exhausted `Failed`
+/// (`attempts >= max_attempts`) rows — the latter are terminal too and were
+/// never cleaned before, so they accumulated. Retryable `Failed` rows
+/// (`attempts < max_attempts`) and any Pending/Queued/Running task are left
+/// untouched. Runs in bounded batches so a large backlog can't hold a long
+/// lock on the table the workers are actively polling.
 pub async fn apalis_prune(_t: Tick, state: Data<Arc<AppState>>) -> Result<String, BoxDynError> {
-    // Clamp so a misconfigured (negative) value can't flip the cutoff into
-    // the future and delete *every* finished task; cap at ~10y for sanity.
-    let retention_days: i64 = std::env::var("APALIS_TASK_RETENTION_DAYS")
+    // Clamp so a misconfigured (negative) value can't flip the cutoff into the
+    // future and delete *every* terminal task; cap at ~10y for sanity.
+    let retention_hours: i64 = std::env::var("APALIS_TASK_RETENTION_HOURS")
         .ok()
         .and_then(|s| s.parse::<i64>().ok())
-        .unwrap_or(7)
-        .clamp(0, 3650);
+        .or_else(|| {
+            std::env::var("APALIS_TASK_RETENTION_DAYS")
+                .ok()
+                .and_then(|s| s.parse::<i64>().ok())
+                .map(|days| days.saturating_mul(24))
+        })
+        .unwrap_or(48)
+        .clamp(0, 3650 * 24);
 
-    let result = sqlx::query(
-        "DELETE FROM apalis.jobs
-         WHERE status IN ('Done', 'Killed')
-           AND done_at IS NOT NULL
-           AND done_at < now() - make_interval(days => $1::int)",
-    )
-    .bind(retention_days)
-    .execute(&state.db_pool)
-    .await?;
+    const BATCH_SIZE: i64 = 10_000;
+    // Backstop against a runaway loop; 100 batches = up to 1M rows per run.
+    const MAX_BATCHES: usize = 100;
+
+    let mut total: u64 = 0;
+    for _ in 0..MAX_BATCHES {
+        let result = sqlx::query(
+            "DELETE FROM apalis.jobs
+             WHERE id IN (
+                 SELECT id FROM apalis.jobs
+                 WHERE done_at IS NOT NULL
+                   AND done_at < now() - make_interval(hours => $1::int)
+                   AND (
+                       status IN ('Done', 'Killed')
+                       OR (status = 'Failed' AND attempts >= max_attempts)
+                   )
+                 LIMIT $2
+             )",
+        )
+        .bind(retention_hours)
+        .bind(BATCH_SIZE)
+        .execute(&state.db_pool)
+        .await?;
+
+        let deleted = result.rows_affected();
+        total += deleted;
+        if (deleted as i64) < BATCH_SIZE {
+            break;
+        }
+    }
 
     Ok(format!(
-        "pruned {} finished tasks older than {retention_days} days",
-        result.rows_affected()
+        "pruned {total} terminal tasks older than {retention_hours}h"
     ))
 }

--- a/nt-be/src/jobs/mod.rs
+++ b/nt-be/src/jobs/mod.rs
@@ -218,7 +218,52 @@ async fn setup_apalis(pool: &PgPool) -> Result<(), sqlx::Error> {
     conn.execute("SET search_path TO apalis_migrations, public")
         .await?;
     PostgresStorage::migrations().run(&mut *conn).await?;
+    drop(conn);
+
+    ensure_board_indexes(pool).await;
     Ok(())
+}
+
+/// Adds composite indexes that the apalis-board queries need but the apalis
+/// schema doesn't ship.
+///
+/// The board's task-list queries filter by `status` (and optionally
+/// `job_type`) and `ORDER BY done_at DESC, run_at DESC`; the built-in schema
+/// only has single-column `status`/`job_type` indexes, so on a large table
+/// (~1M rows on testenv) Postgres filtered then sorted the whole matching set
+/// on every page load — the reason the board UI was slow. These composite
+/// indexes let it satisfy the filter+order with an index range scan.
+///
+/// `CONCURRENTLY` avoids taking a write lock on the table the workers are
+/// actively polling; `IF NOT EXISTS` makes it a cheap no-op after the first
+/// build. It cannot run inside a transaction, so it runs on a plain pooled
+/// connection (autocommit). A failure here must not stop startup — log and
+/// carry on; the board is just slower without them.
+async fn ensure_board_indexes(pool: &PgPool) {
+    use sqlx::Executor as _;
+
+    const INDEXES: [(&str, &str); 3] = [
+        (
+            "idx_jobs_status_doneat_runat",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jobs_status_doneat_runat \
+             ON apalis.jobs (status, done_at DESC, run_at DESC)",
+        ),
+        (
+            "idx_jobs_type_status_doneat_runat",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jobs_type_status_doneat_runat \
+             ON apalis.jobs (job_type, status, done_at DESC, run_at DESC)",
+        ),
+        (
+            "idx_jobs_run_at",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jobs_run_at ON apalis.jobs (run_at)",
+        ),
+    ];
+
+    for (name, ddl) in INDEXES {
+        if let Err(e) = pool.execute(ddl).await {
+            tracing::warn!(index = name, error = %e, "failed to create apalis board index");
+        }
+    }
 }
 
 fn storage(pool: &PgPool, queue: &str) -> TickStorage {

--- a/nt-be/src/jobs/mod.rs
+++ b/nt-be/src/jobs/mod.rs
@@ -90,6 +90,24 @@ fn env_secs(var: &str, default: u64) -> u64 {
         .unwrap_or(default)
 }
 
+/// Wall-clock cap on a single job handler execution (default 30 min,
+/// `APALIS_JOB_TIMEOUT_SECONDS`).
+///
+/// A handler that exceeds it has its future dropped (cancelled) and the task
+/// recorded as failed. This is the safety net for the failure mode that wedged
+/// `account-maintenance` for days on testenv: a handler that hangs on an
+/// un-timed `.await` (e.g. an unresponsive RPC) never completes, but apalis's
+/// keep-alive heartbeat runs on a *separate* task and stays healthy — so the
+/// orphaned-task reenqueue never fires, and with `concurrency(1)` that one
+/// hung task holds the queue's only slot forever while cron ticks pile up
+/// Pending. The timeout frees the slot; the next cron tick retries.
+///
+/// Set generously (30 min) so no legitimate cycle is killed — it only fires on
+/// a genuine hang. Per-job overrides can be added later if a job needs longer.
+pub(crate) fn job_timeout() -> std::time::Duration {
+    std::time::Duration::from_secs(env_secs("APALIS_JOB_TIMEOUT_SECONDS", 1800).max(1))
+}
+
 /// Builds a cron schedule that fires every `secs` seconds.
 ///
 /// A 6-field cron `*/n` step only expresses intervals that divide their
@@ -303,6 +321,11 @@ macro_rules! register_cron_worker {
             WorkerBuilder::new($name)
                 .backend(CronStream::new(schedule.clone()).pipe_to(store.clone()))
                 .data(state.clone())
+                // Innermost layer: bounds the handler itself so a hung cycle
+                // aborts and frees the concurrency(1) slot (see `job_timeout`).
+                // Placed inside catch_panic/Sentry/Trace so the timeout error
+                // is caught, reported to Sentry, and logged like any failure.
+                .timeout(job_timeout())
                 .catch_panic()
                 // apalis's Sentry integration: captures a task failure once
                 // (after catch_panic has converted any panic to an error) with
@@ -693,13 +716,15 @@ pub async fn spawn_all(state: Arc<AppState>) -> (JobQueues, tokio::task::JoinHan
     }
 
     // Retention: prune finished apalis tasks so high-frequency queues don't
-    // grow unbounded. Daily at 03:30 UTC.
+    // grow unbounded. Hourly — the high-frequency queues (2–5s ticks, plus
+    // per-account public-history jobs) produce ~1M rows/day, so a once-daily
+    // prune let the table (and every poll/UI query over it) bloat badly.
     monitor = register_cron_worker!(
         monitor,
         queues,
         state,
         "apalis-prune",
-        Schedule::from_str("0 30 3 * * *").expect("valid cron"),
+        Schedule::from_str("0 0 * * * *").expect("valid cron"),
         handlers::apalis_prune
     );
 


### PR DESCRIPTION
Investigated the live testenv (apalis board API + `/api/jobs/health`). Findings and fixes span the whole apalis job subsystem.

## What was wrong
- **`account-maintenance` wedged ~5 days**: one task Running, 20 ticks piled Pending, 4.55% success. `run_maintenance_cycle` processes every account sequentially in one task; a single account hanging on an un-timed RPC never returns. apalis's keep-alive heartbeat runs on a separate task and stays healthy, so the orphaned-task reenqueue never fires — with `concurrency(1)` that one hung task holds the queue's only slot forever.
- **Board UI painfully slow**: `apalis.jobs` ≈ 986k rows / ~494MB. The board's task-list queries (`WHERE status[/job_type] ORDER BY done_at DESC, run_at DESC`) only had single-column indexes, so Postgres filtered then sorted the whole table on every page.
- `dao-policy-dirty` was 100% healthy — the earlier dirty-DAO starvation theory (#1139) was not the cause; that PR is on hold.

## Fixes

**1. Handler timeout (outer safety net).** Enable apalis's `timeout` feature and wrap every handler (cron + bronze queue workers) in `.timeout(job_timeout())` (default 30 min, `APALIS_JOB_TIMEOUT_SECONDS`). A hung cycle is aborted, the slot freed, and the failure reaches Sentry (a hung task previously produced no event).

**2. Isolated + parallel account maintenance (root cause).** Each account is now handled by an isolated `process_account`: wrapped in a per-account timeout (`ACCOUNT_MAINTENANCE_ACCOUNT_TIMEOUT_SECONDS`, default 120s) so one hung account is abandoned for the cycle instead of stalling the rest; errors stay isolated to that account (previously an un-timed `?` on two steps let one account's DB error abort the whole cycle); and accounts run with bounded parallelism (`ACCOUNT_MAINTENANCE_CONCURRENCY`, default 4). The worker stays `concurrency(1)` (no cross-tick duplication) while cycles finish much faster.

**3. Board indexes.** `setup_apalis` creates `(status, done_at DESC, run_at DESC)`, `(job_type, status, done_at DESC, run_at DESC)`, and `(run_at)` via `CREATE INDEX CONCURRENTLY IF NOT EXISTS` (non-blocking, idempotent). EXPLAIN confirms the task-list queries become an index range scan with the LIMIT satisfied directly — no sort.

**4. Prune the bloat.** Prune hourly (was daily), retention in hours (`APALIS_TASK_RETENTION_HOURS`, default 48; old `_DAYS` still honored), and also delete exhausted `Failed` rows, in bounded 10k-row batches.

## On the missing logs
The board streams live task events but there is no persistent per-task log store (`LOG_BROADCASTER` is in-memory/SSE-only), so a hung task's last log naming the culprit is lost. The per-account timeout now logs which account was abandoned. A durable log store is ops config, flagged separately.

## Testing
- `cargo fmt --check`, `cargo clippy --lib --bins -- -D warnings`: clean. Compiles incl. integration test target.
- `cargo test --lib --bins`: passes (RPC-cache-dependent tests need CI's network/fixtures).
- Board indexes: EXPLAIN on the exact list queries shows Index Scan + LIMIT, no Sort.
- Prune selection validated against a live apalis schema with seeded rows.
- No caller/test expects `run_maintenance_cycle` to return an error, so the error-isolation change is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRWEKUFYCcmGGhwdDYd471