### PR TITLE
obs/perf: attribute logs to jobs & API requests, quiet per-tick logs, index Queues page

### DIFF
--- a/nt-be/src/handlers/public_history/bronze/jobs/worker.rs
+++ b/nt-be/src/handlers/public_history/bronze/jobs/worker.rs
@@ -506,18 +506,35 @@ pub(crate) fn register_public_history_job_workers(
 ) -> Monitor {
     use apalis::layers::sentry::SentryLayer;
     use apalis::layers::tracing::{
-        DefaultMakeSpan, DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer,
+        DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer,
     };
 
-    // Failures stay at WARN for the same reason as the cron workers: the
-    // SentryLayer already captured the task failure, and the tracing→Sentry
-    // bridge would emit a duplicate event at ERROR.
-    fn trace_layer() -> TraceLayer {
-        TraceLayer::new()
-            .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO))
-            .on_request(DefaultOnRequest::new().level(tracing::Level::INFO))
-            .on_response(DefaultOnResponse::new().level(tracing::Level::INFO))
-            .on_failure(DefaultOnFailure::new().level(tracing::Level::WARN))
+    // Same tracing policy as the cron workers in `crate::jobs`: the task span
+    // records `queue` (so each log line is attributable to the job) at INFO;
+    // per-cycle start/done events at DEBUG (boilerplate); failures at WARN (the
+    // SentryLayer already captured them, and the tracing→Sentry bridge would
+    // otherwise emit a duplicate at ERROR). The span is built inline per worker
+    // because it bakes in the queue name.
+    macro_rules! queue_trace_layer {
+        ($queue:literal) => {
+            TraceLayer::new()
+                .make_span_with(move |req: &Task<_, _, _>| {
+                    tracing::info_span!(
+                        "task",
+                        queue = $queue,
+                        task_id = req
+                            .parts
+                            .task_id
+                            .as_ref()
+                            .map(ToString::to_string)
+                            .unwrap_or_default(),
+                        attempt = req.parts.attempt.current(),
+                    )
+                })
+                .on_request(DefaultOnRequest::new().level(tracing::Level::DEBUG))
+                .on_response(DefaultOnResponse::new().level(tracing::Level::DEBUG))
+                .on_failure(DefaultOnFailure::new().level(tracing::Level::WARN))
+        };
     }
 
     let latest_state = state.clone();
@@ -530,7 +547,7 @@ pub(crate) fn register_public_history_job_workers(
             .timeout(crate::jobs::job_timeout())
             .catch_panic()
             .layer(SentryLayer::new())
-            .layer(trace_layer())
+            .layer(queue_trace_layer!("public-history-latest"))
             .concurrency(JOB_CONCURRENCY)
             .build(handle_latest_job)
     });
@@ -542,7 +559,7 @@ pub(crate) fn register_public_history_job_workers(
             .timeout(crate::jobs::job_timeout())
             .catch_panic()
             .layer(SentryLayer::new())
-            .layer(trace_layer())
+            .layer(queue_trace_layer!("public-history-backfill"))
             .concurrency(BACKFILL_JOB_CONCURRENCY)
             .build(handle_backfill_job)
     })

--- a/nt-be/src/jobs/mod.rs
+++ b/nt-be/src/jobs/mod.rs
@@ -24,9 +24,7 @@ use std::sync::Arc;
 
 use apalis::layers::WorkerBuilderExt;
 use apalis::layers::sentry::SentryLayer;
-use apalis::layers::tracing::{
-    DefaultMakeSpan, DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer,
-};
+use apalis::layers::tracing::{DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer};
 use apalis::prelude::*;
 use apalis_core::backend::TaskSink;
 use apalis_core::backend::pipe::PipeExt;
@@ -242,7 +240,7 @@ async fn setup_apalis(pool: &PgPool) -> Result<(), sqlx::Error> {
 async fn ensure_board_indexes(pool: &PgPool) {
     use sqlx::Executor as _;
 
-    const INDEXES: [(&str, &str); 3] = [
+    const INDEXES: [(&str, &str); 5] = [
         (
             "idx_jobs_status_doneat_runat",
             "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jobs_status_doneat_runat \
@@ -256,6 +254,22 @@ async fn ensure_board_indexes(pool: &PgPool) {
         (
             "idx_jobs_run_at",
             "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jobs_run_at ON apalis.jobs (run_at)",
+        ),
+        // Queues page (list_queues): GROUP BY job_type status-count aggregates.
+        // Narrow on purpose — the wider indexes above are too big for the
+        // planner to pick for a pure aggregate, so it kept seq-scanning the fat
+        // table. EXPLAIN shows this turns them into index-only scans.
+        (
+            "idx_jobs_type_status",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jobs_type_status \
+             ON apalis.jobs (job_type, status)",
+        ),
+        // Queues page: per-job_type run_at rollups (7-day activity, most-recent,
+        // time windows).
+        (
+            "idx_jobs_type_runat",
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jobs_type_runat \
+             ON apalis.jobs (job_type, run_at)",
         ),
     ];
 
@@ -377,23 +391,40 @@ macro_rules! register_cron_worker {
                 // the task's queue / id / attempt as Sentry context, plus a
                 // per-task performance transaction. No-op when Sentry is off.
                 .layer(SentryLayer::new())
-                // The `task` span and its start/done events are created at
-                // INFO (apalis defaults them to DEBUG). Two reasons: the
-                // apalis-board dashboard only streams logs carrying a `task`
-                // span (its `/events` SSE filters `span.is_some()`), and a
-                // DEBUG span is disabled under the default `info` filter — so
-                // at INFO the span is live, task activity shows on the board,
-                // and every cycle's logs inherit the task_id/attempt context.
-                // Failures stay at WARN (not the default ERROR): a single
-                // failed cycle is retried by the next cron tick and is a
-                // warning, and this keeps the tracing→Sentry bridge
-                // (ERROR→event) from emitting a *second* event for the same
-                // failure the SentryLayer already captured.
+                // The task span is INFO so it is live under the default `info`
+                // filter: the apalis-board `/events` SSE only streams logs
+                // carrying a `task` span, and every log the handler emits
+                // inherits this span's context. The default span carries only
+                // task_id/attempt — so it is replaced with one that also
+                // records `queue` (the job name), making every job log line
+                // attributable to its queue. The per-cycle start/done events
+                // are dropped to DEBUG: at INFO they flooded the logs with two
+                // lines per tick per queue (~2M/day from the 2–5s queues),
+                // burying anything worth noticing. Failures stay at WARN (not
+                // the default ERROR): a failed cycle is retried by the next
+                // tick, and this keeps the tracing→Sentry bridge (ERROR→event)
+                // from emitting a *second* event for a failure the SentryLayer
+                // already captured.
                 .layer(
                     TraceLayer::new()
-                        .make_span_with(DefaultMakeSpan::new().level(tracing::Level::INFO))
-                        .on_request(DefaultOnRequest::new().level(tracing::Level::INFO))
-                        .on_response(DefaultOnResponse::new().level(tracing::Level::INFO))
+                        .make_span_with({
+                            let queue = $name;
+                            move |req: &apalis_core::task::Task<_, _, _>| {
+                                tracing::info_span!(
+                                    "task",
+                                    queue,
+                                    task_id = req
+                                        .parts
+                                        .task_id
+                                        .as_ref()
+                                        .map(ToString::to_string)
+                                        .unwrap_or_default(),
+                                    attempt = req.parts.attempt.current(),
+                                )
+                            }
+                        })
+                        .on_request(DefaultOnRequest::new().level(tracing::Level::DEBUG))
+                        .on_response(DefaultOnResponse::new().level(tracing::Level::DEBUG))
                         .on_failure(DefaultOnFailure::new().level(tracing::Level::WARN)),
                 )
                 .concurrency(1)

--- a/nt-be/src/main.rs
+++ b/nt-be/src/main.rs
@@ -83,7 +83,13 @@ async fn async_main() {
         // keeps unknown public `/api/*` a plain 404.
         .fallback_service(board)
         .layer(SentryHttpLayer::new().enable_transaction())
-        .layer(NewSentryLayer::<Request<Body>>::new_from_top());
+        .layer(NewSentryLayer::<Request<Body>>::new_from_top())
+        // Opens a per-request tracing span (method/route/request_id) so handler
+        // logs are attributable to the request. Outermost so it wraps every
+        // route, including the board and the sentry layers.
+        .layer(axum::middleware::from_fn(
+            nt_be::observability::trace_request,
+        ));
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "3002".to_string());
     let addr = format!("0.0.0.0:{}", port);

--- a/nt-be/src/observability.rs
+++ b/nt-be/src/observability.rs
@@ -56,6 +56,40 @@ pub fn init_observability() -> ObservabilityGuard {
     }
 }
 
+/// axum middleware that opens a tracing span for the lifetime of each HTTP
+/// request, so every log line a handler emits is attributable to the request:
+/// `method`, `route` (the matched pattern when available, else the path), and a
+/// generated `request_id` to correlate all lines of one request.
+///
+/// Without this, API request logs carried no request context — the Sentry tower
+/// layers create a Sentry transaction/hub, not a `tracing::Span`, so tracing
+/// output during a request was unattributed unless the handler had its own
+/// `#[tracing::instrument]` (only a minority do). The span is INFO so it is live
+/// under the default filter; the fmt layer doesn't emit span open/close lines,
+/// so this adds context to existing logs without adding noise.
+pub async fn trace_request(
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use tracing::Instrument as _;
+
+    let method = request.method().clone();
+    let route = request
+        .extensions()
+        .get::<axum::extract::MatchedPath>()
+        .map(|matched| matched.as_str().to_owned())
+        .unwrap_or_else(|| request.uri().path().to_owned());
+    let request_id = uuid::Uuid::new_v4();
+
+    let span = tracing::info_span!(
+        "http_request",
+        method = %method,
+        route = %route,
+        request_id = %request_id,
+    );
+    next.run(request).instrument(span).await
+}
+
 /// Initialize backend logging through tracing.
 ///
 /// This intentionally mirrors the previous logger behavior: when RUST_LOG is
@@ -282,6 +316,39 @@ fn truncate_sanitized_text(mut text: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `trace_request` must run each request inside the `http_request` span so
+    /// handler logs inherit its context (method/route/request_id).
+    #[tokio::test]
+    async fn trace_request_wraps_handler_in_named_span() {
+        use axum::{Router, body::Body, http::Request, routing::get};
+        use tower::ServiceExt as _;
+
+        async fn handler() -> &'static str {
+            let name = tracing::Span::current().metadata().map(|m| m.name());
+            assert_eq!(name, Some("http_request"), "handler must run in the span");
+            "ok"
+        }
+
+        // A subscriber must be active or spans are no-ops (metadata is None).
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let app = Router::new()
+            .route("/x", get(handler))
+            .layer(axum::middleware::from_fn(super::trace_request));
+
+        let response = app
+            .oneshot(Request::builder().uri("/x").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        // A failed in-handler assertion panics -> 500; 200 proves it ran inside
+        // the span.
+        assert_eq!(response.status(), 200);
+    }
 
     /// The apalis-board layer must forward events emitted inside an apalis
     /// `task` span to the broadcaster — that's what the dashboard's `/events`


### PR DESCRIPTION
Rebased onto main after #1142 merged (conflict resolved). Covers log attribution, log-noise, and the Queues-page index.

## 1. Log attribution — spans now carry identity
You asked whether spans correctly attribute log lines. They didn't, fully:

- **Jobs**: apalis's `TraceLayer` auto-opens a span around every handler, but it's named `"task"` and carries only `task_id` + `attempt` — not the queue. So you could tell a log came from *a* job, not *which*. A custom `MakeSpan` now records `queue = <job name>` on every cron worker and both bronze workers, so each handler log line is attributable to its job.
- **API**: there was **no per-request tracing span at all** — `SentryHttpLayer`/`NewSentryLayer` create a Sentry transaction/hub, not a `tracing::Span`, so request logs had no context unless a handler had its own `#[instrument]` (only ~20 of ~190 files do). New `trace_request` middleware opens an `http_request` span (`method`, `route`, `request_id`) around every request, outermost so it wraps all routes.

`tracing` doesn't attribute automatically — it only propagates whatever span is active. These two changes establish the identifying spans; the formatter already prints span context (`with_current_span`/span scope).

## 2. Quiet the per-tick boilerplate
The apalis TraceLayer logged `task.start` + `task.done` at INFO on **every** tick (~2M lines/day from the 2–5s queues), burying real signal. The `task` span stays INFO (board SSE + handler context) but those two events drop to DEBUG. Failures stay WARN and reach Sentry.

## 3. Queues page index
`list_queues.sql` runs ~13 `GROUP BY job_type` status aggregates + per-queue `run_at` rollups that seq-scanned the fat table. Two narrow indexes — `(job_type, status)` and `(job_type, run_at)` — turn them into index-only scans. EXPLAIN ANALYZE (300k rows): ~70–240× fewer buffers. Created in `setup_apalis` via `CREATE INDEX CONCURRENTLY IF NOT EXISTS`.

## Testing
- `cargo fmt --check`, `cargo clippy --lib --bins --tests -- -D warnings`: clean.
- New unit test: `trace_request` runs the handler inside the `http_request` span (passes).
- jobs + observability unit suites pass. Queue-span closure and index shapes verified by compile + EXPLAIN; full integration suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRWEKUFYCcmGGhwdDYd471