### PR TITLE
obs: report 5xx to Sentry via tower-http TraceLayer; quiet relay client-error alarms

### DIFF
--- a/nt-be/Cargo.lock
+++ b/nt-be/Cargo.lock
@@ -5360,6 +5360,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/nt-be/Cargo.toml
+++ b/nt-be/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "nt-be"
 async-trait = "0.1"
 axum = { version = "0.8.7", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 near-api = "0.8"
 near-account-id = "2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/nt-be/src/handlers/relay/parse/mod.rs
+++ b/nt-be/src/handlers/relay/parse/mod.rs
@@ -72,13 +72,19 @@ pub struct RelayResponse {
 /// Build an error response from a status and message.
 ///
 /// This is the single choke point every relay failure flows through — parse
-/// rejects, authorization, policy, registrations, and on-chain submission —
-/// so it also emits the ERROR event that the tracing→Sentry bridge turns
-/// into a Sentry alert. The message is a field (not the log message) so all
-/// relay failures group under one Sentry issue instead of one per message.
+/// rejects, authorization, policy, registrations, and on-chain submission — so
+/// it logs the failure by class: **server errors (5xx)** at `error!`, which the
+/// tracing→Sentry bridge turns into an alert, and **client errors (4xx)** —
+/// invalid delegate action, forbidden, payment-required — at `warn!` only, so a
+/// caller sending a bad request can't spam Sentry with false alarms. The message
+/// is a field (not the log message) so failures group by status, not by text.
 pub fn error_response(status: StatusCode, msg: impl Into<String>) -> RelayError {
     let msg = msg.into();
-    tracing::error!(status = %status, error = %msg, "relay request failed");
+    if status.is_server_error() {
+        tracing::error!(status = %status, error = %msg, "relay request failed");
+    } else {
+        tracing::warn!(status = %status, error = %msg, "relay request rejected");
+    }
     (
         status,
         Json(RelayResponse {

--- a/nt-be/src/main.rs
+++ b/nt-be/src/main.rs
@@ -7,6 +7,7 @@ use axum::{
 use sentry::integrations::tower::{NewSentryLayer, SentryHttpLayer};
 use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+use tower_http::trace::{DefaultOnFailure, TraceLayer};
 
 fn main() {
     tokio::runtime::Builder::new_multi_thread()
@@ -82,14 +83,31 @@ async fn async_main() {
         // Auth. It answers only paths no other route matched; its API guard
         // keeps unknown public `/api/*` a plain 404.
         .fallback_service(board)
+        // tower-http's standard request tracing. Its default
+        // `ServerErrorsAsFailures` classifier logs 5xx responses via
+        // `on_failure` at ERROR — which the sentry-tracing layer turns into a
+        // Sentry event — while 4xx are not failures, so client errors don't
+        // alarm. The span (INFO) also gives every handler log line request
+        // context (method/path/request_id). This replaces a hand-rolled
+        // middleware with the ecosystem-standard layer.
+        //
+        // Innermost of these three so it runs inside the per-request Sentry hub
+        // bound by `NewSentryLayer`: the 5xx event is then captured with the
+        // request's scope/context.
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(|request: &Request<Body>| {
+                    tracing::info_span!(
+                        "http_request",
+                        method = %request.method(),
+                        path = %request.uri().path(),
+                        request_id = %uuid::Uuid::new_v4(),
+                    )
+                })
+                .on_failure(DefaultOnFailure::new().level(tracing::Level::ERROR)),
+        )
         .layer(SentryHttpLayer::new().enable_transaction())
-        .layer(NewSentryLayer::<Request<Body>>::new_from_top())
-        // Opens a per-request tracing span (method/route/request_id) so handler
-        // logs are attributable to the request. Outermost so it wraps every
-        // route, including the board and the sentry layers.
-        .layer(axum::middleware::from_fn(
-            nt_be::observability::trace_request,
-        ));
+        .layer(NewSentryLayer::<Request<Body>>::new_from_top());
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "3002".to_string());
     let addr = format!("0.0.0.0:{}", port);

--- a/nt-be/src/observability.rs
+++ b/nt-be/src/observability.rs
@@ -56,40 +56,6 @@ pub fn init_observability() -> ObservabilityGuard {
     }
 }
 
-/// axum middleware that opens a tracing span for the lifetime of each HTTP
-/// request, so every log line a handler emits is attributable to the request:
-/// `method`, `route` (the matched pattern when available, else the path), and a
-/// generated `request_id` to correlate all lines of one request.
-///
-/// Without this, API request logs carried no request context — the Sentry tower
-/// layers create a Sentry transaction/hub, not a `tracing::Span`, so tracing
-/// output during a request was unattributed unless the handler had its own
-/// `#[tracing::instrument]` (only a minority do). The span is INFO so it is live
-/// under the default filter; the fmt layer doesn't emit span open/close lines,
-/// so this adds context to existing logs without adding noise.
-pub async fn trace_request(
-    request: axum::extract::Request,
-    next: axum::middleware::Next,
-) -> axum::response::Response {
-    use tracing::Instrument as _;
-
-    let method = request.method().clone();
-    let route = request
-        .extensions()
-        .get::<axum::extract::MatchedPath>()
-        .map(|matched| matched.as_str().to_owned())
-        .unwrap_or_else(|| request.uri().path().to_owned());
-    let request_id = uuid::Uuid::new_v4();
-
-    let span = tracing::info_span!(
-        "http_request",
-        method = %method,
-        route = %route,
-        request_id = %request_id,
-    );
-    next.run(request).instrument(span).await
-}
-
 /// Initialize backend logging through tracing.
 ///
 /// This intentionally mirrors the previous logger behavior: when RUST_LOG is
@@ -317,37 +283,69 @@ fn truncate_sanitized_text(mut text: String) -> String {
 mod tests {
     use super::*;
 
-    /// `trace_request` must run each request inside the `http_request` span so
-    /// handler logs inherit its context (method/route/request_id).
+    /// The tower-http `TraceLayer` wired in `main` must log **5xx** responses at
+    /// ERROR (which the sentry-tracing layer turns into a Sentry event) via the
+    /// default `ServerErrorsAsFailures` classifier, and leave 2xx/4xx alone — so
+    /// client errors don't alarm. Mirrors the layer's failure config.
     #[tokio::test]
-    async fn trace_request_wraps_handler_in_named_span() {
-        use axum::{Router, body::Body, http::Request, routing::get};
+    async fn trace_layer_logs_only_5xx_at_error() {
+        use axum::{Router, body::Body, http::Request, http::StatusCode, routing::get};
+        use std::sync::{Arc, Mutex};
         use tower::ServiceExt as _;
+        use tower_http::trace::{DefaultOnFailure, TraceLayer};
 
-        async fn handler() -> &'static str {
-            let name = tracing::Span::current().metadata().map(|m| m.name());
-            assert_eq!(name, Some("http_request"), "handler must run in the span");
-            "ok"
+        // Records the level of every event so we can count ERROR events (the
+        // ones the sentry-tracing bridge would capture).
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<tracing::Level>>>);
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Capture {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                self.0.lock().unwrap().push(*event.metadata().level());
+            }
         }
 
-        // A subscriber must be active or spans are no-ops (metadata is None).
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::INFO)
-            .finish();
+        let events = Capture::default();
+        let subscriber = tracing_subscriber::registry().with(events.clone());
         let _guard = tracing::subscriber::set_default(subscriber);
 
+        async fn ok() -> &'static str {
+            "ok"
+        }
+        async fn bad() -> StatusCode {
+            StatusCode::BAD_REQUEST
+        }
+        async fn err() -> StatusCode {
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
         let app = Router::new()
-            .route("/x", get(handler))
-            .layer(axum::middleware::from_fn(super::trace_request));
+            .route("/ok", get(ok))
+            .route("/bad", get(bad))
+            .route("/err", get(err))
+            .layer(
+                TraceLayer::new_for_http()
+                    .on_failure(DefaultOnFailure::new().level(tracing::Level::ERROR)),
+            );
 
-        let response = app
-            .oneshot(Request::builder().uri("/x").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
+        for path in ["/ok", "/bad", "/err"] {
+            let _ = app
+                .clone()
+                .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+        }
 
-        // A failed in-handler assertion panics -> 500; 200 proves it ran inside
-        // the span.
-        assert_eq!(response.status(), 200);
+        let error_events = events
+            .0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|level| **level == tracing::Level::ERROR)
+            .count();
+        assert_eq!(error_events, 1, "only the 5xx response logs at ERROR");
     }
 
     /// The apalis-board layer must forward events emitted inside an apalis


### PR DESCRIPTION
Addresses the Sentry-coverage findings, using existing/standard solutions rather than ad-hoc code (per review of Sentry's Rust/axum guidance).

## Findings recap
- **API 5xx were under-reported.** sentry-tower has **no** 5xx-response capture — `SentryHttpLayer` only sets the *transaction* span-status (APM, and dropped at our `traces_sample_rate=0.0`). Official error capture relies on the panic integration + sentry-tracing (`ERROR → event`). So a handler that returned `500` without logging reached Sentry only if it happened to `error!` or panic.
- **A false-alarm source**: `relay::error_response` logged **every** failure at `error!`, including client `400`s (e.g. an invalid delegate action) → Sentry noise.

## Fix (existing solutions)
- **`tower_http::trace::TraceLayer::new_for_http()`** replaces the hand-rolled request middleware. Its default `ServerErrorsAsFailures` classifier logs **5xx** via `on_failure` at ERROR — which sentry-tracing turns into an event — and does **not** classify 4xx as failures, so client errors don't alarm. The span (INFO) still gives handler logs request context (method/path/request_id). Placed inside the per-request Sentry hub so the event carries request scope. This is the ecosystem-standard layer; no bespoke status-checking or dedup.
- **`relay::error_response`** now logs by class: 5xx → `error!` (event), 4xx → `warn!` (breadcrumb only). Removes the client-error alarms.

## What was already correct (left as-is)
- **Jobs**: apalis's native `SentryLayer` captures each task failure once — the standard job solution.
- **Panics**: Sentry's default panic integration.
- **sentry-tracing** filter: `ERROR → event`, `WARN/INFO/DEBUG → breadcrumb`, `TRACE → ignore`.

## Balance
- 4xx / client errors: never alarm.
- Health `503` etc.: `ServerErrorsAsFailures` treats 5xx as failures, so a `503` *would* log at ERROR. Our health endpoints are hit rarely and by uptime monitors; if that proves noisy, the classifier can be narrowed. (Flagging rather than pre-optimizing.)
- Handlers that already `error!` on a 5xx will now also get the TraceLayer's failure event — two events for one failure. These are real errors (not false alarms) and Sentry groups them; trimming redundant handler-level `error!` for returned responses is a reasonable follow-up.

## Testing
- `cargo fmt --check`, `cargo clippy --lib --bins --tests -- -D warnings`, `cargo check`: clean.
- New unit test drives the layer: only the 5xx response logs at ERROR; 2xx/4xx don't.
- relay unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRWEKUFYCcmGGhwdDYd471