### PR TITLE
fix: mobile UI polish and confidential bulk payment responsiveness

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/balance-with-graph.tsx
@@ -574,58 +574,31 @@ export default function BalanceWithGraph({
                                 : "••••••"}
                         </p>
                         {showBreakdown && (
-                            <>
-                                <div className="mt-2 hidden md:flex items-center gap-2 text-sm text-muted-foreground">
-                                    {balanceBreakdownItems.map((item, idx) => (
-                                        <div
-                                            key={item.key}
-                                            className="contents"
-                                        >
-                                            {idx > 0 && (
-                                                <span
-                                                    aria-hidden="true"
-                                                    className="h-3 w-px bg-border"
-                                                />
-                                            )}
-                                            <span>
-                                                {t(
-                                                    `bucket${item.key[0].toUpperCase()}${item.key.slice(1)}` as
-                                                        | "bucketAvailable"
-                                                        | "bucketLocked"
-                                                        | "bucketEarning",
-                                                )}{" "}
-                                                <span className="font-semibold text-foreground">
-                                                    {formatCurrencyWithSubCent(
-                                                        item.value,
-                                                    )}
-                                                </span>
-                                            </span>
-                                        </div>
-                                    ))}
-                                </div>
-                                <div className="mt-4 border-t border-border/70 pt-3 space-y-3 md:hidden">
-                                    {balanceBreakdownItems.map((item) => (
-                                        <div
-                                            key={item.key}
-                                            className="flex items-center justify-between text-base"
-                                        >
-                                            <span className="text-muted-foreground">
-                                                {t(
-                                                    `bucket${item.key[0].toUpperCase()}${item.key.slice(1)}` as
-                                                        | "bucketAvailable"
-                                                        | "bucketLocked"
-                                                        | "bucketEarning",
-                                                )}
-                                            </span>
+                            <div className="mt-2 hidden md:flex items-center gap-2 text-sm text-muted-foreground">
+                                {balanceBreakdownItems.map((item, idx) => (
+                                    <div key={item.key} className="contents">
+                                        {idx > 0 && (
+                                            <span
+                                                aria-hidden="true"
+                                                className="h-3 w-px bg-border"
+                                            />
+                                        )}
+                                        <span>
+                                            {t(
+                                                `bucket${item.key[0].toUpperCase()}${item.key.slice(1)}` as
+                                                    | "bucketAvailable"
+                                                    | "bucketLocked"
+                                                    | "bucketEarning",
+                                            )}{" "}
                                             <span className="font-semibold text-foreground">
                                                 {formatCurrencyWithSubCent(
                                                     item.value,
                                                 )}
                                             </span>
-                                        </div>
-                                    ))}
-                                </div>
-                            </>
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
                         )}
                     </div>
                     {!isConfidential && (
@@ -755,6 +728,28 @@ export default function BalanceWithGraph({
                     )}
                     <HistoryRefreshButton />
                 </div>
+                {showBreakdown && (
+                    <div className="mt-4 border-t border-border/70 pt-3 space-y-3 md:hidden">
+                        {balanceBreakdownItems.map((item) => (
+                            <div
+                                key={item.key}
+                                className="flex items-center justify-between text-base"
+                            >
+                                <span className="text-muted-foreground">
+                                    {t(
+                                        `bucket${item.key[0].toUpperCase()}${item.key.slice(1)}` as
+                                            | "bucketAvailable"
+                                            | "bucketLocked"
+                                            | "bucketEarning",
+                                    )}
+                                </span>
+                                <span className="font-semibold text-foreground">
+                                    {formatCurrencyWithSubCent(item.value)}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                )}
             </div>
 
             <div className="grid grid-cols-3 gap-2 md:gap-4">

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/select-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/select-modal.tsx
@@ -187,7 +187,7 @@ export function SelectModal({
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-            <DialogContent className="max-w-md">
+            <DialogContent className="sm:max-w-md">
                 <DialogHeader centerTitle>
                     <DialogTitle>{title}</DialogTitle>
                 </DialogHeader>
@@ -204,7 +204,7 @@ export function SelectModal({
                     {isLoading ? (
                         <SelectListSkeleton />
                     ) : (
-                        <ScrollArea className="h-[400px]">
+                        <ScrollArea className="h-[min(400px,calc(80vh-10rem))]">
                             {sections?.length ? (
                                 filteredSections.length > 0 ? (
                                     filteredSections.map((section) => {

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/bulk-payment-credits-display.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/bulk-payment-credits-display.tsx
@@ -41,11 +41,11 @@ export function BulkPaymentCreditsDisplay({
     const periodDisplay = isTrial ? t("oneTimeTrial") : t("month");
 
     return (
-        <div className="space-y-3">
+        <div className="space-y-3 min-w-0">
             {/* Header */}
-            <div className="flex items-center justify-between">
+            <div className="flex flex-wrap items-center justify-between gap-2">
                 <p className="font-semibold">{t("title")}</p>
-                <span className="text-sm font-medium border py-1 px-2 rounded-lg border-general-border bg-general-unofficial-outline">
+                <span className="text-xs sm:text-sm font-medium border py-1 px-2 rounded-lg border-general-border bg-general-unofficial-outline whitespace-nowrap">
                     {isUnlimited
                         ? t("unlimited")
                         : t("creditsPerPeriod", {
@@ -69,7 +69,7 @@ export function BulkPaymentCreditsDisplay({
 
             {/* Upgrade CTA - Only show if not unlimited */}
             {!isUnlimited && (
-                <div className="flex items-center justify-between">
+                <div className="flex flex-wrap items-center justify-between gap-2">
                     <span className="text-sm text-secondary-foreground">
                         {t("moreFlexibility")}
                     </span>
@@ -77,7 +77,7 @@ export function BulkPaymentCreditsDisplay({
                         variant={
                             creditsAvailable === 0 ? "default" : "secondary"
                         }
-                        className="p-3"
+                        className="px-3"
                         size="sm"
                         onClick={() => {
                             window.open(APP_CONTACT_US_URL, "_blank");

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/edit-payment-step.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/edit-payment-step.tsx
@@ -19,6 +19,11 @@ interface EditPaymentStepProps extends StepProps {
     paymentIndex: number;
     selectedToken: SelectedTokenData;
     networkFeePerRecipient: string | null;
+    /**
+     * Confidential bulk receive-network name. When set, recipient address
+     * validation and address-book filtering use this chain (not NEAR / send).
+     */
+    destinationNetwork?: string;
     onSave: (
         index: number,
         data: EditPaymentFormValues,
@@ -32,6 +37,7 @@ export function EditPaymentStep({
     paymentIndex,
     selectedToken,
     networkFeePerRecipient,
+    destinationNetwork,
     onSave,
     onCancel,
 }: EditPaymentStepProps) {
@@ -104,6 +110,7 @@ export function EditPaymentStep({
                     saveButtonText={tBulk("saveChanges")}
                     onSave={handleSave}
                     hideRecipientNetwork
+                    recipientNetworkOverride={destinationNetwork}
                     isSubmitting={isSaving}
                 />
             </Form>

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslations } from "next-intl";
 import { PageCard } from "@/components/card";
@@ -27,6 +27,7 @@ import { validateAccountsAndStorage } from "../utils";
 import { useBulkParsingLabels } from "../utils/use-parsing-labels";
 import { useToken, useTokenBalance } from "@/hooks/use-treasury-queries";
 import { useTreasury } from "@/hooks/use-treasury";
+import { useBridgeTokens } from "@/hooks/use-bridge-tokens";
 import { useAddressBook } from "@/features/address-book";
 import { AmountSummary } from "@/components/amount-summary";
 import { CreateRequestButton } from "@/components/create-request-button";
@@ -34,6 +35,7 @@ import { trackEvent } from "@/lib/analytics";
 import { Tooltip } from "@/components/tooltip";
 import { Address } from "@/components/address";
 import { toast } from "sonner";
+import { getNearComChainIcons, isNearComNetwork } from "@/lib/intents-network";
 
 interface ReviewPaymentsStepProps extends StepProps {
     initialPaymentData: BulkPaymentData[];
@@ -42,6 +44,17 @@ interface ReviewPaymentsStepProps extends StepProps {
     onPaymentDataChange: (data: BulkPaymentData[]) => void;
     onSubmit: () => void;
     isSubmitting?: boolean;
+    /**
+     * Confidential flow: selected receive-network id (bridge asset network id
+     * or near.com). Drives the network badge on each recipient amount row —
+     * same pattern as single confidential payment review.
+     */
+    destinationNetworkId?: string;
+    /**
+     * Confidential flow: raw receive-network name used for NEAR account /
+     * storage validation when receive chain ≠ source token chain.
+     */
+    destinationNetworkName?: string;
     /**
      * Confidential flow only: lifecycle of the review-time prepare call that
      * fetches firm quotes. Fees render from `fees` (not the local estimate),
@@ -67,6 +80,8 @@ export function ReviewPaymentsStep({
     onPaymentDataChange,
     onSubmit,
     isSubmitting = false,
+    destinationNetworkId,
+    destinationNetworkName,
     confidentialPrepare,
 }: ReviewPaymentsStepProps) {
     const tPay = useTranslations("payments");
@@ -90,11 +105,30 @@ export function ReviewPaymentsStep({
 
     const { treasuryId } = useTreasury();
     const { data: addressBook = [] } = useAddressBook();
+    const { data: bridgeAssets = [] } = useBridgeTokens(true);
     const { data: selectedTokenData } = useToken(selectedToken?.address || "");
     const { data: balance } = useTokenBalance(
         treasuryId,
         selectedToken?.address || "",
     );
+
+    // Chain icons for the receive network (recipient amount badge) — mirrors
+    // single confidential payment review.
+    const destinationChainIcons = useMemo(() => {
+        if (!destinationNetworkId) {
+            return undefined;
+        }
+        if (isNearComNetwork(destinationNetworkId)) {
+            return getNearComChainIcons();
+        }
+        for (const asset of bridgeAssets) {
+            const network = asset.networks.find(
+                (n) => n.id === destinationNetworkId,
+            );
+            if (network?.chainIcons) return network.chainIcons;
+        }
+        return undefined;
+    }, [bridgeAssets, destinationNetworkId]);
 
     // Validate accounts on mount
     useEffect(() => {
@@ -108,6 +142,7 @@ export function ReviewPaymentsStep({
                     paymentData,
                     selectedToken,
                     parsingLabels,
+                    destinationNetworkName,
                 );
                 setPaymentData(validatedPayments);
                 onPaymentDataChange(validatedPayments);
@@ -229,7 +264,7 @@ export function ReviewPaymentsStep({
     }
 
     return (
-        <PageCard className="max-w-[600px] mx-auto">
+        <PageCard className="max-w-[600px] mx-auto w-full min-w-0">
             <ReviewStep
                 reviewingTitle={tPay("reviewYourPayment")}
                 handleBack={handleBack}
@@ -342,143 +377,131 @@ export function ReviewPaymentsStep({
                                                         : "secondary"
                                                 }
                                             />
-                                            <div className="flex-1 min-w-0">
-                                                <div className="flex items-start justify-between gap-3 mb-2">
-                                                    <div className="flex flex-col gap-2 justify-between min-w-0 flex-1 lg:flex-auto">
-                                                        <div className="flex flex-col gap-0.5">
-                                                            {(() => {
-                                                                const contact =
-                                                                    addressBook.find(
-                                                                        (e) =>
-                                                                            e.address.toLowerCase() ===
-                                                                            payment.recipient.toLowerCase(),
-                                                                    );
-                                                                return (
-                                                                    <>
-                                                                        {contact && (
-                                                                            <span className="font-semibold text-sm text-foreground">
-                                                                                {
-                                                                                    contact.name
-                                                                                }
-                                                                            </span>
-                                                                        )}
-
-                                                                        <Address
-                                                                            address={
-                                                                                payment.recipient
-                                                                            }
-                                                                            className={cn(
-                                                                                contact
-                                                                                    ? "text-xs text-muted-foreground"
-                                                                                    : "font-semibold text-sm text-foreground",
-                                                                            )}
-                                                                        />
-                                                                    </>
+                                            <div className="flex-1 min-w-0 space-y-2">
+                                                <div className="flex items-start justify-between gap-2 w-full">
+                                                    <div className="flex flex-col gap-0.5 min-w-0 overflow-hidden">
+                                                        {(() => {
+                                                            const contact =
+                                                                addressBook.find(
+                                                                    (e) =>
+                                                                        e.address.toLowerCase() ===
+                                                                        payment.recipient.toLowerCase(),
                                                                 );
-                                                            })()}
-                                                        </div>
-                                                        {payment.validationError && (
-                                                            <div className="text-xs text-red-600 dark:text-red-400 mb-2">
-                                                                {
-                                                                    payment.validationError
-                                                                }
-                                                            </div>
-                                                        )}
+                                                            return (
+                                                                <>
+                                                                    {contact && (
+                                                                        <span className="font-semibold text-sm text-foreground truncate">
+                                                                            {
+                                                                                contact.name
+                                                                            }
+                                                                        </span>
+                                                                    )}
+
+                                                                    <Address
+                                                                        address={
+                                                                            payment.recipient
+                                                                        }
+                                                                        className={cn(
+                                                                            "min-w-0",
+                                                                            contact
+                                                                                ? "text-xs text-muted-foreground"
+                                                                                : "font-semibold text-sm text-foreground",
+                                                                        )}
+                                                                    />
+                                                                </>
+                                                            );
+                                                        })()}
                                                     </div>
 
-                                                    <div className="shrink-0">
-                                                        <div className="flex flex-col gap-2 items-end">
-                                                            <div className="flex items-center gap-2">
-                                                                <TokenDisplay
-                                                                    symbol={
-                                                                        selectedToken.symbol
-                                                                    }
-                                                                    icon={
-                                                                        selectedToken.icon ||
-                                                                        ""
-                                                                    }
-                                                                    chainIcons={
-                                                                        selectedToken.chainIcons
-                                                                    }
-                                                                    iconSize="md"
-                                                                />
-                                                                <div className="text-right">
-                                                                    <div className="text-sm font-semibold whitespace-nowrap">
-                                                                        {formatTokenDisplayAmount(
-                                                                            payment.amount,
-                                                                        )}{" "}
-                                                                        {
-                                                                            selectedToken.symbol
-                                                                        }
-                                                                    </div>
-                                                                    <div className="text-xs text-muted-foreground whitespace-nowrap">
-                                                                        ≈ $
-                                                                        {estimatedUSDValue.toFixed(
-                                                                            2,
-                                                                        )}
-                                                                    </div>
-                                                                    {confidentialPrepare?.status ===
-                                                                    "loading" ? (
-                                                                        <div className="flex items-center justify-end gap-1 text-xs text-muted-foreground whitespace-nowrap">
-                                                                            {tPay(
-                                                                                "networkFee",
-                                                                            )}
-                                                                            :
-                                                                            <span className="inline-block h-4 w-16 bg-muted animate-pulse rounded" />
-                                                                        </div>
-                                                                    ) : (
-                                                                        recipientFee && (
-                                                                            <div className="text-xs text-muted-foreground whitespace-nowrap">
-                                                                                {tPay(
-                                                                                    "networkFee",
-                                                                                )}
-                                                                                :{" "}
-                                                                                {formatTokenDisplayAmount(
-                                                                                    recipientFee,
-                                                                                )}{" "}
-                                                                                {
-                                                                                    selectedToken.symbol
-                                                                                }
-                                                                            </div>
-                                                                        )
-                                                                    )}
-                                                                </div>
-                                                            </div>
-                                                            <div className="flex items-center gap-3 justify-end">
-                                                                <Button
-                                                                    variant="unstyled"
-                                                                    size="sm"
-                                                                    className="text-muted-foreground hover:text-foreground px-0!"
-                                                                    onClick={() =>
-                                                                        onEditPayment(
-                                                                            index,
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    <Edit2 className="w-4 h-4" />{" "}
-                                                                    {tBulk(
-                                                                        "edit",
-                                                                    )}
-                                                                </Button>
-                                                                <Button
-                                                                    variant="unstyled"
-                                                                    size="sm"
-                                                                    className="text-muted-foreground hover:text-foreground px-0!"
-                                                                    onClick={() =>
-                                                                        handleRemoveClick(
-                                                                            index,
-                                                                            payment.recipient,
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    <Trash2 className="w-4 h-4" />{" "}
-                                                                    {tBulk(
-                                                                        "remove",
-                                                                    )}
-                                                                </Button>
-                                                            </div>
+                                                    <div className="flex items-start gap-2 shrink-0">
+                                                        <TokenDisplay
+                                                            symbol={
+                                                                selectedToken.symbol
+                                                            }
+                                                            icon={
+                                                                selectedToken.icon ||
+                                                                ""
+                                                            }
+                                                            chainIcons={
+                                                                destinationChainIcons ??
+                                                                selectedToken.chainIcons
+                                                            }
+                                                            iconSize="md"
+                                                        />
+                                                        <div className="flex flex-col gap-[3px] items-end">
+                                                            <p className="text-sm font-semibold whitespace-nowrap leading-5">
+                                                                {formatTokenDisplayAmount(
+                                                                    payment.amount,
+                                                                )}{" "}
+                                                                {
+                                                                    selectedToken.symbol
+                                                                }
+                                                            </p>
+                                                            <p className="text-xs text-muted-foreground whitespace-nowrap">
+                                                                ≈ $
+                                                                {estimatedUSDValue.toFixed(
+                                                                    2,
+                                                                )}
+                                                            </p>
                                                         </div>
                                                     </div>
+                                                </div>
+
+                                                {payment.validationError && (
+                                                    <div className="text-xs text-red-600 dark:text-red-400">
+                                                        {
+                                                            payment.validationError
+                                                        }
+                                                    </div>
+                                                )}
+
+                                                {confidentialPrepare?.status ===
+                                                "loading" ? (
+                                                    <div className="flex items-center justify-end gap-1 text-xs text-muted-foreground">
+                                                        {tPay("networkFee")}:
+                                                        <span className="inline-block h-4 w-16 bg-muted animate-pulse rounded" />
+                                                    </div>
+                                                ) : (
+                                                    recipientFee && (
+                                                        <div className="text-xs text-muted-foreground text-right">
+                                                            {tPay("networkFee")}
+                                                            :{" "}
+                                                            {formatTokenDisplayAmount(
+                                                                recipientFee,
+                                                            )}{" "}
+                                                            {
+                                                                selectedToken.symbol
+                                                            }
+                                                        </div>
+                                                    )
+                                                )}
+
+                                                <div className="flex items-center gap-3 justify-end">
+                                                    <Button
+                                                        variant="unstyled"
+                                                        size="sm"
+                                                        className="text-muted-foreground hover:text-foreground px-0!"
+                                                        onClick={() =>
+                                                            onEditPayment(index)
+                                                        }
+                                                    >
+                                                        <Edit2 className="w-4 h-4" />{" "}
+                                                        {tBulk("edit")}
+                                                    </Button>
+                                                    <Button
+                                                        variant="unstyled"
+                                                        size="sm"
+                                                        className="text-muted-foreground hover:text-foreground px-0!"
+                                                        onClick={() =>
+                                                            handleRemoveClick(
+                                                                index,
+                                                                payment.recipient,
+                                                            )
+                                                        }
+                                                    >
+                                                        <Trash2 className="w-4 h-4" />{" "}
+                                                        {tBulk("remove")}
+                                                    </Button>
                                                 </div>
                                             </div>
                                         </div>

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx
@@ -57,12 +57,23 @@ interface ReviewPaymentsStepProps extends StepProps {
     destinationNetworkName?: string;
     /**
      * Confidential flow only: lifecycle of the review-time prepare call that
-     * fetches firm quotes. Fees render from `fees` (not the local estimate),
-     * and submission stays blocked until the call succeeds.
+     * fetches firm quotes. Display amounts come from `quotes` (same fields
+     * request details reads from stored prepare metadata); submission stays
+     * blocked until status is success.
      */
     confidentialPrepare?: {
         status: "idle" | "loading" | "success" | "error";
         fees: QuoteFees | null;
+        /**
+         * Firm quote amounts from prepare — mirrors backend / request details.
+         * Null while loading or while a fee re-pad is in flight.
+         */
+        quotes: {
+            /** DAO total spend (`headerQuote.amountInFormatted`). */
+            headerAmountInFormatted: string;
+            /** Per-recipient net (`amountOutFormatted`), same order as payments. */
+            recipientAmountOutFormatted: string[];
+        } | null;
         retry: () => void;
         /**
          * Treasury has no batch-payment credits (or prepare 402'd). Quotes
@@ -210,12 +221,18 @@ export function ReviewPaymentsStep({
             ? quotedTotalFee
             : null
         : estimatedTotalFee;
-    // Confidential bulk charges the DAO recipients + fees. Roll fees into
-    // the headline total so the AmountSummary and balance check reflect
-    // reality.
-    const totalAmount = totalNetworkFee
-        ? recipientsTotal.add(totalNetworkFee)
-        : recipientsTotal;
+    // Confidential: Total = header quote amountIn (what the DAO is charged) —
+    // same field request details uses. Fallback while quotes load: typed sum
+    // (+ estimated fee for public / pre-quote).
+    const quotedTotalAmount = confidentialPrepare?.quotes
+        ?.headerAmountInFormatted
+        ? Big(confidentialPrepare.quotes.headerAmountInFormatted)
+        : null;
+    const totalAmount =
+        quotedTotalAmount ??
+        (totalNetworkFee
+            ? recipientsTotal.add(totalNetworkFee)
+            : recipientsTotal);
     // Per-recipient fee shown on each row: the firm quote leg in the
     // confidential flow (guarded on length so a just-edited list never reads
     // a stale quote by index; zero-fee legs show nothing), the flat local
@@ -225,6 +242,11 @@ export function ReviewPaymentsStep({
         paymentData.length
             ? confidentialPrepare.fees.perRecipientFees
             : null;
+    const quotedRecipientOuts =
+        confidentialPrepare?.quotes?.recipientAmountOutFormatted.length ===
+        paymentData.length
+            ? confidentialPrepare.quotes.recipientAmountOutFormatted
+            : null;
     const getRecipientFee = (index: number) => {
         if (confidentialPrepare) {
             const fee = quotedRecipientFees?.[index];
@@ -232,6 +254,10 @@ export function ReviewPaymentsStep({
         }
         return feePerRecipient;
     };
+    // Confidential: show amountOut (net received) once quotes land — matches
+    // request details. Until then show the typed amount.
+    const getRecipientDisplayAmount = (index: number, typedAmount: string) =>
+        quotedRecipientOuts?.[index] ?? typedAmount;
 
     // Calculate total USD value and check insufficient balance (amount + fees)
     let totalUSDValue = Big(0);
@@ -246,10 +272,16 @@ export function ReviewPaymentsStep({
             );
             const balanceFormattedBig = Big(balanceFormattedString);
 
+            // When total already includes fees (header quote or typed+fee),
+            // do not pass networkFee again — that double-counts.
             balanceWarning = getPaymentBalanceWarning({
-                amount: totalAmount.toString(),
+                amount: quotedTotalAmount
+                    ? totalAmount.toString()
+                    : recipientsTotal.toString(),
                 balance: balanceFormattedBig,
-                networkFee: totalNetworkFee ?? undefined,
+                networkFee: quotedTotalAmount
+                    ? undefined
+                    : (totalNetworkFee ?? undefined),
                 decimals: selectedToken.decimals,
                 symbol: selectedToken.symbol,
             });
@@ -331,10 +363,12 @@ export function ReviewPaymentsStep({
                         <>
                             {paymentData.map((payment, index) => {
                                 const recipientFee = getRecipientFee(index);
-                                // Calculate estimated USD value
-                                // balanceUSD is the total USD value of the token balance
-                                // To get price per token: balanceUSD / (balance / 10^decimals)
-                                // To get USD value of payment: amount * pricePerToken
+                                const displayAmount = getRecipientDisplayAmount(
+                                    index,
+                                    payment.amount,
+                                );
+                                // Calculate estimated USD value from the
+                                // amount shown (net amountOut once quoted).
                                 let estimatedUSDValue = 0;
                                 if (selectedTokenData?.price && balance) {
                                     try {
@@ -347,7 +381,7 @@ export function ReviewPaymentsStep({
                                         );
                                         if (balanceFormatted > 0) {
                                             estimatedUSDValue =
-                                                Number(payment.amount) *
+                                                Number(displayAmount) *
                                                 selectedTokenData.price;
                                         }
                                     } catch (error) {
@@ -431,7 +465,7 @@ export function ReviewPaymentsStep({
                                                         <div className="flex flex-col gap-[3px] items-end">
                                                             <p className="text-sm font-semibold whitespace-nowrap leading-5">
                                                                 {formatTokenDisplayAmount(
-                                                                    payment.amount,
+                                                                    displayAmount,
                                                                 )}{" "}
                                                                 {
                                                                     selectedToken.symbol

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/upload-data-step.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/upload-data-step.tsx
@@ -276,6 +276,9 @@ export function UploadDataStep({
                         ? { ...selectedToken, address: destinationAssetId }
                         : selectedToken,
                     parsingLabels,
+                    // Confidential: quote against the receive network, not
+                    // the source token's residency chain.
+                    isConfidential ? destinationNetwork : undefined,
                 );
 
                 if (!isConfidential) {
@@ -311,9 +314,9 @@ export function UploadDataStep({
     // Show full page skeleton while loading
     if (isLoading) {
         return (
-            <div className="flex flex-wrap justify-center gap-6 w-full">
+            <div className="flex flex-col lg:flex-row lg:justify-center gap-4 w-full min-w-0">
                 {/* Main Content Skeleton */}
-                <div className="flex-1 min-w-0 max-w-3xl">
+                <div className="w-full min-w-0 max-w-[600px] mx-auto lg:mx-0">
                     <PageCard className="gap-2">
                         <div className="flex flex-col gap-3">
                             <div className="flex flex-col">
@@ -323,12 +326,12 @@ export function UploadDataStep({
                                             variant="unstyled"
                                             size="icon"
                                             onClick={handleBack}
-                                            className="p-0!"
+                                            className="p-0! shrink-0"
                                         >
-                                            <ArrowLeft className="w-5 h-5" />
+                                            <ArrowLeft className="size-5" />
                                         </Button>
                                     )}
-                                    <h4 className="text-lg font-bold mb-1">
+                                    <h4 className="text-base md:text-lg font-bold mb-1">
                                         {t("headerTitle")}
                                     </h4>
                                 </div>
@@ -341,9 +344,9 @@ export function UploadDataStep({
                             <div>
                                 <div className="flex gap-2 mb-4">
                                     <div className="w-6 h-6 bg-muted-foreground/20 rounded-full animate-pulse" />
-                                    <div className="flex-1 space-y-3">
+                                    <div className="flex-1 space-y-3 min-w-0">
                                         <div className="h-5 bg-muted-foreground/20 rounded w-32 animate-pulse" />
-                                        <div className="h-14 bg-muted-foreground/20 rounded animate-pulse" />
+                                        <div className="h-12 bg-muted-foreground/20 rounded animate-pulse" />
                                     </div>
                                 </div>
                             </div>
@@ -352,22 +355,22 @@ export function UploadDataStep({
                             <div>
                                 <div className="flex gap-2 mb-4">
                                     <div className="w-6 h-6 bg-muted-foreground/20 rounded-full animate-pulse" />
-                                    <div className="flex-1 space-y-3">
+                                    <div className="flex-1 space-y-3 min-w-0">
                                         <div className="h-5 bg-muted-foreground/20 rounded w-48 animate-pulse" />
                                         <div className="h-10 bg-muted-foreground/20 rounded animate-pulse" />
-                                        <div className="h-64 bg-muted-foreground/20 rounded animate-pulse" />
+                                        <div className="h-48 md:h-64 bg-muted-foreground/20 rounded animate-pulse" />
                                     </div>
                                 </div>
                             </div>
 
                             {/* Button Skeleton */}
-                            <div className="h-12 bg-muted-foreground/20 rounded animate-pulse" />
+                            <div className="h-11 bg-muted-foreground/20 rounded animate-pulse" />
                         </div>
                     </PageCard>
                 </div>
 
                 {/* Sidebar Skeleton */}
-                <div className="flex flex-col gap-4 w-full lg:w-80 shrink-0">
+                <div className="flex flex-col gap-4 w-full max-w-[600px] mx-auto lg:mx-0 lg:w-80 lg:max-w-none shrink-0">
                     {/* Requirements Card Skeleton */}
                     <PageCard
                         style={{
@@ -401,9 +404,9 @@ export function UploadDataStep({
     }
 
     return (
-        <div className="flex flex-wrap justify-center gap-4 w-full">
+        <div className="flex flex-col lg:flex-row lg:justify-center gap-4 w-full min-w-0">
             {/* Main Content */}
-            <div className="flex-1 max-w-[600px] min-w-[300px]">
+            <div className="w-full min-w-0 max-w-[600px] mx-auto lg:mx-0">
                 <PageCard className="gap-2">
                     {/* Header */}
                     <div className="flex flex-col gap-3">
@@ -414,12 +417,12 @@ export function UploadDataStep({
                                         variant="ghost"
                                         size="icon"
                                         onClick={handleBack}
-                                        className="p-0!"
+                                        className="p-0! shrink-0"
                                     >
-                                        <ArrowLeft />
+                                        <ArrowLeft className="size-5" />
                                     </Button>
                                 )}
-                                <div className="flex flex-col">
+                                <div className="flex flex-col min-w-0">
                                     <p className="font-semibold mb-1">
                                         {t("headerTitle")}
                                     </p>
@@ -485,11 +488,11 @@ export function UploadDataStep({
                                                 "disableTokenMessage",
                                             )}
                                             disabled={availableCredits === 0}
-                                            iconSize="lg"
+                                            iconSize="md"
                                             classNames={{
                                                 trigger: showTokenWarning
-                                                    ? "w-full h-14 shrink-0 border-0 bg-transparent shadow-none hover:bg-transparent hover:border-none rounded-none px-0"
-                                                    : "w-full h-14 rounded-lg px-4 bg-muted hover:bg-muted/80 hover:border-none",
+                                                    ? "w-full h-11 md:h-12 shrink-0 border-0 bg-transparent shadow-none hover:bg-transparent hover:border-none rounded-none px-0"
+                                                    : "w-full h-11 md:h-12 rounded-lg px-3 md:px-4 bg-muted hover:bg-muted/80 hover:border-none",
                                             }}
                                         />
                                         {showTokenWarning && (
@@ -504,8 +507,8 @@ export function UploadDataStep({
                             </div>
                         </div>
                         {/* Step 2: Provide Payment Data */}
-                        <div className="mb-4">
-                            <div className="flex gap-2 mb-4">
+                        <div className="md:mb-4">
+                            <div className="flex gap-2 md:mb-4">
                                 <NumberBadge number={2} variant="secondary" />
                                 <div className="flex-1 flex flex-col gap-2">
                                     <h3 className="text-sm font-semibold">
@@ -613,7 +616,7 @@ export function UploadDataStep({
                                                             </div>
                                                         </div>
 
-                                                        <div className="flex items-center gap-2 text-sm">
+                                                        <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2 text-sm">
                                                             <span className="text-muted-foreground">
                                                                 {t(
                                                                     "noFilePrompt",
@@ -751,7 +754,7 @@ export function UploadDataStep({
                                                     borderless
                                                     placeholder={`alice.near, 100.00\nbob.near, 100.00\ncharlie.near, 100.00`}
                                                     rows={8}
-                                                    className={`w-full max-w-full resize-none font-mono text-sm bg-muted focus:outline-none break-all whitespace-pre-wrap wrap-anywhere overflow-x-hidden min-h-41 ${
+                                                    className={`w-full max-w-full resize-none font-mono text-sm bg-muted focus:outline-none break-all whitespace-pre-wrap wrap-anywhere overflow-x-hidden min-h-32 md:min-h-41 ${
                                                         dataErrors &&
                                                         dataErrors.length > 0
                                                             ? "border border-destructive bg-destructive/5! focus:border-destructive!"
@@ -846,7 +849,7 @@ export function UploadDataStep({
             </div>
 
             {/* Right Sidebar */}
-            <div className="flex flex-col gap-4 w-full lg:w-80 shrink-0">
+            <div className="flex flex-col gap-4 w-full max-w-[600px] mx-auto lg:mx-0 lg:w-80 lg:max-w-none shrink-0">
                 {/* Requirements Card */}
                 <PageCard
                     style={{

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
@@ -605,13 +605,16 @@ export default function BulkPaymentPage() {
                 title={pageTitle}
                 description={t("description")}
             >
-                <div className="w-full max-w-[600px] mx-auto">
+                <div className="w-full max-w-[600px] mx-auto min-w-0">
                     <EditPaymentStep
                         handleBack={handleCancelEdit}
                         payment={payment}
                         paymentIndex={editingIndex}
                         selectedToken={selectedToken}
                         networkFeePerRecipient={networkFeePerRecipient}
+                        destinationNetwork={
+                            isConfidential ? destinationNetworkName : undefined
+                        }
                         onSave={handleSaveEdit}
                         onCancel={handleCancelEdit}
                     />
@@ -624,7 +627,7 @@ export default function BulkPaymentPage() {
         <PageComponentLayout title={pageTitle} description={t("description")}>
             <FormProvider {...form}>
                 <div
-                    className={`w-full mx-auto ${step === 1 ? "max-w-3xl" : "max-w-7xl"}`}
+                    className={`w-full mx-auto min-w-0 ${step === 1 ? "max-w-[600px]" : "max-w-7xl"}`}
                 >
                     {/* Step 0: Upload Data */}
                     {step === 0 && (
@@ -658,6 +661,9 @@ export default function BulkPaymentPage() {
                                             >[0]["token"]
                                         }
                                         recipient={firstRecipient}
+                                        // Pick receive network independently —
+                                        // CSV validation enforces address type.
+                                        requireRecipient={false}
                                         sectionRules={networkSectionRules}
                                         bridgeAssets={bridgeAssets}
                                         isBridgeAssetsLoading={
@@ -689,6 +695,16 @@ export default function BulkPaymentPage() {
                             onPaymentDataChange={setPaymentData}
                             onSubmit={onSubmit}
                             isSubmitting={isSubmittingProposal}
+                            destinationNetworkId={
+                                isConfidential
+                                    ? destinationNetworkId
+                                    : undefined
+                            }
+                            destinationNetworkName={
+                                isConfidential
+                                    ? destinationNetworkName
+                                    : undefined
+                            }
                             confidentialPrepare={
                                 isConfidential
                                     ? {

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { PageComponentLayout } from "@/components/page-component-layout";
@@ -48,6 +48,8 @@ import {
     buildPrepareRequest,
     deriveQuoteFees,
     isOutOfCreditsError,
+    maxQuotedRecipientFee,
+    needsFeeRepad,
 } from "./utils/confidential-prepare";
 import { useConfidentialPrepare } from "./utils/use-confidential-prepare";
 import { useSubscription } from "@/hooks/use-subscription";
@@ -200,6 +202,25 @@ export default function BulkPaymentPage() {
             prepare.status === "success" ? deriveQuoteFees(prepare.data) : null,
         [prepare],
     );
+    // SDK pad can understate the firm 1Click fee. When that happens, bump the
+    // pad and re-prepare so EXACT_INPUT amountOut matches the typed amount —
+    // same numbers request details will show from stored quotes.
+    const padAdjustmentPending =
+        prepare.status === "success" &&
+        quoteFees != null &&
+        needsFeeRepad(networkFeePerRecipient, quoteFees);
+
+    useEffect(() => {
+        if (!padAdjustmentPending || !quoteFees) return;
+        setNetworkFeePerRecipient(maxQuotedRecipientFee(quoteFees).toFixed());
+    }, [padAdjustmentPending, quoteFees]);
+
+    const prepareReady = prepare.status === "success" && !padAdjustmentPending;
+    const prepareStatusForReview =
+        prepare.status === "success" && padAdjustmentPending
+            ? "loading"
+            : prepare.status;
+
     // The 402 branch is a race backstop: credits ran out between the
     // subscription check above and the prepare call landing.
     const outOfCredits =
@@ -270,8 +291,8 @@ export default function BulkPaymentPage() {
     const onSubmitConfidential = async () => {
         if (!selectedTreasury || paymentData.length === 0 || !selectedToken)
             return;
-        // Confirm is disabled until quotes load, so this only guards races.
-        if (prepare.status !== "success") return;
+        // Confirm is disabled until quotes load and any fee re-pad finishes.
+        if (!prepareReady || prepare.status !== "success") return;
         const prepared = prepare.data;
 
         const proposalBond = policy?.proposal_bond || "0";
@@ -708,8 +729,23 @@ export default function BulkPaymentPage() {
                             confidentialPrepare={
                                 isConfidential
                                     ? {
-                                          status: prepare.status,
-                                          fees: quoteFees,
+                                          status: prepareStatusForReview,
+                                          fees: prepareReady ? quoteFees : null,
+                                          quotes:
+                                              prepareReady &&
+                                              prepare.status === "success"
+                                                  ? {
+                                                        headerAmountInFormatted:
+                                                            prepare.data
+                                                                .headerQuote
+                                                                .amountInFormatted,
+                                                        recipientAmountOutFormatted:
+                                                            prepare.data.recipientQuotes.map(
+                                                                (q) =>
+                                                                    q.amountOutFormatted,
+                                                            ),
+                                                    }
+                                                  : null,
                                           retry: retryPrepare,
                                           outOfCredits,
                                       }

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/confidential-prepare.test.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/confidential-prepare.test.ts
@@ -9,6 +9,8 @@ import {
     createPrepareController,
     deriveQuoteFees,
     isOutOfCreditsError,
+    maxQuotedRecipientFee,
+    needsFeeRepad,
     type PrepareState,
 } from "./confidential-prepare";
 
@@ -124,6 +126,46 @@ describe("deriveQuoteFees", () => {
     it("reports zero fees for pure intra-Intents transfers", () => {
         const fees = deriveQuoteFees(prepareResponse());
         expect(fees.totalNetworkFee.toString()).toBe("0");
+    });
+});
+
+describe("maxQuotedRecipientFee / needsFeeRepad", () => {
+    it("returns the largest per-recipient fee", () => {
+        const fees = deriveQuoteFees({
+            recipientQuotes: [
+                legQuote({
+                    amountInFormatted: "1.30",
+                    amountOutFormatted: "0.70",
+                }),
+                legQuote({
+                    amountInFormatted: "2.40",
+                    amountOutFormatted: "2.00",
+                }),
+            ],
+            headerQuote: legQuote({
+                amountInFormatted: "3.70",
+                amountOutFormatted: "3.70",
+            }),
+        });
+        expect(maxQuotedRecipientFee(fees).toString()).toBe("0.6");
+    });
+
+    it("needs re-pad when firm fee exceeds the current pad", () => {
+        const fees = deriveQuoteFees({
+            recipientQuotes: [
+                legQuote({
+                    amountInFormatted: "1.30",
+                    amountOutFormatted: "0.70",
+                }),
+            ],
+            headerQuote: legQuote({
+                amountInFormatted: "1.30",
+                amountOutFormatted: "1.30",
+            }),
+        });
+        expect(needsFeeRepad("0.3", fees)).toBe(true);
+        expect(needsFeeRepad("0.6", fees)).toBe(false);
+        expect(needsFeeRepad(null, fees)).toBe(true);
     });
 });
 

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/confidential-prepare.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/confidential-prepare.ts
@@ -87,6 +87,29 @@ export function deriveQuoteFees(
     return { perRecipientFees, totalNetworkFee };
 }
 
+/** Largest per-recipient withdrawal fee from firm quotes (token units). */
+export function maxQuotedRecipientFee(fees: QuoteFees): Big {
+    return fees.perRecipientFees.reduce(
+        (max, fee) => (fee.gt(max) ? fee : max),
+        Big(0),
+    );
+}
+
+/**
+ * True when the firm quote fee exceeds the pad used for EXACT_INPUT — the
+ * recipient would under-receive vs the typed amount until we re-pad and
+ * re-prepare.
+ */
+export function needsFeeRepad(
+    currentPad: string | null | undefined,
+    fees: QuoteFees,
+): boolean {
+    const pad = currentPad ? Big(currentPad) : Big(0);
+    const maxFee = maxQuotedRecipientFee(fees);
+    // Tiny epsilon avoids churn on float/decimal noise between quote rounds.
+    return maxFee.gt(pad.plus("0.0000001"));
+}
+
 // ─── Error classification ───
 
 /**

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.test.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.test.ts
@@ -1,9 +1,42 @@
 import { describe, expect, it } from "bun:test";
-import { parseAmount } from "./parsing";
+import { parseAmount, parseAndValidateCsv } from "./parsing";
+import type { BulkParsingLabels } from "./parsing";
 
 const labels = {
     pleaseRemoveChars: (chars: string) => `Please remove: ${chars}`,
     amountCannotBeEmpty: "Amount cannot be empty",
+};
+
+const parsingLabels: BulkParsingLabels = {
+    rowPrefix: (row, message) => `Row ${row}: ${message}`,
+    rowPrefixOnly: (row) => `Row ${row}: `,
+    missingRecipientFirstColumn: "missing recipient",
+    invalidNearAddress: (address) => `invalid near ${address}`,
+    invalidChainAddress: (address, chain) =>
+        `invalid ${chain} address ${address}`,
+    rowNeedsAmountRecipient: "needs amount and recipient",
+    missingRecipientBeforeComma: "missing recipient before comma",
+    missingAmountAfterComma: (recipient) => `missing amount after ${recipient}`,
+    invalidAmountNumber: (amountStr) => `invalid amount ${amountStr}`,
+    amountGreaterThanZero: (amountStr) => `amount not > 0: ${amountStr}`,
+    amountTooLarge: (amountStr) => `amount too large: ${amountStr}`,
+    invalidAmountFallback: "invalid amount",
+    pleaseRemoveChars: (chars) => `Please remove: ${chars}`,
+    amountCannotBeEmpty: "Amount cannot be empty",
+    tokenMismatch: (provided, expected) =>
+        `token mismatch ${provided} vs ${expected}`,
+    multipleTokenSymbols: (symbols) => `multiple symbols ${symbols}`,
+    noPaymentDataFound: "no payment data",
+    exceedsRecipientLimit: (count, limit) => `exceeds limit ${count}/${limit}`,
+    noPaymentDataProvided: "no data provided",
+    headerColumnsNotFound: "header not found",
+    failedToParseCsv: "failed csv",
+    failedToParsePaste: "failed paste",
+    failedToValidateAccount: "failed validate account",
+    nearValidationError: () => "near validation error",
+    feeEstimationFailed: "fee failed",
+    feeEstimationFailedRow: (row, recipient) =>
+        `fee failed row ${row} ${recipient}`,
 };
 
 describe("parseAmount thousand separators", () => {
@@ -31,5 +64,40 @@ describe("parseAmount thousand separators", () => {
     it("still handles mixed comma+dot formats", () => {
         expect(parseAmount("1,000.50", labels).amount).toBe("1000.50");
         expect(parseAmount("1.000,50", labels).amount).toBe("1000.50");
+    });
+});
+
+describe("parseAndValidateCsv destination network", () => {
+    const ethAddress = "0x1111111111111111111111111111111111111111";
+    const nearAddress = "alice.near";
+    const ethCsv = `recipient,amount\n${ethAddress},10`;
+    const nearCsv = `recipient,amount\n${nearAddress},10`;
+
+    it("validates addresses against receive network, not send token network", () => {
+        // Source token lives on NEAR; receive network is eth.
+        const result = parseAndValidateCsv(
+            ethCsv,
+            parsingLabels,
+            { symbol: "USDC", network: "near", residency: "intents" },
+            "eth",
+        );
+
+        expect(result.errors).toEqual([]);
+        expect(result.payments).toHaveLength(1);
+        expect(result.payments[0]?.recipient).toBe(ethAddress);
+    });
+
+    it("rejects near addresses when receive network is eth", () => {
+        // Without destination override this would pass (token network = near).
+        const result = parseAndValidateCsv(
+            nearCsv,
+            parsingLabels,
+            { symbol: "USDC", network: "near", residency: "intents" },
+            "eth",
+        );
+
+        expect(result.payments).toHaveLength(0);
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.errors[0]?.message.toLowerCase()).toContain("eth");
     });
 });

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/utils/parsing.ts
@@ -663,6 +663,10 @@ export function needsStorageDepositCheck(token: {
 
 /**
  * Validate accounts and check storage deposits
+ *
+ * `destinationNetwork` overrides the token's own network when deciding
+ * whether recipients are on NEAR (existence + storage checks). Used by
+ * confidential bulk where receive chain can differ from the source token.
  */
 export async function validateAccountsAndStorage(
     payments: BulkPaymentData[],
@@ -671,8 +675,10 @@ export async function validateAccountsAndStorage(
         BulkParsingLabels,
         "failedToValidateAccount" | "nearValidationError"
     >,
+    destinationNetwork?: string,
 ): Promise<BulkPaymentData[]> {
-    const isNear = isNearToken(selectedToken.network, selectedToken.residency);
+    const networkForNearCheck = destinationNetwork ?? selectedToken.network;
+    const isNear = isNearToken(networkForNearCheck, selectedToken.residency);
 
     // Step 1: Validate account existence (only for NEAR)
     if (isNear) {
@@ -763,6 +769,10 @@ export async function validateAccountsAndStorage(
 /**
  * Estimate network fee per recipient for cross-chain intents bulk payments.
  * Uses one validated recipient as representative (same destination chain).
+ *
+ * `destinationNetwork` overrides the token's own network for both the
+ * cross-chain check and the fee quote destination blockchain — required for
+ * confidential bulk where receive network ≠ send token network.
  */
 export async function validateIntentsFeeCoverage(
     payments: BulkPaymentData[],
@@ -777,8 +787,15 @@ export async function validateIntentsFeeCoverage(
         BulkParsingLabels,
         "feeEstimationFailed" | "feeEstimationFailedRow"
     >,
+    destinationNetwork?: string,
 ): Promise<{ payments: BulkPaymentData[]; networkFee: string | null }> {
-    if (!isIntentsCrossChainToken(selectedToken)) {
+    const networkForFee = destinationNetwork ?? selectedToken.network;
+    if (
+        !isIntentsCrossChainToken({
+            address: selectedToken.address,
+            network: networkForFee,
+        })
+    ) {
         return { payments, networkFee: null };
     }
 
@@ -797,7 +814,7 @@ export async function validateIntentsFeeCoverage(
             },
             destinationAddress: representativeAddress,
             destinationBlockchain: getBlockchainType(
-                selectedToken.network || "unknown",
+                networkForFee || "unknown",
             ),
         });
 

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
@@ -70,6 +70,13 @@ interface PaymentFormSectionProps<
     destinationNetworkNameFieldName?: Path<TFieldValues>;
     /** Hide recipient network selector (e.g. bulk payments). Default false. */
     hideRecipientNetwork?: boolean;
+    /**
+     * When the network selector is hidden (bulk), validate the recipient and
+     * filter the address book against this receive-network name instead of
+     * defaulting to NEAR / the send token's chain. Used by confidential bulk
+     * where receive network can differ from the source token.
+     */
+    recipientNetworkOverride?: string;
     bridgeAssets?: BridgeAsset[];
     isBridgeAssetsLoading?: boolean;
     sendWarningMessage?: string | null;
@@ -99,6 +106,7 @@ export function PaymentFormSection<
     destinationNetworkName,
     destinationNetworkNameFieldName,
     hideRecipientNetwork = false,
+    recipientNetworkOverride,
     bridgeAssets = [],
     isBridgeAssetsLoading = false,
     sendWarningMessage,
@@ -135,7 +143,9 @@ export function PaymentFormSection<
     }) as unknown as [Token | null, string, string | undefined];
     const token = watched[0];
     const recipient = (watched[1] ?? "") as string;
-    const selectedNetworkName = (watched[2] ?? "") as string;
+    const selectedNetworkName = ((watched[2] ?? "") ||
+        recipientNetworkOverride ||
+        "") as string;
     const amountValue = useWatch({
         control,
         name: amountName,
@@ -190,10 +200,10 @@ export function PaymentFormSection<
         ];
     }, [selectedContact, tRecipientNetwork]);
 
-    // For bulk (hideRecipientNetwork=true) we still validate against token's
-    // chain. When the network selector is shown, the recipient input runs in
-    // "unknown" mode (no validation) and compatibility is surfaced through
-    // the network selector sections instead.
+    // For bulk (hideRecipientNetwork=true) validate against the receive
+    // network (override or form field), falling back to NEAR. When the
+    // network selector is shown, the recipient input runs in "unknown" mode
+    // and compatibility is surfaced through the network selector sections.
     const blockchainType = useMemo(() => {
         if (!hideRecipientNetwork) return "unknown";
         if (!selectedNetworkName) return NEAR_NETWORK_ID;

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -56,6 +56,13 @@ interface RecipientNetworkSelectProps {
     invalid?: boolean;
     /** Error text shown under the network card. */
     errorMessage?: string | null;
+    /**
+     * When false (confidential bulk), the picker is available before any
+     * recipient address is entered and does not filter/clear by address
+     * compatibility — all recipients share one chosen receive network.
+     * Default true (single-payment flow).
+     */
+    requireRecipient?: boolean;
 }
 
 export type RecipientNetworkRuleOption = RecipientNetworkOption & {
@@ -88,7 +95,7 @@ function NetworkRow({
     return (
         <div
             className={cn(
-                "flex items-center gap-3 w-full",
+                "flex items-center gap-2 md:gap-3 w-full min-w-0",
                 disabled && "opacity-50",
             )}
         >
@@ -96,15 +103,15 @@ function NetworkRow({
                 src={option.icon}
                 alt={`${option.name} network`}
                 className={cn(
-                    "size-8 rounded-full object-cover",
+                    "size-6 md:size-8 rounded-full object-cover shrink-0",
                     option.networkName.toLowerCase() === NEAR_NETWORK_ID &&
                         "p-1",
                 )}
             />
-            <div className="flex flex-col items-start text-left">
+            <div className="flex flex-col items-start text-left min-w-0">
                 <span
                     className={cn(
-                        "text-base font-semibold",
+                        "text-sm md:text-base font-semibold truncate max-w-full",
                         getNetworkDisplayCaseClass(option.id),
                     )}
                 >
@@ -132,6 +139,7 @@ export function RecipientNetworkSelect({
     warningMessage,
     invalid = false,
     errorMessage = null,
+    requireRecipient = true,
 }: RecipientNetworkSelectProps) {
     const t = useTranslations("recipientNetworkSelect");
     const tAddressBookTable = useTranslations("addressBookTable");
@@ -209,12 +217,13 @@ export function RecipientNetworkSelect({
     const enrichedOptions = useMemo(() => {
         return availableOptions.map((option) => ({
             ...option,
-            isCompatible: isAddressCompatibleWithNetwork(
-                recipient,
-                option.networkName,
-            ),
+            // Bulk confidential picks the receive network first; every option
+            // is available and CSV validation enforces the address type later.
+            isCompatible: requireRecipient
+                ? isAddressCompatibleWithNetwork(recipient, option.networkName)
+                : true,
         }));
-    }, [availableOptions, recipient]);
+    }, [availableOptions, recipient, requireRecipient]);
 
     const compatibleOptions = useMemo(
         () => enrichedOptions.filter((option) => option.isCompatible),
@@ -241,23 +250,34 @@ export function RecipientNetworkSelect({
     }, [enrichedOptions, sectionRules]);
 
     const hasCompatibleNetwork = compatibleOptions.length > 0;
-    const isDisabled =
-        !recipient || isBridgeAssetsLoading || !hasCompatibleNetwork;
+    const isDisabled = requireRecipient
+        ? !recipient || isBridgeAssetsLoading || !hasCompatibleNetwork
+        : isBridgeAssetsLoading || availableOptions.length === 0;
 
     // Clear the selection when the address no longer matches it (e.g. user
-    // edited the address into a different chain's format).
+    // edited the address into a different chain's format). Skip in bulk mode
+    // where the receive network is chosen independently of any single address.
     useEffect(() => {
+        if (!requireRecipient) return;
         if (!value) return;
         if (availableOptions.length === 0) return;
         if (compatibleOptions.some((o) => o.id === value)) return;
         onChange("");
-    }, [value, availableOptions, compatibleOptions, onChange]);
+    }, [
+        value,
+        availableOptions,
+        compatibleOptions,
+        onChange,
+        requireRecipient,
+    ]);
 
-    const placeholderText = !recipient
-        ? t("enterAddressFirst")
-        : !hasCompatibleNetwork
-          ? t("noCompatibleNetwork")
-          : t("placeholder");
+    const placeholderText = requireRecipient
+        ? !recipient
+            ? t("enterAddressFirst")
+            : !hasCompatibleNetwork
+              ? t("noCompatibleNetwork")
+              : t("placeholder")
+        : t("placeholder");
 
     return (
         <>
@@ -272,16 +292,16 @@ export function RecipientNetworkSelect({
                     variant="ghost"
                     onClick={() => setOpen(true)}
                     disabled={isDisabled}
-                    className="w-full h-12 justify-between px-0! hover:bg-transparent dark:hover:bg-transparent focus-visible:bg-transparent dark:focus-visible:bg-transparent disabled:opacity-100"
+                    className="w-full h-11 md:h-12 justify-between px-0! hover:bg-transparent dark:hover:bg-transparent focus-visible:bg-transparent dark:focus-visible:bg-transparent disabled:opacity-100"
                 >
                     {selectedOption && !isDisabled ? (
                         <NetworkRow option={selectedOption} />
                     ) : (
-                        <span className="text-xl! font-normal text-muted-foreground">
+                        <span className="text-base md:text-xl! font-normal text-muted-foreground truncate">
                             {placeholderText}
                         </span>
                     )}
-                    <ChevronDown className="size-5 text-muted-foreground ml-auto" />
+                    <ChevronDown className="size-5 text-muted-foreground ml-auto shrink-0" />
                 </Button>
                 {warningMessage && (
                     <WarningMessage

--- a/nt-fe/components/modal.tsx
+++ b/nt-fe/components/modal.tsx
@@ -190,7 +190,7 @@ function DialogContent({
             className={cn(
                 "bg-card p-3.5 flex flex-col",
                 // Mobile: bottom drawer (full width, no margins)
-                "max-w-none! w-full inset-x-0 left-0 right-0 bottom-0 top-auto translate-x-0 translate-y-0 max-h-[85vh] rounded-t-2xl rounded-b-none",
+                "max-w-none! w-full inset-x-0 left-0 right-0 bottom-0 top-auto translate-x-0 translate-y-0 max-h-[80vh] rounded-t-2xl rounded-b-none",
                 "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
                 "data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100",
                 // Desktop: centered modal

--- a/nt-fe/components/page-component-layout.tsx
+++ b/nt-fe/components/page-component-layout.tsx
@@ -97,7 +97,7 @@ export function PageComponentLayout({
 
                         {logo ?? (
                             <div className="flex items-baseline gap-2">
-                                <h1 className="text-base md:text-lg font-bold">
+                                <h1 className="text-sm md:text-lg font-bold">
                                     {title}
                                 </h1>
                                 {description && (

--- a/nt-fe/components/token-select.tsx
+++ b/nt-fe/components/token-select.tsx
@@ -390,7 +390,7 @@ export default function TokenSelect({
                     <ChevronDown className="size-4 text-muted-foreground ml-auto" />
                 </Button>
             </DialogTrigger>
-            <DialogContent className="flex flex-col max-w-md">
+            <DialogContent className="flex flex-col sm:max-w-md">
                 <DialogHeader centerTitle={true}>
                     <div className="flex items-center gap-2 w-full">
                         {step === "network" && (
@@ -436,7 +436,7 @@ export default function TokenSelect({
                                 ))}
                             </div>
                         ) : (
-                            <ScrollArea className="h-[400px]">
+                            <ScrollArea className="h-[min(400px,calc(80vh-10rem))]">
                                 {showPopularAssets &&
                                     popularTokens.length > 0 && (
                                         <div className="mb-3">
@@ -515,7 +515,7 @@ export default function TokenSelect({
                     </div>
                 )}
                 {step === "network" && selectedAsset && (
-                    <ScrollArea className="h-[400px]">
+                    <ScrollArea className="h-[min(400px,calc(80vh-10rem))]">
                         {(() => {
                             const hasBalance = (item: MergedNetwork) => {
                                 if (

--- a/nt-fe/features/confidential/components/bulk-activation-card.tsx
+++ b/nt-fe/features/confidential/components/bulk-activation-card.tsx
@@ -61,8 +61,8 @@ export function BulkActivationCard() {
     // settles): show a spinner rather than an empty page.
     if (isLoading || (!status && !isError)) {
         return (
-            <Card className="mx-auto w-full max-w-xl">
-                <CardContent className="text-muted-foreground flex items-center justify-center p-8">
+            <Card className="mx-auto w-full max-w-[600px] min-w-0">
+                <CardContent className="text-muted-foreground flex items-center justify-center p-4 sm:p-8">
                     <Loader2 className="size-6 animate-spin" />
                 </CardContent>
             </Card>
@@ -74,10 +74,12 @@ export function BulkActivationCard() {
     // `isLoading` false once it has errored).
     if (!status) {
         return (
-            <Card className="mx-auto w-full max-w-xl">
-                <CardContent className="flex flex-col items-center gap-4 p-8 text-center">
-                    <AlertTriangle className="text-destructive size-10" />
-                    <h3 className="text-lg font-semibold">{t("errorTitle")}</h3>
+            <Card className="mx-auto w-full max-w-[600px] min-w-0">
+                <CardContent className="flex flex-col items-center gap-3 sm:gap-4 p-4 sm:p-8 text-center">
+                    <AlertTriangle className="text-destructive size-8 sm:size-10" />
+                    <h3 className="text-base sm:text-lg font-semibold">
+                        {t("errorTitle")}
+                    </h3>
                     <p className="text-muted-foreground text-sm">
                         {tCommon("tryAgain")}
                     </p>
@@ -124,19 +126,19 @@ export function BulkActivationCard() {
     };
 
     return (
-        <Card className="mx-auto w-full max-w-xl">
-            <CardContent className="flex flex-col items-center gap-4 p-8 text-center">
+        <Card className="mx-auto w-full max-w-[600px] min-w-0">
+            <CardContent className="flex flex-col items-center gap-3 sm:gap-4 p-4 sm:p-8 text-center">
                 {awaitingApproval ? (
                     <>
-                        <Users className="text-primary size-10" />
-                        <h3 className="text-lg font-semibold">
+                        <Users className="text-primary size-8 sm:size-10" />
+                        <h3 className="text-base sm:text-lg font-semibold">
                             {t("awaitingTitle")}
                         </h3>
                         <p className="text-muted-foreground text-sm">
                             {t("awaitingDescription")}
                         </p>
                         <div className="text-muted-foreground flex items-center gap-2 text-xs">
-                            <CheckCircle2 className="size-4" />
+                            <CheckCircle2 className="size-4 shrink-0" />
                             {t("awaitingHint")}
                         </div>
                         <p className="text-muted-foreground text-xs">
@@ -145,8 +147,8 @@ export function BulkActivationCard() {
                     </>
                 ) : (
                     <>
-                        <ShieldCheck className="text-primary size-10" />
-                        <h3 className="text-lg font-semibold">
+                        <ShieldCheck className="text-primary size-8 sm:size-10" />
+                        <h3 className="text-base sm:text-lg font-semibold">
                             {t("introTitle")}
                         </h3>
                         <p className="text-muted-foreground text-sm">

--- a/nt-fe/features/confidential/components/confidential-banner.tsx
+++ b/nt-fe/features/confidential/components/confidential-banner.tsx
@@ -38,14 +38,15 @@ export function ConfidentialBanner({
 
     if (type === "mini") {
         return (
-            <Tooltip
-                content={t("description")}
-                triggerProps={{
-                    asChild: false,
-                    className: cn("size-4", className),
-                }}
-            >
-                <Shield className="fill-foreground w-full h-full" />
+            <Tooltip content={t("description")}>
+                <span
+                    className={cn(
+                        "inline-flex size-4 shrink-0 items-center justify-center",
+                        className,
+                    )}
+                >
+                    <Shield className="size-full fill-foreground" />
+                </span>
             </Tooltip>
         );
     }

--- a/nt-fe/features/proposals/components/proposals-table.tsx
+++ b/nt-fe/features/proposals/components/proposals-table.tsx
@@ -393,7 +393,7 @@ export function ProposalsTable({
                 ),
             }),
         ],
-        [policy, accountId, treasuryId],
+        [policy, accountId, treasuryId, isMobile, router],
     );
 
     const table = useReactTable({


### PR DESCRIPTION
#1137
- Make Available / Locked / Earning rows full width on the mobile dashboard
- Fix oversized confidential shield in the mobile header
- Make confidential bulk payment flow mobile-responsive (upload, activation, review, modals)
- Correct receive-network handling in confidential bulk validation, edit, and review badges
- Align create review with prepare quotes (same as request details): Total = header amountIn, recipient = amountOut, fee = amountIn − amountOut. Re-pad EXACT_INPUT from the firm 1Click fee when the SDK estimate is too low, then re-prepare before confirm so the recipient nets ~the typed amount

