### PR TITLE
fix: survive DB connection storms — pool hardening + job-fleet self-heal

### DIFF
--- a/nt-be/src/jobs/mod.rs
+++ b/nt-be/src/jobs/mod.rs
@@ -826,6 +826,13 @@ pub async fn spawn_all(state: Arc<AppState>) -> (JobQueues, tokio::task::JoinHan
 
     let QueueRegistry { entries, specs } = queues;
     watchdog::install(specs);
+
+    // Liveness monitor runs *outside* the apalis Monitor so it survives a
+    // fleet-wide stall (e.g. a Postgres restart that parks every worker) and
+    // can restart the process to recover — the in-process `job-watchdog` can't,
+    // since it stalls along with the fleet it watches.
+    tokio::spawn(watchdog::run_liveness_monitor(state.db_pool.clone()));
+
     let queues = JobQueues { entries };
 
     // Jobs that previously ran once at startup, in addition to their cron

--- a/nt-be/src/jobs/watchdog.rs
+++ b/nt-be/src/jobs/watchdog.rs
@@ -309,9 +309,125 @@ pub async fn jobs_health(State(state): State<Arc<AppState>>, headers: HeaderMap)
         .into_response()
 }
 
+/// True when a large enough fraction of registered queues are stale to call
+/// it a *systemic* stall (the whole worker fleet down) rather than one bad job.
+fn is_systemic_stall(stale: usize, total: usize, fraction: f64) -> bool {
+    total > 0 && (stale as f64) / (total as f64) >= fraction
+}
+
+fn env_f64(var: &str, default: f64) -> f64 {
+    std::env::var(var)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|v: &f64| v.is_finite() && *v > 0.0)
+        .unwrap_or(default)
+}
+
+fn env_u64(var: &str, default: u64) -> u64 {
+    std::env::var(var)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Independent liveness monitor for the whole job fleet.
+///
+/// The `job-watchdog` above runs as an apalis worker, so when the *entire*
+/// fleet stalls — e.g. a Postgres restart drops every pooled connection at once
+/// and the workers park (heartbeat stops, queue dead) instead of erroring, so
+/// the Monitor's exit-triggered `should_restart` never fires — the watchdog
+/// stalls with it and can neither alert nor recover. (That is also why such an
+/// outage produced no Sentry alert: the alerting job never ran.)
+///
+/// This runs as a plain background task, independent of the apalis Monitor, so
+/// it keeps working when the workers don't. After a startup grace period, it
+/// checks every minute whether a large fraction of queues have gone stale (or
+/// the DB is unreachable) for several consecutive checks; if so it emits an
+/// ERROR (→ Sentry) and **exits the process** so the orchestrator restarts it
+/// clean — the only reliable way to unpark workers stuck on dead connections.
+///
+/// Guards against restart loops: a startup grace period (healthy queues need
+/// time to record their first success), and a required run of consecutive bad
+/// checks so a momentary blip doesn't restart the process. Config via env:
+/// `JOB_LIVENESS_GRACE_SECONDS` (900), `JOB_LIVENESS_CHECK_INTERVAL_SECONDS`
+/// (60), `JOB_LIVENESS_STALE_FRACTION` (0.6), `JOB_LIVENESS_CONSECUTIVE` (3).
+pub async fn run_liveness_monitor(pool: PgPool) {
+    let grace = Duration::from_secs(env_u64("JOB_LIVENESS_GRACE_SECONDS", 900));
+    let interval = Duration::from_secs(env_u64("JOB_LIVENESS_CHECK_INTERVAL_SECONDS", 60).max(1));
+    let stale_fraction = env_f64("JOB_LIVENESS_STALE_FRACTION", 0.6);
+    let needed = env_u64("JOB_LIVENESS_CONSECUTIVE", 3).max(1);
+
+    let start = Instant::now();
+    let mut consecutive: u64 = 0;
+
+    loop {
+        tokio::time::sleep(interval).await;
+        if start.elapsed() < grace {
+            continue;
+        }
+
+        let bad = match evaluate(&pool).await {
+            Ok(report) if !report.is_empty() => {
+                let total = report.len();
+                let stale = report.iter().filter(|job| job.stale).count();
+                if is_systemic_stall(stale, total, stale_fraction) {
+                    tracing::warn!(
+                        stale,
+                        total,
+                        consecutive = consecutive + 1,
+                        "job fleet appears broadly stalled"
+                    );
+                    Some(format!("{stale}/{total} queues stale"))
+                } else {
+                    None
+                }
+            }
+            // Registry not installed yet, or no queues — not a signal.
+            Ok(_) => None,
+            // DB unreachable is itself a fleet-down signal; restarting
+            // re-establishes connections.
+            Err(e) => {
+                tracing::warn!(error = %e, consecutive = consecutive + 1, "job liveness check failed");
+                Some(format!("liveness DB check failed: {e}"))
+            }
+        };
+
+        match bad {
+            Some(reason) => {
+                consecutive += 1;
+                if consecutive >= needed {
+                    // ERROR → Sentry (this task is alive even when the fleet is
+                    // not, so unlike the in-process watchdog this alert fires).
+                    tracing::error!(
+                        reason = %reason,
+                        consecutive,
+                        "job fleet stalled; restarting process to recover"
+                    );
+                    // Give the log/Sentry a moment to flush before exit.
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    std::process::exit(1);
+                }
+            }
+            None => consecutive = 0,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn systemic_stall_needs_a_majority_of_queues() {
+        // One bad job in a healthy fleet is not systemic.
+        assert!(!is_systemic_stall(1, 30, 0.6));
+        assert!(!is_systemic_stall(17, 30, 0.6)); // 56% < 60%
+        // The incident: 24/30 stale is systemic.
+        assert!(is_systemic_stall(24, 30, 0.6));
+        assert!(is_systemic_stall(18, 30, 0.6)); // exactly 60%
+        // Never divide by zero on an empty registry.
+        assert!(!is_systemic_stall(0, 0, 0.6));
+    }
 
     #[test]
     fn interval_derived_from_uniform_schedules() {


### PR DESCRIPTION
Incident (testenv ~2026-07-20 10:15): an instance restart reset all DB connections and **24/30 apalis workers parked** (heartbeat stopped, queue not consumed) instead of erroring, and the Monitor's exit-triggered `should_restart` never restarted them. `dao-policy-dirty` was one → `is_dirty` DAOs never synced. No Sentry alert either, because the `job-watchdog` is itself an apalis worker and parked with the fleet.

Two complementary fixes, because **restart alone doesn't help — the stall is triggered by the connection pressure at (re)start**:

## 1. Harden the DB pool so boot survives the connection storm
The pool opened up to 20 connections and, with no idle/lifetime bounds, held them forever. During a rolling deploy the outgoing + incoming instances overlap at ~2× the pool, and against the DB's `max_connections` the new instance can't acquire connections → workers stall.
- `idle_timeout(10m)` — release idle connections, so a mostly-idle instance holds only a handful; the deploy overlap is small instead of 20+20.
- `max_lifetime(30m)` — recycle so reset-broken connections are dropped.
- `test_before_acquire(true)` — hand out only live connections (a reset-killed socket is replaced, not failed onto a worker).
- `min_connections(0)` — lazy boot, no eager herd.
- `DATABASE_MAX_CONNECTIONS` / `DATABASE_ACQUIRE_TIMEOUT_SECONDS` (default 20 / 10s, up from a 3s acquire timeout) so ops can fit the pool to the DB cap × instance count.

## 2. Self-heal a fleet that stalls anyway
`watchdog::run_liveness_monitor`, spawned **outside** the apalis Monitor as a plain task, so it stays alive when the fleet doesn't. After a grace period, if ≥60% of queues are stale (or the DB is unreachable) for several consecutive checks, it logs ERROR (→ Sentry — this task is alive when the in-process watchdog isn't) and `exit(1)` so the orchestrator restarts. Now crash-loop-safe: with the pool hardening a restart reconnects cleanly. Env: `JOB_LIVENESS_{GRACE_SECONDS,CHECK_INTERVAL_SECONDS,STALE_FRACTION,CONSECUTIVE}`.

## Notes
- Our storages use `new_with_config` (polling `PgFetcher`), **not** `new_with_notify` — so workers share the pool transiently and don't hold per-worker `PgListener` connections. App footprint is one pool per instance.
- Infra follow-up worth checking: DB `max_connections ≥ pool_max × max_concurrent_instances + headroom`, and connection draining on deploy.

## Testing
- `cargo fmt --check`, `cargo clippy --lib --bins --tests -- -D warnings`, `cargo check`: clean.
- Unit test for the systemic-stall predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRWEKUFYCcmGGhwdDYd471