### PR TITLE
perf: de-bloat apalis.jobs so the board queries are fast (supersedes #1162)

### DIFF
--- a/nt-be/src/jobs/handlers.rs
+++ b/nt-be/src/jobs/handlers.rs
@@ -575,6 +575,20 @@ pub async fn apalis_prune(_t: Tick, state: Data<Arc<AppState>>) -> Result<String
         }
     }
 
+    // Reclaim the space the deletes (and the churn) leave behind and refresh the
+    // visibility map + stats. Without this the table keeps hundreds of MB of
+    // dead tuples behind a small live set, and the board's full-table aggregate
+    // queries scan all of it. Plain `VACUUM` (not `FULL`) takes only a
+    // SHARE UPDATE EXCLUSIVE lock, so workers keep polling; it can't run inside
+    // a transaction, so it goes out on a pooled connection in autocommit. A
+    // failure here shouldn't fail the prune.
+    if let Err(e) = sqlx::query("VACUUM (ANALYZE) apalis.jobs")
+        .execute(&state.db_pool)
+        .await
+    {
+        tracing::warn!(error = %e, "VACUUM apalis.jobs after prune failed");
+    }
+
     Ok(format!(
         "pruned {total} terminal tasks older than {retention_hours}h"
     ))

--- a/nt-be/src/jobs/mod.rs
+++ b/nt-be/src/jobs/mod.rs
@@ -233,7 +233,36 @@ async fn setup_apalis(pool: &PgPool) -> Result<(), sqlx::Error> {
     drop(conn);
 
     ensure_board_indexes(pool).await;
+    tune_apalis_autovacuum(pool).await;
     Ok(())
+}
+
+/// Makes autovacuum far more aggressive on `apalis.jobs`.
+///
+/// The queues churn ~1M rows/day (insert → Running → Done, then pruned), so at
+/// Postgres's default `autovacuum_vacuum_scale_factor` of 0.2 (vacuum only once
+/// 20% of the table is dead) the table bloats badly — on testenv it grew to
+/// ~370 MB of dead tuples behind only ~70k live rows, which made the board's
+/// full-table aggregate queries (`/api/v1/overview`, `/api/v1/queues`) scan
+/// hundreds of MB and take >1s. Aggressive settings keep dead tuples low (so the
+/// heap stays compact) and the visibility map fresh (so the board's aggregates
+/// can use index-only scans). `insert_scale_factor` matters because this table
+/// is insert-heavy — it triggers vacuums that keep the VM current even when few
+/// rows are updated. Idempotent; a failure here only degrades board latency, so
+/// log and carry on rather than block startup.
+async fn tune_apalis_autovacuum(pool: &PgPool) {
+    use sqlx::Executor as _;
+
+    let ddl = "ALTER TABLE apalis.jobs SET (\
+         autovacuum_vacuum_scale_factor = 0.05, \
+         autovacuum_vacuum_threshold = 500, \
+         autovacuum_analyze_scale_factor = 0.05, \
+         autovacuum_analyze_threshold = 500, \
+         autovacuum_vacuum_insert_scale_factor = 0.05, \
+         autovacuum_vacuum_cost_delay = 2)";
+    if let Err(e) = pool.execute(ddl).await {
+        tracing::warn!(error = %e, "failed to tune apalis.jobs autovacuum");
+    }
 }
 
 /// Adds composite indexes that the apalis-board queries need but the apalis


### PR DESCRIPTION
Follow-up to your point on #1162 — instead of hiding the slow-statement warning by raising the threshold, actually make the board queries fast.

## Root cause: table bloat, not row count
Measured on testenv: `TOTAL_JOBS` ≈ **70k** live rows, but `DB_SIZE` ≈ **371 MB** — ~5 KB/row, i.e. the table is almost all **dead tuples**. The queues churn ~1M rows/day (insert → Running → Done → pruned), and Postgres's default autovacuum only kicks in at 20% dead (`autovacuum_vacuum_scale_factor = 0.2`), which can't keep up. So the board's full-table aggregates (`SUM(CASE WHEN status …)`, `COUNT(*)`) scan hundreds of MB of mostly-dead pages → ~1.5s.

## Fix (attack the bloat)
- **Aggressive autovacuum on `apalis.jobs`** (`tune_apalis_autovacuum`, run in `setup_apalis`): `vacuum_scale_factor = 0.05`, `autovacuum_vacuum_insert_scale_factor = 0.05` (the table is insert-heavy, so insert-triggered vacuums keep the visibility map fresh), lower thresholds, small cost delay. Keeps dead tuples low (compact heap) and the VM fresh (so the aggregates can use **index-only scans** over the narrow indexes already added, bypassing the heap entirely).
- **`VACUUM (ANALYZE) apalis.jobs`** at the end of the hourly `apalis_prune`: reclaims the space the deletes leave + refreshes VM/stats. Plain `VACUUM` (not `FULL`) takes only a SHARE UPDATE EXCLUSIVE lock, so workers keep polling.

## Relationship to the other PRs
- **Supersedes #1162** (slow-statement threshold bump) for these queries — recommend closing #1162, or keeping only as a minor defensive default. This PR makes them genuinely fast.
- Complements #1161 (retention + stuck-`Running` reclaimer): fewer rows *and* no bloat.
- **Ops, one-time**: `VACUUM FULL apalis.jobs` reclaims the existing ~370 MB immediately (brief exclusive lock); the settings here prevent it re-bloating.

## Testing
`cargo fmt --check`, `cargo clippy --lib -- -D warnings`, `cargo check`: clean. Validated the `ALTER TABLE … SET (autovacuum_*)` and `VACUUM (ANALYZE)` statements against Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRWEKUFYCcmGGhwdDYd471