### PR TITLE
ci: per-PR Playwright video report on GitHub Pages

### DIFF
--- a/.github/workflows/e2e-report-cleanup.yml
+++ b/.github/workflows/e2e-report-cleanup.yml
@@ -1,0 +1,44 @@
+name: Cleanup E2E Report
+
+# Removes a PR's published report from gh-pages when the PR is closed/merged.
+# `pull_request_target` runs in the base repo with a write token (fork-safe);
+# it never checks out or runs PR code — it only deletes a folder on gh-pages.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: gh-pages-e2e-report
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        id: checkout
+        uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          ref: gh-pages
+
+      - name: Remove PR report folder
+        if: steps.checkout.outcome == 'success'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          dir="pr-${PR_NUMBER}"
+          if [ ! -d "$dir" ]; then
+            echo "No report at $dir; nothing to clean up."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git rm -rf "$dir"
+          git commit -m "cleanup e2e report for PR #${PR_NUMBER}"
+          git push

--- a/.github/workflows/e2e-report.yml
+++ b/.github/workflows/e2e-report.yml
@@ -1,0 +1,124 @@
+name: Publish E2E Report
+
+# Runs after "Frontend E2E Tests" completes and publishes its Playwright HTML
+# report (with inline videos, traces and screenshots) to GitHub Pages under a
+# per-PR path, then posts/updates a sticky comment linking it.
+#
+# This is a separate `workflow_run` workflow on purpose: `pull_request` runs
+# from forks get a read-only token and cannot push to gh-pages or comment.
+# `workflow_run` always executes in the base repo with the base repo's token,
+# so it works for fork PRs too. It only ever publishes an already-built static
+# report — it never checks out or runs PR code.
+
+on:
+  workflow_run:
+    workflows: ["Frontend E2E Tests"]
+    types: [completed]
+
+permissions:
+  contents: write # push the report to the gh-pages branch
+  pull-requests: write # post/update the sticky comment
+  actions: read # download artifacts from the triggering run
+
+# Serialize gh-pages deploys across all PRs so concurrent runs don't clash on
+# the branch.
+concurrency:
+  group: gh-pages-e2e-report
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish report to Pages
+    # Only for PR-triggered E2E runs (pushes to main don't need a PR comment).
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Playwright report
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download PR metadata
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-meta
+          path: pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # A run that died before uploading (e.g. a build failure) leaves no
+      # report. Skip quietly in that case instead of failing this workflow.
+      - name: Resolve PR number and validate report
+        id: pr
+        run: |
+          if [ ! -f pr-meta/pr-number.txt ] || [ ! -f playwright-report/index.html ]; then
+            echo "Report or PR metadata missing; nothing to publish."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          num="$(tr -dc '0-9' < pr-meta/pr-number.txt)"
+          if [ -z "$num" ]; then
+            echo "No PR number found; nothing to publish."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "number=$num" >> "$GITHUB_OUTPUT"
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to gh-pages
+        if: steps.pr.outputs.ok == 'true'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: playwright-report
+          target-folder: pr-${{ steps.pr.outputs.number }}
+          clean: false
+          commit-message: "e2e report for PR #${{ steps.pr.outputs.number }} @ ${{ github.event.workflow_run.head_sha }}"
+
+      - name: Comment report link on PR
+        if: steps.pr.outputs.ok == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            const run = context.payload.workflow_run;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const url = `https://${owner.toLowerCase()}.github.io/${repo}/pr-${prNumber}/`;
+
+            const passed = run.conclusion === 'success';
+            const status = passed
+              ? '✅ E2E tests passed'
+              : `⚠️ E2E run \`${run.conclusion}\``;
+            const marker = '<!-- e2e-report -->';
+            const body = [
+              marker,
+              '## 🎬 E2E report — visual review',
+              '',
+              `${status} · commit \`${run.head_sha.slice(0, 7)}\``,
+              '',
+              `**[▶ Open the live report](${url})** — every test recorded as a`,
+              'video, plus traces and screenshots. Videos stream in the browser;',
+              'no download needed. Use it to review the behaviour this PR produces.',
+              '',
+              `<sub>Rebuilt on every push to this PR · [workflow run](${run.html_url})</sub>`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body,
+              });
+            }

--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -108,3 +108,21 @@ jobs:
           path: nt-fe/test-results/
           retention-days: 30
           if-no-files-found: ignore
+
+      # Record which PR this run belongs to so the fork-safe `e2e-report`
+      # workflow (triggered on workflow_run) can publish the report to that
+      # PR. `pull_request` runs from forks have a read-only token and cannot
+      # comment or push to gh-pages themselves.
+      - name: Save PR metadata
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          mkdir -p pr-meta
+          echo "${{ github.event.pull_request.number }}" > pr-meta/pr-number.txt
+
+      - name: Upload PR metadata
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-meta
+          path: pr-meta/
+          retention-days: 1

--- a/nt-fe/playwright.config.ts
+++ b/nt-fe/playwright.config.ts
@@ -17,8 +17,12 @@ export default defineConfig({
 
     use: {
         baseURL: "http://localhost:3000",
+        // Record every test (pass or fail) so the published HTML report is a
+        // full visual walkthrough of the behaviour the PR produces, not just a
+        // failure debugging aid. The report embeds these videos so reviewers
+        // can watch them inline. See .github/workflows/e2e-report.yml.
         video: {
-            mode: process.env.CI ? "on-first-retry" : "on",
+            mode: "on",
             size: { width: 1280, height: 800 },
         },
         trace: "on-first-retry",


### PR DESCRIPTION
Makes every Trezu PR reviewable from a single link: a live report with the E2E **video recordings**, traces and screenshots, so you can watch what the PR does without downloading anything.

## What changes
- **Record video for every test** (`playwright.config.ts`: `video: "on"`), not just retries — the report becomes a full visual walkthrough of the PR's behaviour, not only a failure aid.
- **`e2e-report` workflow** (`workflow_run` after *Frontend E2E Tests*): publishes the Playwright HTML report to **GitHub Pages** under `pr-<N>/` and posts/updates a sticky PR comment linking the live URL. Videos stream in-browser.
- **`e2e-report-cleanup` workflow**: removes a PR's report from `gh-pages` when the PR is closed/merged.
- **`frontend-e2e`**: uploads a small `pr-meta` artifact so the publisher knows which PR a run belongs to.

## Why `workflow_run` (fork-safe)
Trezu PRs come from forks, whose `pull_request` runs get a **read-only** token — they can't push to `gh-pages` or comment. `workflow_run` always runs in the base repo with a write token, so it works for fork PRs. It only serves an already-built static report and **never checks out or runs PR code**.

## Reviewer experience
```
🎬 E2E report — visual review
✅ E2E tests passed · commit abc1234
▶ Open the live report — videos stream in the browser, no download.
```

## ⚠️ One-time setup required
- Enable **GitHub Pages** for the repo: Settings → Pages → Source = **Deploy from a branch**, branch = **gh-pages** `/ (root)`. The first publish creates the branch.
- `workflow_run` / `pull_request_target` workflows only take effect from the **default branch**, so the publisher/cleanup activate **after this merges**. The `frontend-e2e` changes (video + `pr-meta`) run on this PR already.

Validated with `actionlint`. Only `nt-fe/**` and workflow files were touched, so the `nt-be` suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)