### PR TITLE
feat: restore Google Analytics alongside Google Tag Manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 export NEXT_PUBLIC_BACKEND_API_BASE=http://localhost:3002
 export NEXT_PUBLIC_GTM_ID=
+export NEXT_PUBLIC_GA_MEASUREMENT_ID=
 export NEARBLOCKS_API_KEY=
 export FASTNEAR_API_KEY=
 export SPUTNIK_DAO_API_BASE=https://sputnik-indexer.fly.dev

--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -1,6 +1,6 @@
 # Analytics Events
 
-Most events are fired via `trackEvent()` from `nt-fe/lib/analytics.ts`, which sends to both **PostHog** and **Google Tag Manager** (`dataLayer`) simultaneously. Marketing configures GA4 conversion tracking and ad pixels inside GTM.
+Most events are fired via `trackEvent()` from `nt-fe/lib/analytics.ts`, which sends to **PostHog**, **Google Tag Manager** (`dataLayer`), and **Google Analytics** (GA4 via `gtag`) simultaneously. Marketing configures conversion tracking and ad pixels inside GTM; GA4 also receives events directly.
 
 Some onboarding survey events are provider-specific and are sent directly with `posthog.capture()` (PostHog-only).
 

--- a/nt-fe/README.md
+++ b/nt-fe/README.md
@@ -118,7 +118,8 @@ nt-fe/
 ## Environment Variables
 
 - `NEXT_PUBLIC_BACKEND_API_BASE` - Backend API base URL (default: http://localhost:8080)
-- `NEXT_PUBLIC_GTM_ID` - Google Tag Manager container ID (for example: GTM-XXXXXXX). Marketing configures GA4 and conversion tags inside GTM.
+- `NEXT_PUBLIC_GTM_ID` - Google Tag Manager container ID (for example: GTM-XXXXXXX). Marketing configures conversion tags and ad pixels inside GTM.
+- `NEXT_PUBLIC_GA_MEASUREMENT_ID` - Google Analytics 4 measurement ID (for example: G-XXXXXXXXXX). Loaded alongside GTM for direct GA4 tracking.
 
 ## Tech Stack
 

--- a/nt-fe/app/(init)/layout.tsx
+++ b/nt-fe/app/(init)/layout.tsx
@@ -5,6 +5,7 @@ import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import { getLocaleDirection } from "@/i18n/config";
 import "../globals.css";
 import { GleapWidget } from "@/components/gleap-widget";
+import { GoogleAnalytics } from "@/components/google-analytics";
 import { GoogleTagManager } from "@/components/google-tag-manager";
 import { QueryProvider } from "@/components/query-provider";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -86,6 +87,7 @@ export default async function RootLayout({
                             <WarningsProvider>
                                 {children}
                                 <Toaster />
+                                <GoogleAnalytics />
                                 <GoogleTagManager />
                             </WarningsProvider>
                         </QueryProvider>

--- a/nt-fe/app/(treasury)/layout.tsx
+++ b/nt-fe/app/(treasury)/layout.tsx
@@ -6,6 +6,7 @@ import { getLocaleDirection } from "@/i18n/config";
 import "../globals.css";
 import { AuthProvider } from "@/components/auth-provider";
 import { GleapWidget } from "@/components/gleap-widget";
+import { GoogleAnalytics } from "@/components/google-analytics";
 import { GoogleTagManager } from "@/components/google-tag-manager";
 import { NearInitializer } from "@/components/near-initializer";
 import { QueryProvider } from "@/components/query-provider";
@@ -93,6 +94,7 @@ export default async function RootLayout({
                                 </AuthProvider>
                             </WarningsProvider>
                             <Toaster />
+                            <GoogleAnalytics />
                             <GoogleTagManager />
                         </QueryProvider>
                         <GleapWidget />

--- a/nt-fe/components/google-analytics.tsx
+++ b/nt-fe/components/google-analytics.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import Script from "next/script";
+import { Suspense, useEffect } from "react";
+
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+declare global {
+    interface Window {
+        dataLayer?: Record<string, unknown>[];
+        gtag?: (...args: unknown[]) => void;
+    }
+}
+
+function GoogleAnalyticsPageTracker() {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const query = searchParams.toString();
+
+    useEffect(() => {
+        if (!GA_MEASUREMENT_ID) return;
+
+        const pagePath = query ? `${pathname}?${query}` : pathname;
+        window.gtag?.("event", "page_view", {
+            page_path: pagePath,
+            send_to: GA_MEASUREMENT_ID,
+        });
+    }, [pathname, query]);
+
+    return null;
+}
+
+export function GoogleAnalytics() {
+    if (!GA_MEASUREMENT_ID) {
+        return null;
+    }
+
+    return (
+        <>
+            <Script
+                src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+                strategy="afterInteractive"
+            />
+            <Script id="google-analytics" strategy="afterInteractive">
+                {`
+                  window.dataLayer = window.dataLayer || [];
+                  function gtag(){dataLayer.push(arguments);}
+                  window.gtag = gtag;
+                  gtag('js', new Date());
+                  gtag('config', '${GA_MEASUREMENT_ID}', { send_page_view: false });
+                `}
+            </Script>
+            <Suspense fallback={null}>
+                <GoogleAnalyticsPageTracker />
+            </Suspense>
+        </>
+    );
+}

--- a/nt-fe/lib/analytics.ts
+++ b/nt-fe/lib/analytics.ts
@@ -6,10 +6,12 @@ type AnalyticsParamValue = string | number | boolean | null | undefined;
 type AnalyticsParams = Record<string, AnalyticsParamValue>;
 
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
 declare global {
     interface Window {
         dataLayer?: Record<string, unknown>[];
+        gtag?: (...args: unknown[]) => void;
     }
 }
 
@@ -23,7 +25,20 @@ function pushToDataLayer(eventName: string, params: AnalyticsParams = {}) {
     });
 }
 
+function sendToGoogleAnalytics(
+    eventName: string,
+    params: AnalyticsParams = {},
+) {
+    if (!GA_MEASUREMENT_ID || typeof window === "undefined") return;
+
+    window.gtag?.("event", eventName, {
+        send_to: GA_MEASUREMENT_ID,
+        ...params,
+    });
+}
+
 export function trackEvent(eventName: string, params: AnalyticsParams = {}) {
     posthog.capture(eventName, params);
     pushToDataLayer(eventName, params);
+    sendToGoogleAnalytics(eventName, params);
 }


### PR DESCRIPTION
[#1104](https://github.com/NEAR-DevHub/trezu/pull/1104) replaced Google Analytics with Google Tag Manager, which dropped direct GA4 tracking. This restores GA so **both GA and GTM run together**.

## Changes
- **Restore `components/google-analytics.tsx`** — the `gtag` loader + a `page_view` on each route change (`send_page_view: false`, tracked manually). Rendered next to `<GoogleTagManager />` in both `(init)` and `(treasury)` layouts.
- **`lib/analytics.ts`** — `trackEvent()` now fans out to **PostHog + GTM (`dataLayer`) + GA (`gtag`)**.
- **`NEXT_PUBLIC_GA_MEASUREMENT_ID`** re-added to `.env.example`; `NEXT_PUBLIC_GTM_ID` kept.
- Docs: `README`, `docs/ANALYTICS_EVENTS.md`.

## Coexistence
GA and GTM share a single `window.dataLayer` — the standard Google setup. The `dataLayer` global type is kept identical (`Record<string, unknown>[]`) across all three files so the TS global-augmentation merges cleanly; `gtag` is declared where used. GA's script initializes `dataLayer`/`gtag`, GTM's snippet reuses the same array. Each is independently gated on its env var, so partial configuration is safe.

No CSP in the app to update (GTM script host `www.googletagmanager.com` is shared; no host allowlist blocks GA hits).

biome format clean; typecheck via CI `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)