### PR TITLE
style: set primary color to #1E4575

### DIFF
--- a/nt-fe/app/globals.css
+++ b/nt-fe/app/globals.css
@@ -11,7 +11,7 @@
     --card-foreground: rgb(25, 25, 26);
     --popover: rgb(255, 255, 255);
     --popover-foreground: rgb(25, 25, 26);
-    --primary: rgb(25, 25, 26);
+    --primary: rgb(30, 69, 117);
     --primary-foreground: rgb(250, 250, 250);
     --secondary: rgb(245, 245, 245);
     --secondary-foreground: rgb(10, 10, 10);
@@ -99,8 +99,8 @@
     --card-foreground: rgb(250, 250, 250);
     --popover: rgb(38, 38, 38);
     --popover-foreground: rgb(250, 250, 250);
-    --primary: rgb(229, 229, 229);
-    --primary-foreground: rgb(25, 25, 26);
+    --primary: rgb(30, 69, 117);
+    --primary-foreground: rgb(250, 250, 250);
     --secondary: rgb(38, 38, 38);
     --secondary-foreground: rgb(250, 250, 250);
     --muted: rgb(38, 38, 38);


### PR DESCRIPTION
## What

Change the `--primary` color token to **#1E4575** in both light and dark themes.

- Light `--primary`: `rgb(25,25,26)` → `rgb(30,69,117)`
- Dark `--primary`: `rgb(229,229,229)` → `rgb(30,69,117)`
- Dark `--primary-foreground`: `rgb(25,25,26)` → `rgb(250,250,250)` (white text for contrast on the blue)

Affects all `bg-primary` elements (primary buttons, etc.).

## Verification

Confirmed live via browser on the running dev server:
- Root `--primary` resolves to `#1e4575` in both themes
- A `bg-primary` element computes `rgb(30, 69, 117)` background with `rgb(250, 250, 250)` white text

🤖 Generated with [Claude Code](https://claude.com/claude-code)