### PR TITLE
Fix/token defaults and bulk payment ux

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -41,10 +41,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageCard } from "@/components/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/underline-tabs";
 import {
+    DEFAULT_ASSETS_QUERY,
     type AggregatedAsset,
     useAggregatedTokens,
     useAssets,
 } from "@/hooks/use-assets";
+import { pickDefaultDepositAsset } from "@/lib/pick-default-token";
 import { usePopularAssetsByActivity } from "@/hooks/use-treasury-queries";
 import { type BridgeNetwork, useBridgeTokens } from "@/hooks/use-bridge-tokens";
 import { useTreasury } from "@/hooks/use-treasury";
@@ -348,10 +350,7 @@ export function DepositModal({
     const {
         data: { tokens: treasuryAssets } = { tokens: STABLE_EMPTY_ARRAY },
         isPending: isAssetsPending,
-    } = useAssets(treasuryId, {
-        onlyPositiveBalance: false,
-        onlySupportedTokens: true,
-    });
+    } = useAssets(treasuryId, DEFAULT_ASSETS_QUERY);
     const aggregatedTreasuryTokens = useAggregatedTokens(treasuryAssets);
     // Prevent old async responses from updating state.
     const latestAddressRequestRef = useRef(0);
@@ -740,11 +739,10 @@ export function DepositModal({
             NetworkBalanceDisplay
         >();
 
-        // Auto-select asset:
+        // Auto-select asset only (network stays empty unless URL prefill):
         // 1) explicit prefill token/network
         // 2) highest-USD owned asset (yourAssets is USD-sorted)
-        // 3) USDC (NEAR network preferred below)
-        // 4) first available
+        // 3) USDC, else first available
         let targetAsset: SelectOption | undefined;
         let networkFromTokenPrefill: SelectOption | null = null;
         if (prefillTokenId) {
@@ -804,12 +802,7 @@ export function DepositModal({
         // Wait for treasury assets so we don't flash USDC then swap to the
         // highest-USD owned holding when the cache/fetch lands.
         if (!targetAsset && !isAssetsPending) {
-            targetAsset =
-                yourAssets[0] ||
-                formattedAssets.find(
-                    (asset) => asset.id?.toLowerCase() === "usdc",
-                ) ||
-                formattedAssets[0];
+            targetAsset = pickDefaultDepositAsset(yourAssets, formattedAssets);
         }
 
         if (targetAsset) {
@@ -829,6 +822,9 @@ export function DepositModal({
             nextSelectedNetworkBalances =
                 networkBalancesByAssetId.get(targetAsset.id) || new Map();
 
+            // Network is never inferred from balances / USDC / single-option.
+            // Only apply an explicit URL prefill; otherwise leave empty so the
+            // user picks. Don't clear a network the user already chose.
             let networkToSelect: SelectOption | null = networkFromTokenPrefill;
 
             if (prefillNetworkId) {
@@ -846,43 +842,6 @@ export function DepositModal({
                 if (prefillNetwork) networkToSelect = prefillNetwork;
             }
 
-            // Prefer the owned network with the highest USD balance for this asset.
-            if (!networkToSelect && !isNetworkSelectionRestricted) {
-                const balances =
-                    networkBalancesByAssetId.get(targetAsset.id) || new Map();
-                let bestUsd = -1;
-                for (const network of availableNetworks) {
-                    const usd = balances.get(network.id)?.amountUSD ?? 0;
-                    if (usd > bestUsd) {
-                        bestUsd = usd;
-                        networkToSelect = network;
-                    }
-                }
-                if (bestUsd <= 0) {
-                    networkToSelect = null;
-                }
-            }
-
-            // No owned balance — fall back to USDC on NEAR when that asset is selected.
-            if (
-                !networkToSelect &&
-                !isNetworkSelectionRestricted &&
-                targetAsset.id?.toLowerCase() === "usdc"
-            ) {
-                networkToSelect =
-                    availableNetworks.find(
-                        (n) => n.name.toLowerCase() === NEAR_NETWORK_ID,
-                    ) ?? null;
-            }
-
-            if (
-                !networkToSelect &&
-                availableNetworks.length === 1 &&
-                !isNetworkSelectionRestricted
-            ) {
-                networkToSelect = availableNetworks[0];
-            }
-
             // Guests (and logged-out users) on confidential treasuries may not
             // select or restore any network.
             if (isNetworkSelectionRestricted) {
@@ -890,9 +849,15 @@ export function DepositModal({
             }
 
             const currentNetwork = form.getValues("network");
-            const nextNetworkId = networkToSelect?.id ?? null;
-            if ((currentNetwork?.id ?? null) !== nextNetworkId) {
-                form.setValue("network", networkToSelect);
+            if (isNetworkSelectionRestricted) {
+                if (currentNetwork) form.setValue("network", null);
+            } else if (networkToSelect) {
+                if (currentNetwork?.id !== networkToSelect.id) {
+                    form.setValue("network", networkToSelect);
+                }
+            } else if (currentAsset?.id !== targetAsset.id) {
+                // Default asset just changed — clear any prior network.
+                if (currentNetwork) form.setValue("network", null);
             }
         }
 
@@ -944,24 +909,14 @@ export function DepositModal({
                 },
             });
 
-            // Auto-select network only when there is exactly one option and the
-            // user is actually allowed to select a network (guests on confidential
-            // treasuries have network selection disabled).
-            if (
-                availableNetworks.length === 1 &&
-                !isNetworkSelectionRestricted
-            ) {
-                form.setValue("network", availableNetworks[0]);
-            } else {
-                form.setValue("network", null);
-            }
+            // Always leave network for the user to pick (including single-option).
+            form.setValue("network", null);
         },
         [
             form,
             assetNetworksMap,
             networkBalancesByAsset,
             invalidatePendingAddressRequest,
-            isNetworkSelectionRestricted,
         ],
     );
 

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -909,14 +909,24 @@ export function DepositModal({
                 },
             });
 
-            // Always leave network for the user to pick (including single-option).
-            form.setValue("network", null);
+            // Auto-select network only when there is exactly one option and the
+            // user is actually allowed to select a network (guests on confidential
+            // treasuries have network selection disabled).
+            if (
+                availableNetworks.length === 1 &&
+                !isNetworkSelectionRestricted
+            ) {
+                form.setValue("network", availableNetworks[0]);
+            } else {
+                form.setValue("network", null);
+            }
         },
         [
             form,
             assetNetworksMap,
             networkBalancesByAsset,
             invalidatePendingAddressRequest,
+            isNetworkSelectionRestricted,
         ],
     );
 

--- a/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/dashboard/components/deposit-modal.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/constants/network-ids";
 import { NEAR_CHAIN_ICONS } from "@/constants/token";
 import { Form, FormField, FormItem, FormMessage } from "@/components/ui/form";
+import { Skeleton } from "@/components/ui/skeleton";
 import { PageCard } from "@/components/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/underline-tabs";
 import {
@@ -346,6 +347,7 @@ export function DepositModal({
     const searchParams = useSearchParams();
     const {
         data: { tokens: treasuryAssets } = { tokens: STABLE_EMPTY_ARRAY },
+        isPending: isAssetsPending,
     } = useAssets(treasuryId, {
         onlyPositiveBalance: false,
         onlySupportedTokens: true,
@@ -739,8 +741,10 @@ export function DepositModal({
         >();
 
         // Auto-select asset:
-        // 1) explicit prefill token, 2) owned USDC, 3) first token in "Your Assets",
-        // 4) any USDC option, 5) first available
+        // 1) explicit prefill token/network
+        // 2) highest-USD owned asset (yourAssets is USD-sorted)
+        // 3) USDC (NEAR network preferred below)
+        // 4) first available
         let targetAsset: SelectOption | undefined;
         let networkFromTokenPrefill: SelectOption | null = null;
         if (prefillTokenId) {
@@ -797,11 +801,10 @@ export function DepositModal({
                 }
             }
         }
-        if (!targetAsset) {
+        // Wait for treasury assets so we don't flash USDC then swap to the
+        // highest-USD owned holding when the cache/fetch lands.
+        if (!targetAsset && !isAssetsPending) {
             targetAsset =
-                yourAssets.find(
-                    (asset) => asset.id?.toLowerCase() === "usdc",
-                ) ||
                 yourAssets[0] ||
                 formattedAssets.find(
                     (asset) => asset.id?.toLowerCase() === "usdc",
@@ -843,6 +846,35 @@ export function DepositModal({
                 if (prefillNetwork) networkToSelect = prefillNetwork;
             }
 
+            // Prefer the owned network with the highest USD balance for this asset.
+            if (!networkToSelect && !isNetworkSelectionRestricted) {
+                const balances =
+                    networkBalancesByAssetId.get(targetAsset.id) || new Map();
+                let bestUsd = -1;
+                for (const network of availableNetworks) {
+                    const usd = balances.get(network.id)?.amountUSD ?? 0;
+                    if (usd > bestUsd) {
+                        bestUsd = usd;
+                        networkToSelect = network;
+                    }
+                }
+                if (bestUsd <= 0) {
+                    networkToSelect = null;
+                }
+            }
+
+            // No owned balance — fall back to USDC on NEAR when that asset is selected.
+            if (
+                !networkToSelect &&
+                !isNetworkSelectionRestricted &&
+                targetAsset.id?.toLowerCase() === "usdc"
+            ) {
+                networkToSelect =
+                    availableNetworks.find(
+                        (n) => n.name.toLowerCase() === NEAR_NETWORK_ID,
+                    ) ?? null;
+            }
+
             if (
                 !networkToSelect &&
                 availableNetworks.length === 1 &&
@@ -880,6 +912,7 @@ export function DepositModal({
     }, [
         bridgeAssets,
         aggregatedTreasuryTokens,
+        isAssetsPending,
         prefillTokenId,
         prefillNetworkId,
         popularAssets,
@@ -1232,12 +1265,22 @@ export function DepositModal({
                                         type="button"
                                         onClick={() => setModalType("asset")}
                                         variant="unstyled"
-                                        disabled={depositSelectorsDisabled}
+                                        disabled={
+                                            depositSelectorsDisabled ||
+                                            (isAssetsPending && !selectedAsset)
+                                        }
                                         data-testid="deposit-asset-selector"
                                         className="w-full text-left cursor-pointer hover:opacity-80 h-auto justify-start p-0! mt-1"
                                     >
                                         <div className="w-full flex items-center justify-between py-1">
-                                            {selectedAsset ? (
+                                            {isAssetsPending &&
+                                            !selectedAsset ? (
+                                                // Same footprint as OptionIcon (size-6) + asset name.
+                                                <div className="flex items-center gap-2">
+                                                    <Skeleton className="size-6 rounded-full shrink-0" />
+                                                    <Skeleton className="h-5 w-24" />
+                                                </div>
+                                            ) : selectedAsset ? (
                                                 <div className="flex items-center gap-2">
                                                     <OptionIcon
                                                         icon={

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/components/step1.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/components/step1.tsx
@@ -235,6 +235,7 @@ export function Step1({
                         }
                         tokenSelect={{
                             filterTokens: filterSellTokens,
+                            autoSelect: false,
                         }}
                         usdValueOverride={
                             quoteData?.quote
@@ -280,6 +281,7 @@ export function Step1({
                     tokenSelect={{
                         filterTokens: filterReceiveTokens,
                         showPopularAssets: true,
+                        autoSelect: false,
                     }}
                     usdValueOverride={
                         quoteData?.quote

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/review-payments-step.tsx
@@ -380,8 +380,14 @@ export function ReviewPaymentsStep({
                                     index,
                                     payment.amount,
                                 );
-                                // Calculate estimated USD value from the
-                                // amount shown (net amountOut once quoted).
+                                // Total includes fee when present (matches the
+                                // info-tooltip breakdown); USD stays on the
+                                // net recipient amount.
+                                const rowTotalAmount = recipientFee
+                                    ? Big(displayAmount || "0").add(
+                                          recipientFee,
+                                      )
+                                    : Big(displayAmount || "0");
                                 let estimatedUSDValue = 0;
                                 if (selectedTokenData?.price && balance) {
                                     try {
@@ -476,14 +482,40 @@ export function ReviewPaymentsStep({
                                                             iconSize="md"
                                                         />
                                                         <div className="flex flex-col gap-[3px] items-end">
-                                                            <p className="text-sm font-semibold whitespace-nowrap leading-5">
-                                                                {formatTokenDisplayAmount(
-                                                                    displayAmount,
-                                                                )}{" "}
-                                                                {
-                                                                    selectedToken.symbol
-                                                                }
-                                                            </p>
+                                                            <div className="flex items-center gap-1">
+                                                                <p className="text-sm font-semibold whitespace-nowrap leading-5">
+                                                                    {formatTokenDisplayAmount(
+                                                                        rowTotalAmount,
+                                                                    )}{" "}
+                                                                    {
+                                                                        selectedToken.symbol
+                                                                    }
+                                                                </p>
+                                                                {recipientFee && (
+                                                                    <Tooltip
+                                                                        content={
+                                                                            <div className="text-left">
+                                                                                <p>
+                                                                                    {`${formatTokenDisplayAmount(displayAmount)} ${selectedToken.symbol} + ${formatTokenDisplayAmount(recipientFee)}${selectedToken.symbol}`}
+                                                                                </p>
+                                                                                <p className="lowercase">
+                                                                                    {tPay(
+                                                                                        "networkFee",
+                                                                                    )}
+                                                                                </p>
+                                                                            </div>
+                                                                        }
+                                                                        side="right"
+                                                                    >
+                                                                        <Info
+                                                                            className="size-3.5 shrink-0 text-muted-foreground"
+                                                                            aria-label={tPay(
+                                                                                "networkFeeInfo",
+                                                                            )}
+                                                                        />
+                                                                    </Tooltip>
+                                                                )}
+                                                            </div>
                                                             <p className="text-xs text-muted-foreground whitespace-nowrap">
                                                                 ≈ $
                                                                 {estimatedUSDValue.toFixed(
@@ -500,27 +532,6 @@ export function ReviewPaymentsStep({
                                                             payment.validationError
                                                         }
                                                     </div>
-                                                )}
-
-                                                {confidentialPrepare?.status ===
-                                                "loading" ? (
-                                                    <div className="flex items-center justify-end gap-1 text-xs text-muted-foreground">
-                                                        {tPay("networkFee")}:
-                                                        <span className="inline-block h-4 w-16 bg-muted animate-pulse rounded" />
-                                                    </div>
-                                                ) : (
-                                                    recipientFee && (
-                                                        <div className="text-xs text-muted-foreground text-right">
-                                                            {tPay("networkFee")}
-                                                            :{" "}
-                                                            {formatTokenDisplayAmount(
-                                                                recipientFee,
-                                                            )}{" "}
-                                                            {
-                                                                selectedToken.symbol
-                                                            }
-                                                        </div>
-                                                    )
                                                 )}
 
                                                 <div className="flex items-center gap-3 justify-end">

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/upload-data-step.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/components/upload-data-step.tsx
@@ -223,9 +223,8 @@ export function UploadDataStep({
         }
 
         // Confidential bulk requires a picked recipient network — its raw name
-        // drives address validation for ALL recipients. RecipientNetworkSelect
-        // auto-picks when only one option matches the first address, but the
-        // user may have wiped the selection (no compatible network) — block here.
+        // drives address validation for ALL recipients. The picker is gated on
+        // having payment data; block Continue if they haven't chosen one yet.
         if (isConfidential && !destinationNetwork) {
             setNetworkError(t("selectRecipientNetwork"));
             return;

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/bulk-payment/page.tsx
@@ -78,17 +78,18 @@ export default function BulkPaymentPage() {
         useBridgeTokens(true);
 
     const [step, setStep] = useState(0);
+    // Empty until the user adds a recipient address and picks a network —
+    // RecipientNetworkSelect stays disabled until firstRecipient is set.
     const [destinationNetworkId, setDestinationNetworkId] =
-        useState<string>(NEAR_COM_NETWORK_ID);
+        useState<string>("");
     const [destinationAssetId, setDestinationAssetId] = useState<string | null>(
         null,
     );
     // Raw bridge network name ("near", "eth", "sol", ...). Drives address
     // validation for ALL recipients regardless of which one filtered the
-    // network picker. Empty string when no network is selected (e.g. address
-    // has no compatible network).
+    // network picker. Empty string when no network is selected.
     const [destinationNetworkName, setDestinationNetworkName] =
-        useState<string>("near");
+        useState<string>("");
 
     const form = useForm<BulkPaymentFormValues>({
         resolver: zodResolver(bulkPaymentFormSchema),
@@ -682,9 +683,9 @@ export default function BulkPaymentPage() {
                                             >[0]["token"]
                                         }
                                         recipient={firstRecipient}
-                                        // Pick receive network independently —
-                                        // CSV validation enforces address type.
-                                        requireRecipient={false}
+                                        // Disabled until payment data includes
+                                        // a recipient; then filters by address
+                                        // compatibility of the first row.
                                         sectionRules={networkSectionRules}
                                         bridgeAssets={bridgeAssets}
                                         isBridgeAssetsLoading={

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
@@ -83,6 +83,11 @@ interface PaymentFormSectionProps<
     recipientNetworkWarningMessage?: string | null;
     /** True when payments are blocked by a critical warning (not warning/info). */
     slotBlocked?: boolean;
+    /**
+     * When true (default), TokenSelect picks highest-USD owned → USDC NEAR.
+     * Set false when the page seeds from ?token= / ?networks=.
+     */
+    tokenAutoSelect?: boolean;
 }
 
 export function PaymentFormSection<
@@ -112,6 +117,7 @@ export function PaymentFormSection<
     sendWarningMessage,
     recipientNetworkWarningMessage,
     slotBlocked = false,
+    tokenAutoSelect = true,
 }: PaymentFormSectionProps<TFieldValues, TTokenPath>) {
     const t = useTranslations("paymentFormSection");
     const tRecipientNetwork = useTranslations("recipientNetworkSelect");
@@ -348,9 +354,7 @@ export function PaymentFormSection<
                     locked: tokenLocked,
                     disabled: tokenLocked,
                     showOnlyOwnedAssets: false,
-                    // Page owns default (highest-USD owned → USDC NEAR) and
-                    // ?token= / ?networks= overrides — don't fight it here.
-                    autoSelect: false,
+                    autoSelect: tokenAutoSelect,
                 }}
                 warningMessage={sendWarningMessage}
                 showInsufficientBalance={

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
@@ -348,6 +348,9 @@ export function PaymentFormSection<
                     locked: tokenLocked,
                     disabled: tokenLocked,
                     showOnlyOwnedAssets: false,
+                    // Page owns default (highest-USD owned → USDC NEAR) and
+                    // ?token= / ?networks= overrides — don't fight it here.
+                    autoSelect: false,
                 }}
                 warningMessage={sendWarningMessage}
                 showInsufficientBalance={

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/payment-form-section.tsx
@@ -41,7 +41,7 @@ interface PaymentFormSectionProps<
     control: Control<TFieldValues>;
     amountName: Path<TFieldValues>;
     tokenName: TTokenPath extends Path<TFieldValues>
-        ? PathValue<TFieldValues, TTokenPath> extends Token
+        ? NonNullable<PathValue<TFieldValues, TTokenPath>> extends Token
             ? TTokenPath
             : never
         : never;

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/components/recipient-network-select.tsx
@@ -57,10 +57,9 @@ interface RecipientNetworkSelectProps {
     /** Error text shown under the network card. */
     errorMessage?: string | null;
     /**
-     * When false (confidential bulk), the picker is available before any
-     * recipient address is entered and does not filter/clear by address
-     * compatibility — all recipients share one chosen receive network.
-     * Default true (single-payment flow).
+     * When true (default), the picker stays disabled until a recipient
+     * address is entered and filters/clears by address compatibility.
+     * When false, every option is available immediately (no address gate).
      */
     requireRecipient?: boolean;
 }
@@ -217,8 +216,6 @@ export function RecipientNetworkSelect({
     const enrichedOptions = useMemo(() => {
         return availableOptions.map((option) => ({
             ...option,
-            // Bulk confidential picks the receive network first; every option
-            // is available and CSV validation enforces the address type later.
             isCompatible: requireRecipient
                 ? isAddressCompatibleWithNetwork(recipient, option.networkName)
                 : true,
@@ -254,17 +251,21 @@ export function RecipientNetworkSelect({
         ? !recipient || isBridgeAssetsLoading || !hasCompatibleNetwork
         : isBridgeAssetsLoading || availableOptions.length === 0;
 
-    // Clear the selection when the address no longer matches it (e.g. user
-    // edited the address into a different chain's format). Skip in bulk mode
-    // where the receive network is chosen independently of any single address.
+    // Clear selection when the address is removed or no longer matches the
+    // chosen network (e.g. user edited into a different chain's format).
     useEffect(() => {
         if (!requireRecipient) return;
         if (!value) return;
+        if (!recipient) {
+            onChange("");
+            return;
+        }
         if (availableOptions.length === 0) return;
         if (compatibleOptions.some((o) => o.id === value)) return;
         onChange("");
     }, [
         value,
+        recipient,
         availableOptions,
         compatibleOptions,
         onChange,

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -28,7 +28,6 @@ import { Textarea } from "@/components/textarea";
 import { Tooltip } from "@/components/tooltip";
 import { type Token, tokenSchema } from "@/components/token-input";
 import { Form, FormField } from "@/components/ui/form";
-import { default_near_token } from "@/constants/token";
 import { useAddressBook } from "@/features/address-book";
 import { useMergedTokens } from "@/hooks/use-merged-tokens";
 import { pickDefaultSelectedToken } from "@/lib/pick-default-token";
@@ -93,6 +92,7 @@ function buildPaymentFormSchema(messages: {
     recipientMax: string;
     amountGreaterThanZero: string;
     recipientSameAsToken: string;
+    selectToken: string;
 }) {
     return z
         .object({
@@ -108,9 +108,18 @@ function buildPaymentFormSchema(messages: {
                     message: messages.amountGreaterThanZero,
                 }),
             memo: z.string().optional(),
-            token: tokenSchema,
+            // Null while assets load before seeding the default token.
+            token: tokenSchema.nullable(),
         })
         .superRefine((data, ctx) => {
+            if (!data.token) {
+                ctx.addIssue({
+                    code: "custom",
+                    path: ["token"],
+                    message: messages.selectToken,
+                });
+                return;
+            }
             if (data.address === data.token.address) {
                 ctx.addIssue({
                     code: "custom",
@@ -285,7 +294,7 @@ function Step2({
         control: form.control,
         name: ["token", "amount", "address", "destinationNetwork"],
     }) as [PaymentFormValues["token"], string, string, string];
-    const { data: tokenData } = useToken(token.address);
+    const { data: tokenData } = useToken(token?.address);
     // Chain icons for the destination network (for the review token icon overlay)
     const destinationChainIcons = useMemo(() => {
         if (!destinationNetwork) {
@@ -314,6 +323,16 @@ function Step2({
         estimatedUSDValue,
         recipientEstimatedUSDValue,
     } = useMemo(() => {
+        if (!token) {
+            return {
+                totalAmountWithFees: Big(0),
+                recipientAmount: Big(0),
+                displayNetworkFee: Big(0),
+                estimatedUSDValue: Big(0),
+                recipientEstimatedUSDValue: Big(0),
+            };
+        }
+
         const enteredAmount = Big(amount || "0");
         const price = tokenData?.price ?? 0;
 
@@ -358,10 +377,12 @@ function Step2({
                 ? enteredAmount.mul(price)
                 : Big(0),
         };
-    }, [amount, liveQuote, token.decimals, tokenData?.price]);
+    }, [amount, liveQuote, token, tokenData?.price]);
 
     const isQuoteLoading =
         isViaIntents && (isLoadingLiveQuote || isFetchingLiveQuote);
+
+    if (!token) return null;
 
     return (
         <PageCard>
@@ -669,6 +690,7 @@ export default function PaymentsPage() {
                 recipientMax: tValidation("recipientMax"),
                 amountGreaterThanZero: tValidation("amountGreaterThanZero"),
                 recipientSameAsToken: tValidation("recipientSameAsToken"),
+                selectToken: tValidation("selectToken"),
             }),
         [tValidation],
     );
@@ -717,7 +739,7 @@ export default function PaymentsPage() {
         if (tokenParam) {
             return parseTokenQueryParam(
                 tokenParam,
-                pickDefaultSelectedToken(mergedTokens, { isConfidential }),
+                pickDefaultSelectedToken(mergedTokens),
             );
         }
         // Wait for assets (and bridge when ?networks= is present) so the first
@@ -726,14 +748,12 @@ export default function PaymentsPage() {
         if (preferredNetworks.length > 0) {
             if (isBridgeAssetsLoading) return null;
             return (
-                compatibleDefaultToken ??
-                pickDefaultSelectedToken(mergedTokens, { isConfidential })
+                compatibleDefaultToken ?? pickDefaultSelectedToken(mergedTokens)
             );
         }
-        return pickDefaultSelectedToken(mergedTokens, { isConfidential });
+        return pickDefaultSelectedToken(mergedTokens);
     }, [
         tokenParam,
-        isConfidential,
         mergedTokens,
         isAssetsReady,
         preferredNetworks.length,
@@ -775,7 +795,7 @@ export default function PaymentsPage() {
             amount: "",
             memo: "",
             // Null until assets resolve — avoids USDC→owned flash.
-            token: defaultToken as PaymentFormValues["token"],
+            token: defaultToken,
             destinationNetwork: "",
             destinationNetworkName: "",
         },
@@ -819,12 +839,16 @@ export default function PaymentsPage() {
         : null;
 
     const watchedTokenClassification = useMemo(
-        () => classifyPaymentToken(watchedToken, watchedDestinationNetwork),
+        () =>
+            watchedToken
+                ? classifyPaymentToken(watchedToken, watchedDestinationNetwork)
+                : null,
         [watchedToken, watchedDestinationNetwork],
     );
     const isWatchedNearNativeToken =
-        watchedTokenClassification.isNearNativeToken;
-    const isWatchedNearFtToken = watchedTokenClassification.isNearFtToken;
+        watchedTokenClassification?.isNearNativeToken ?? false;
+    const isWatchedNearFtToken =
+        watchedTokenClassification?.isNearFtToken ?? false;
 
     const normalizedWatchedAddress = watchedAddress.trim().toLowerCase();
     const isWatchedEthImplicit = isEthImplicitNearAddress(
@@ -833,7 +857,8 @@ export default function PaymentsPage() {
     const isWatchedNearRecipient =
         isValidNearAddressFormat(normalizedWatchedAddress) &&
         !isWatchedEthImplicit;
-    const isWatchedNearComRoute = watchedTokenClassification.isNearComRoute;
+    const isWatchedNearComRoute =
+        watchedTokenClassification?.isNearComRoute ?? false;
 
     // True when we'll send via a direct Transfer (not through Intents).
     const isWatchedDirectTransfer =
@@ -844,7 +869,9 @@ export default function PaymentsPage() {
 
     // Token object to use for the 1Click quote. For native NEAR and NEAR FT we
     // swap in the nep141: prefix so the hook enables and shows a fee preview.
-    const quoteToken = useMemo((): Token => {
+    // Null while assets load (before default token is seeded).
+    const quoteToken = useMemo((): Token | null => {
+        if (!watchedToken || !watchedTokenClassification) return null;
         if (isConfidential || isWatchedDirectTransfer) return watchedToken;
         return watchedTokenClassification.tokenForIntentsQuote;
     }, [
@@ -855,17 +882,17 @@ export default function PaymentsPage() {
     ]);
 
     // Whether this payment will go through the Intents protocol.
-    const isViaIntents = isIntentsToken(quoteToken);
+    const isViaIntents = !!quoteToken && isIntentsToken(quoteToken);
     const quoteContextKey = useMemo(
         () =>
             buildQuoteContextKey({
-                tokenAddress: quoteToken.address,
+                tokenAddress: quoteToken?.address ?? "",
                 amount: watchedAmount ?? "",
                 address: watchedAddress ?? "",
                 destinationNetwork: watchedDestinationNetwork,
             }),
         [
-            quoteToken.address,
+            quoteToken?.address,
             watchedAmount,
             watchedAddress,
             watchedDestinationNetwork,
@@ -874,11 +901,13 @@ export default function PaymentsPage() {
 
     const destinationAmountDecimals = useMemo(
         () =>
-            getDestinationAmountDecimals(
-                quoteToken,
-                watchedDestinationNetwork,
-                bridgeAssets,
-            ),
+            quoteToken
+                ? getDestinationAmountDecimals(
+                      quoteToken,
+                      watchedDestinationNetwork,
+                      bridgeAssets,
+                  )
+                : undefined,
         [bridgeAssets, quoteToken, watchedDestinationNetwork],
     );
 
@@ -905,8 +934,8 @@ export default function PaymentsPage() {
         destinationNetwork: watchedDestinationNetwork,
         isPayment: true,
         // Paused payment (critical warning on token/network or app-wide): don't
-        // fetch the quote.
-        enabled: !paymentsSlotBlocked,
+        // fetch the quote. Also wait until the default token is ready.
+        enabled: !paymentsSlotBlocked && !!quoteToken,
     });
 
     const paymentNetworkFee = useMemo(() => {
@@ -927,7 +956,7 @@ export default function PaymentsPage() {
     useEffect(() => {
         cachedQuoteRef.current = null;
     }, [
-        watchedToken.address,
+        watchedToken?.address,
         watchedAmount,
         watchedAddress,
         watchedDestinationNetwork,
@@ -942,7 +971,7 @@ export default function PaymentsPage() {
         form.clearErrors("amount");
     }, [
         form,
-        watchedToken.address,
+        watchedToken?.address,
         watchedAmount,
         watchedAddress,
         watchedDestinationNetwork,
@@ -983,6 +1012,8 @@ export default function PaymentsPage() {
     // ── Ensure quote is fresh before entering the review step ─────────────────
 
     const ensureQuoteBeforeReview = useCallback(async (): Promise<boolean> => {
+        if (!quoteToken) return false;
+
         const formValues = form.getValues();
         const ensureRequestKey = buildQuoteContextKey({
             tokenAddress: quoteToken.address,
@@ -1069,15 +1100,17 @@ export default function PaymentsPage() {
             if (sendScopeMessage) toast.error(sendScopeMessage);
             return;
         }
+        const token = data.token;
+        if (!token) return;
 
         try {
             const proposalBond = policy?.proposal_bond || "0";
             const trimmedAddress = data.address.trim();
-            const normalizedNearAddress = trimmedAddress.toLowerCase();
             const tokenClassification = classifyPaymentToken(
-                data.token,
+                token,
                 data.destinationNetwork,
             );
+            const normalizedNearAddress = trimmedAddress.toLowerCase();
             const { isNearNativeToken, isNearFtToken, isNearComRoute } =
                 tokenClassification;
 
@@ -1095,11 +1128,11 @@ export default function PaymentsPage() {
                 (isNearNativeToken || isNearFtToken);
 
             const shouldUseIntents = isConfidential
-                ? isIntentsToken(data.token)
+                ? isIntentsToken(token)
                 : !shouldUseDirectTransfer;
 
             const directTransferAmount = Big(data.amount)
-                .mul(Big(10).pow(data.token.decimals))
+                .mul(Big(10).pow(token.decimals))
                 .toFixed();
 
             let description = encodeToMarkdown({ notes: data.memo || "" });
@@ -1178,9 +1211,9 @@ export default function PaymentsPage() {
                     description = buildIntentTransferDescription(data, quote);
                     const { depositAddress, amountIn } = quote.quote;
 
-                    if (isIntentsToken(data.token)) {
+                    if (isIntentsToken(token)) {
                         proposalKind = buildIntentsTransferProposal(
-                            data.token.address,
+                            token.address,
                             depositAddress,
                             amountIn,
                         );
@@ -1191,7 +1224,7 @@ export default function PaymentsPage() {
                         );
                     } else {
                         proposalKind = buildNearFtIntentsKind(
-                            data.token.address,
+                            token.address,
                             depositAddress,
                             amountIn,
                         );
@@ -1201,7 +1234,7 @@ export default function PaymentsPage() {
                 // Direct NEAR or NEAR FT transfer
                 proposalKind = buildDirectTransferKind(
                     trimmedAddress,
-                    data.token,
+                    token,
                     directTransferAmount,
                     isConfidential,
                 );
@@ -1220,7 +1253,7 @@ export default function PaymentsPage() {
                 .then(() => {
                     trackEvent("payment-submitted", {
                         treasury_id: treasuryId ?? "",
-                        token_symbol: data.token.symbol,
+                        token_symbol: token.symbol,
                         amount: data.amount,
                     });
                     form.reset();

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -30,6 +30,8 @@ import { type Token, tokenSchema } from "@/components/token-input";
 import { Form, FormField } from "@/components/ui/form";
 import { default_near_token } from "@/constants/token";
 import { useAddressBook } from "@/features/address-book";
+import { useMergedTokens } from "@/hooks/use-merged-tokens";
+import { pickDefaultSelectedToken } from "@/lib/pick-default-token";
 import {
     PAGE_TOUR_NAMES,
     PAGE_TOUR_STORAGE_KEYS,
@@ -676,7 +678,6 @@ export default function PaymentsPage() {
     const { data: policy } = useTreasuryPolicy(treasuryId);
     const [step, setStep] = useState(0);
     const searchParams = useSearchParams();
-    const autoSelectedTokenKeyRef = useRef<string | null>(null);
     // Cached quote + context key — avoids re-fetching while preventing stale reuse.
     const cachedQuoteRef = useRef<CachedQuote | null>(null);
     const [isAddressBookRecipientSelected, setIsAddressBookRecipientSelected] =
@@ -691,20 +692,18 @@ export default function PaymentsPage() {
                 .filter(Boolean),
         [searchParams],
     );
-    const autoSelectionKey = useMemo(
-        () => preferredNetworks.join(","),
-        [preferredNetworks],
-    );
     const {
         data: bridgeAssets = [],
         isLoading: isBridgeAssetsLoading,
         isFetching: isBridgeAssetsFetching,
     } = useBridgeTokens(true);
-
-    const defaultToken = useMemo(() => {
-        const fallbackToken = default_near_token(isConfidential);
-        return parseTokenQueryParam(tokenParam, fallbackToken);
-    }, [tokenParam, isConfidential]);
+    // Owned holdings from the assets cache (dashboard etc.) drive the default
+    // token: highest USD network, else USDC on NEAR. Wait until assets are
+    // ready so we never flash USDC and then swap.
+    const { tokens: mergedTokens, isAssetsReady } = useMergedTokens({
+        enabled: true,
+        showOnlyOwned: false,
+    });
 
     const compatibleDefaultToken = useMemo(() => {
         if (tokenParam || preferredNetworks.length === 0) {
@@ -713,6 +712,34 @@ export default function PaymentsPage() {
 
         return pickCompatibleFallbackToken(preferredNetworks, bridgeAssets);
     }, [bridgeAssets, preferredNetworks, tokenParam]);
+
+    const defaultToken = useMemo(() => {
+        if (tokenParam) {
+            return parseTokenQueryParam(
+                tokenParam,
+                pickDefaultSelectedToken(mergedTokens, { isConfidential }),
+            );
+        }
+        // Wait for assets (and bridge when ?networks= is present) so the first
+        // painted token is the final one — no USDC→owned flash.
+        if (!isAssetsReady) return null;
+        if (preferredNetworks.length > 0) {
+            if (isBridgeAssetsLoading) return null;
+            return (
+                compatibleDefaultToken ??
+                pickDefaultSelectedToken(mergedTokens, { isConfidential })
+            );
+        }
+        return pickDefaultSelectedToken(mergedTokens, { isConfidential });
+    }, [
+        tokenParam,
+        isConfidential,
+        mergedTokens,
+        isAssetsReady,
+        preferredNetworks.length,
+        isBridgeAssetsLoading,
+        compatibleDefaultToken,
+    ]);
 
     const preferredBlockchainTypes = useMemo(() => {
         const set = new Set<string>();
@@ -747,7 +774,8 @@ export default function PaymentsPage() {
             address: "",
             amount: "",
             memo: "",
-            token: defaultToken,
+            // Null until assets resolve — avoids USDC→owned flash.
+            token: defaultToken as PaymentFormValues["token"],
             destinationNetwork: "",
             destinationNetworkName: "",
         },
@@ -993,8 +1021,19 @@ export default function PaymentsPage() {
     // ── Effects ───────────────────────────────────────────────────────────────
 
     useEffect(() => {
-        form.setValue("token", defaultToken);
-    }, [defaultToken, form]);
+        if (!defaultToken) return;
+
+        if (tokenParam) {
+            form.setValue("token", defaultToken);
+            return;
+        }
+
+        const currentToken = form.getValues("token");
+        // Only seed once assets are ready and the field is still empty.
+        if (!currentToken) {
+            form.setValue("token", defaultToken);
+        }
+    }, [defaultToken, form, tokenParam]);
 
     useEffect(() => {
         if (!compatibleDestination) return;
@@ -1022,28 +1061,6 @@ export default function PaymentsPage() {
             shouldValidate: true,
         });
     }, [defaultAddress, watchedDestinationNetwork, form]);
-
-    useEffect(() => {
-        if (!compatibleDefaultToken || tokenParam) {
-            return;
-        }
-
-        const currentToken = form.getValues("token");
-        const defaultNearToken = default_near_token(isConfidential);
-        const isStillDefaultNearToken =
-            currentToken?.address === defaultNearToken.address &&
-            currentToken?.network === defaultNearToken.network;
-
-        if (
-            !isStillDefaultNearToken ||
-            autoSelectedTokenKeyRef.current === autoSelectionKey
-        ) {
-            return;
-        }
-
-        form.setValue("token", compatibleDefaultToken);
-        autoSelectedTokenKeyRef.current = autoSelectionKey;
-    }, [autoSelectionKey, compatibleDefaultToken, form, tokenParam]);
 
     // ── Submit ────────────────────────────────────────────────────────────────
 

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -28,9 +28,8 @@ import { Textarea } from "@/components/textarea";
 import { Tooltip } from "@/components/tooltip";
 import { type Token, tokenSchema } from "@/components/token-input";
 import { Form, FormField } from "@/components/ui/form";
+import { default_usdc_near_token } from "@/constants/token";
 import { useAddressBook } from "@/features/address-book";
-import { useMergedTokens } from "@/hooks/use-merged-tokens";
-import { pickDefaultSelectedToken } from "@/lib/pick-default-token";
 import {
     PAGE_TOUR_NAMES,
     PAGE_TOUR_STORAGE_KEYS,
@@ -143,6 +142,8 @@ interface Step1Props extends StepProps {
     paymentsSlotBlocked?: boolean;
     sendWarningMessage?: string | null;
     recipientNetworkWarningMessage?: string | null;
+    /** False when the page seeds token from ?token= / ?networks=. */
+    tokenAutoSelect?: boolean;
 }
 
 function Step1({
@@ -159,6 +160,7 @@ function Step1({
     paymentsSlotBlocked = false,
     sendWarningMessage = null,
     recipientNetworkWarningMessage = null,
+    tokenAutoSelect = true,
 }: Step1Props) {
     const tPay = useTranslations("payments");
     const tCreate = useTranslations("createRequestButton");
@@ -265,6 +267,7 @@ function Step1({
                     recipientNetworkWarningMessage={
                         recipientNetworkWarningMessage
                     }
+                    tokenAutoSelect={tokenAutoSelect}
                 />
             </PageCard>
         </>
@@ -719,14 +722,8 @@ export default function PaymentsPage() {
         isLoading: isBridgeAssetsLoading,
         isFetching: isBridgeAssetsFetching,
     } = useBridgeTokens(true);
-    // Owned holdings from the assets cache (dashboard etc.) drive the default
-    // token: highest USD network, else USDC on NEAR. Wait until assets are
-    // ready so we never flash USDC and then swap.
-    const { tokens: mergedTokens, isAssetsReady } = useMergedTokens({
-        enabled: true,
-        showOnlyOwned: false,
-    });
-
+    // Generic default (highest-USD → USDC) lives in TokenSelect.autoSelect.
+    // Page only seeds from URL overrides so the two don't fight.
     const compatibleDefaultToken = useMemo(() => {
         if (tokenParam || preferredNetworks.length === 0) {
             return null;
@@ -735,31 +732,26 @@ export default function PaymentsPage() {
         return pickCompatibleFallbackToken(preferredNetworks, bridgeAssets);
     }, [bridgeAssets, preferredNetworks, tokenParam]);
 
-    const defaultToken = useMemo(() => {
+    const urlOverrideToken = useMemo(() => {
         if (tokenParam) {
-            return parseTokenQueryParam(
-                tokenParam,
-                pickDefaultSelectedToken(mergedTokens),
-            );
+            return parseTokenQueryParam(tokenParam, default_usdc_near_token());
         }
-        // Wait for assets (and bridge when ?networks= is present) so the first
-        // painted token is the final one — no USDC→owned flash.
-        if (!isAssetsReady) return null;
-        if (preferredNetworks.length > 0) {
-            if (isBridgeAssetsLoading) return null;
-            return (
-                compatibleDefaultToken ?? pickDefaultSelectedToken(mergedTokens)
-            );
-        }
-        return pickDefaultSelectedToken(mergedTokens);
+        if (preferredNetworks.length === 0) return null;
+        if (isBridgeAssetsLoading) return null;
+        return compatibleDefaultToken;
     }, [
         tokenParam,
-        mergedTokens,
-        isAssetsReady,
         preferredNetworks.length,
         isBridgeAssetsLoading,
         compatibleDefaultToken,
     ]);
+
+    // Let TokenSelect pick when there's no URL token and no compatible
+    // ?networks= match (or no networks param at all).
+    const tokenAutoSelect =
+        !tokenParam &&
+        (preferredNetworks.length === 0 ||
+            (!isBridgeAssetsLoading && !compatibleDefaultToken));
 
     const preferredBlockchainTypes = useMemo(() => {
         const set = new Set<string>();
@@ -794,8 +786,8 @@ export default function PaymentsPage() {
             address: "",
             amount: "",
             memo: "",
-            // Null until assets resolve — avoids USDC→owned flash.
-            token: defaultToken,
+            // Null until TokenSelect auto-selects or a URL override seeds.
+            token: null,
             destinationNetwork: "",
             destinationNetworkName: "",
         },
@@ -1051,20 +1043,18 @@ export default function PaymentsPage() {
 
     // ── Effects ───────────────────────────────────────────────────────────────
 
+    // Seed only URL overrides; TokenSelect.autoSelect handles the rest.
     useEffect(() => {
-        if (!defaultToken) return;
-
+        if (!urlOverrideToken) return;
         if (tokenParam) {
-            form.setValue("token", defaultToken);
+            form.setValue("token", urlOverrideToken);
             return;
         }
-
         const currentToken = form.getValues("token");
-        // Only seed once assets are ready and the field is still empty.
         if (!currentToken) {
-            form.setValue("token", defaultToken);
+            form.setValue("token", urlOverrideToken);
         }
-    }, [defaultToken, form, tokenParam]);
+    }, [urlOverrideToken, form, tokenParam]);
 
     useEffect(() => {
         if (!compatibleDestination) return;
@@ -1296,6 +1286,7 @@ export default function PaymentsPage() {
                     paymentsSlotBlocked,
                     sendWarningMessage,
                     recipientNetworkWarningMessage,
+                    tokenAutoSelect,
                 },
             },
             {
@@ -1330,6 +1321,7 @@ export default function PaymentsPage() {
             paymentsSlotBlocked,
             sendWarningMessage,
             recipientNetworkWarningMessage,
+            tokenAutoSelect,
             quoteContextKey,
         ],
     );

--- a/nt-fe/components/modal.tsx
+++ b/nt-fe/components/modal.tsx
@@ -121,7 +121,7 @@ function DialogHeader({
         >
             <div className={cn(centerTitle && "flex-1")}>{children}</div>
             {closeButton && (
-                <BaseDialogClose className="ring-offset-background focus-visible:ring-ring inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none">
+                <BaseDialogClose className="ring-offset-background focus-visible:ring-ring inline-flex size-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none">
                     <XIcon className="size-4" />
                     <span className="sr-only">{t("close")}</span>
                 </BaseDialogClose>

--- a/nt-fe/components/token-input.tsx
+++ b/nt-fe/components/token-input.tsx
@@ -90,6 +90,11 @@ interface TokenInputProps<
             network: string;
             residency?: string;
         }) => boolean;
+        /**
+         * When false, skips the shared default-token auto-select
+         * (highest-USD owned → USDC on NEAR). Exchange sets this false.
+         */
+        autoSelect?: boolean;
     };
     readOnly?: boolean;
     loading?: boolean;
@@ -385,6 +390,9 @@ export function TokenInput<
                                                 }
                                                 filterTokens={
                                                     tokenSelect?.filterTokens
+                                                }
+                                                autoSelect={
+                                                    tokenSelect?.autoSelect
                                                 }
                                             />
                                         );

--- a/nt-fe/components/token-input.tsx
+++ b/nt-fe/components/token-input.tsx
@@ -9,8 +9,9 @@ import {
 import { useTranslations } from "next-intl";
 import { Button } from "./button";
 import { useTreasury } from "@/hooks/use-treasury";
-import { useAssets } from "@/hooks/use-assets";
+import { DEFAULT_ASSETS_QUERY, useAssets } from "@/hooks/use-assets";
 import { availableBalance } from "@/lib/balance";
+import { findMatchingTreasuryAsset } from "@/lib/match-treasury-asset";
 import { cn, formatBalance, formatCurrency } from "@/lib/utils";
 import TokenSelect, { SelectedTokenData } from "./token-select";
 import { WarningMessage } from "./warning-message";
@@ -66,7 +67,7 @@ interface TokenInputProps<
     title?: string;
     amountName: Path<TFieldValues>;
     tokenName: TTokenPath extends Path<TFieldValues>
-        ? PathValue<TFieldValues, TTokenPath> extends Token
+        ? NonNullable<PathValue<TFieldValues, TTokenPath>> extends Token
             ? TTokenPath
             : never
         : never;
@@ -150,35 +151,33 @@ export function TokenInput<
     const { treasuryId } = useTreasury();
     const { setValue } = useFormContext<TFieldValues>();
     const amount = useWatch({ control, name: amountName });
-    const token = useWatch({ control, name: tokenName }) as Token;
+    // Null while payments waits for assets to seed a default token.
+    const token = useWatch({ control, name: tokenName }) as Token | null;
 
-    // Use balance & price from useAssets (passed through token-select)
-    const { data: assetsData } = useAssets(treasuryId, {
-        enabled: true,
-        onlySupportedTokens: true,
-    });
+    // Shared DEFAULT_ASSETS_QUERY so we hit the same cache as useMergedTokens.
+    const { data: assetsData, isPending: isAssetsPending } = useAssets(
+        treasuryId,
+        DEFAULT_ASSETS_QUERY,
+    );
 
-    // Find the matching asset from useAssets to get fresh balance/price
-    const matchedAsset = useMemo(() => {
-        if (!assetsData?.tokens || !token?.address) return null;
-        return assetsData.tokens.find(
-            (t) =>
-                (t.contractId ?? t.id) === token.address &&
-                t.network === token.network,
-        );
-    }, [assetsData?.tokens, token?.address, token?.network]);
+    const matchedAsset = useMemo(
+        () => findMatchingTreasuryAsset(assetsData?.tokens, token),
+        [assetsData?.tokens, token],
+    );
 
-    // Treat missing balance as zero so unsupported/unowned selections show the
-    // same insufficient-assets feedback as low-balance selections.
+    // Prefer live assets balance; fall back to the form token's balance.
+    // Never invent "0" while assets are still loading (avoids Balance: 0 flash).
     const tokenBalance = matchedAsset
         ? availableBalance(matchedAsset.balance).toFixed(0)
-        : (token?.balance ?? "0");
+        : (token?.balance ?? (isAssetsPending ? null : "0"));
     const tokenPrice = matchedAsset?.price ?? token?.price;
     const tokenDecimals = matchedAsset?.decimals ?? token?.decimals;
 
     const balanceWarning = useMemo(() => {
-        if (!showInsufficientBalance) return null;
-        if (!tokenBalance || !amount || isNaN(amount) || amount <= 0) {
+        if (!showInsufficientBalance || !token || tokenBalance == null) {
+            return null;
+        }
+        if (!amount || isNaN(amount) || amount <= 0) {
             return null;
         }
 
@@ -202,11 +201,11 @@ export function TokenInput<
         });
     }, [
         showInsufficientBalance,
+        token,
         tokenBalance,
         amount,
         tokenDecimals,
         networkFee,
-        token.symbol,
     ]);
 
     const estimatedUSDValue = useMemo(() => {
@@ -297,30 +296,32 @@ export function TokenInput<
                         invalid={!!displayError}
                         topRightContent={
                             <div className="flex items-center gap-2">
-                                {tokenBalance && tokenDecimals && (
-                                    <>
-                                        <p className="text-xs text-muted-foreground">
-                                            {t("balance", {
-                                                amount: formatBalance(
-                                                    tokenBalance,
-                                                    tokenDecimals,
-                                                ),
-                                                symbol: token.symbol.toUpperCase(),
-                                            })}
-                                        </p>
-                                        {!readOnly && (
-                                            <Button
-                                                type="button"
-                                                variant="secondary"
-                                                className="bg-muted-foreground/10 hover:bg-muted-foreground/20"
-                                                size="sm"
-                                                onClick={handleMaxClick}
-                                            >
-                                                {t("max")}
-                                            </Button>
-                                        )}
-                                    </>
-                                )}
+                                {token &&
+                                    tokenBalance != null &&
+                                    tokenDecimals != null && (
+                                        <>
+                                            <p className="text-xs text-muted-foreground">
+                                                {t("balance", {
+                                                    amount: formatBalance(
+                                                        tokenBalance,
+                                                        tokenDecimals,
+                                                    ),
+                                                    symbol: token.symbol.toUpperCase(),
+                                                })}
+                                            </p>
+                                            {!readOnly && (
+                                                <Button
+                                                    type="button"
+                                                    variant="secondary"
+                                                    className="bg-muted-foreground/10 hover:bg-muted-foreground/20"
+                                                    size="sm"
+                                                    onClick={handleMaxClick}
+                                                >
+                                                    {t("max")}
+                                                </Button>
+                                            )}
+                                        </>
+                                    )}
                             </div>
                         }
                     >

--- a/nt-fe/components/token-select.tsx
+++ b/nt-fe/components/token-select.tsx
@@ -9,8 +9,10 @@ import {
     type MergedToken,
 } from "@/hooks/use-merged-tokens";
 import { usePopularAssetsByActivity } from "@/hooks/use-treasury-queries";
+import { useTreasury } from "@/hooks/use-treasury";
 import type { ChainIcons } from "@/lib/api";
 import Big from "@/lib/big";
+import { pickDefaultSelectedToken } from "@/lib/pick-default-token";
 import {
     canonicalizeTokenIdForMatch,
     cn,
@@ -32,6 +34,7 @@ import { NetworkIconDisplay } from "./token-display";
 import { TokenDisplay } from "./token-display-with-network";
 import { Tooltip } from "./tooltip";
 import { ScrollArea } from "./ui/scroll-area";
+import { Skeleton } from "./ui/skeleton";
 
 // Selected token (asset + specific network)
 export interface SelectedTokenData {
@@ -86,6 +89,12 @@ interface TokenSelectProps {
         network: string;
         residency?: string;
     }) => boolean;
+    /**
+     * When true (default), auto-picks the highest-USD owned asset from the
+     * assets cache, else USDC on NEAR. Set false for Exchange (and any flow
+     * that seeds its own tokens).
+     */
+    autoSelect?: boolean;
 }
 
 export default function TokenSelect({
@@ -101,9 +110,11 @@ export default function TokenSelect({
     iconSize = "md",
     filterTokens,
     showPopularAssets = false,
+    autoSelect = true,
 }: TokenSelectProps) {
     const t = useTranslations("tokenSelectDialog");
     const tDepositSections = useTranslations("depositModal.sections");
+    const { isConfidential } = useTreasury();
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState("");
     const [selectedAsset, setSelectedAsset] = useState<MergedToken | null>(
@@ -114,31 +125,32 @@ export default function TokenSelect({
         showPopularAssets && open && step === "token",
     );
 
-    const { tokens, isLoading } = useMergedTokens({
+    const { tokens, isLoading, isAssetsReady } = useMergedTokens({
         enabled: !showOnlyOwnedAssets && open,
         showOnlyOwned: showOnlyOwnedAssets,
     });
 
-    // Auto-select first available token on initial load.
+    // Wait for assets cache/fetch before picking — avoids flashing USDC then
+    // swapping to the highest-USD owned token when holdings arrive.
     useEffect(() => {
-        if (tokens.length > 0 && !selectedToken && !locked) {
-            const firstToken = tokens[0];
-            const firstNetwork = firstToken.networks[0];
-            if (!firstNetwork) return;
-            setSelectedToken({
-                address: firstNetwork.id,
-                symbol: firstNetwork.symbol,
-                decimals: firstNetwork.decimals,
-                name: firstToken.name || firstNetwork.symbol,
-                icon: firstToken.icon || "",
-                network: firstNetwork.name,
-                chainIcons: firstNetwork.chainIcons || undefined,
-                residency: firstNetwork.residency,
-                minWithdrawalAmount: firstNetwork.minWithdrawalAmount,
-                minDepositAmount: firstNetwork.minDepositAmount,
-            });
-        }
-    }, [tokens, selectedToken, locked, setSelectedToken]);
+        if (!autoSelect || locked || selectedToken || !isAssetsReady) return;
+
+        setSelectedToken(
+            pickDefaultSelectedToken(tokens, {
+                disableTokens,
+                isConfidential,
+            }),
+        );
+    }, [
+        autoSelect,
+        isAssetsReady,
+        tokens,
+        selectedToken,
+        locked,
+        setSelectedToken,
+        disableTokens,
+        isConfidential,
+    ]);
 
     // Source-agnostic list for rendering/selecting.
     const filteredTokens = useMemo(() => {
@@ -354,9 +366,14 @@ export default function TokenSelect({
         );
     };
 
+    // Payments/bulk wait for assets before seeding — show a skeleton. Exchange already has a seeded token.
+    const showDefaultLoading = !selectedToken && !isAssetsReady;
+    const iconSkeletonClass =
+        iconSize === "lg" ? "size-6" : iconSize === "sm" ? "size-4" : "size-5";
+
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
-            <DialogTrigger asChild disabled={disabled}>
+            <DialogTrigger asChild disabled={disabled || showDefaultLoading}>
                 <Button
                     type="button"
                     variant="outline"
@@ -365,7 +382,21 @@ export default function TokenSelect({
                         classNames?.trigger,
                     )}
                 >
-                    {selectedToken ? (
+                    {showDefaultLoading ? (
+                        // Same pattern as treasury-selector loading state.
+                        <div className="flex items-center gap-2 min-w-0 h-9">
+                            <Skeleton
+                                className={cn(
+                                    "rounded-full shrink-0",
+                                    iconSkeletonClass,
+                                )}
+                            />
+                            <div className="flex flex-col gap-1">
+                                <Skeleton className="h-3 w-16" />
+                                <Skeleton className="h-3 w-12" />
+                            </div>
+                        </div>
+                    ) : selectedToken ? (
                         <>
                             <TokenDisplay
                                 symbol={selectedToken.symbol}

--- a/nt-fe/components/token-select.tsx
+++ b/nt-fe/components/token-select.tsx
@@ -9,7 +9,6 @@ import {
     type MergedToken,
 } from "@/hooks/use-merged-tokens";
 import { usePopularAssetsByActivity } from "@/hooks/use-treasury-queries";
-import { useTreasury } from "@/hooks/use-treasury";
 import type { ChainIcons } from "@/lib/api";
 import Big from "@/lib/big";
 import { pickDefaultSelectedToken } from "@/lib/pick-default-token";
@@ -48,6 +47,8 @@ export interface SelectedTokenData {
     residency?: string;
     minWithdrawalAmount?: string;
     minDepositAmount?: string;
+    balance?: string;
+    price?: number;
 }
 
 interface TokenSelectProps {
@@ -114,7 +115,6 @@ export default function TokenSelect({
 }: TokenSelectProps) {
     const t = useTranslations("tokenSelectDialog");
     const tDepositSections = useTranslations("depositModal.sections");
-    const { isConfidential } = useTreasury();
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState("");
     const [selectedAsset, setSelectedAsset] = useState<MergedToken | null>(
@@ -138,7 +138,6 @@ export default function TokenSelect({
         setSelectedToken(
             pickDefaultSelectedToken(tokens, {
                 disableTokens,
-                isConfidential,
             }),
         );
     }, [
@@ -149,7 +148,6 @@ export default function TokenSelect({
         locked,
         setSelectedToken,
         disableTokens,
-        isConfidential,
     ]);
 
     // Source-agnostic list for rendering/selecting.
@@ -273,6 +271,8 @@ export default function TokenSelect({
                 residency: network.residency,
                 minWithdrawalAmount: network.minWithdrawalAmount,
                 minDepositAmount: network.minDepositAmount,
+                balance: network.balance,
+                price: network.price,
             });
 
             setOpen(false);

--- a/nt-fe/components/ui/dialog.tsx
+++ b/nt-fe/components/ui/dialog.tsx
@@ -71,7 +71,7 @@ function DialogContent({
                 {showCloseButton && (
                     <DialogPrimitive.Close
                         data-slot="dialog-close"
-                        className="ring-offset-background focus-visible:ring-ring absolute top-4 right-4 inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+                        className="ring-offset-background focus-visible:ring-ring absolute top-4 right-4 inline-flex size-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
                     >
                         <XIcon />
                         <span className="sr-only">{t("close")}</span>

--- a/nt-fe/constants/token.ts
+++ b/nt-fe/constants/token.ts
@@ -13,6 +13,14 @@ export const NEAR_TOKEN_DECIMALS = 24;
 
 export const NEAR_COM_ICON = "/near.com.svg";
 
+/** Native USDC contract on NEAR (Circle). */
+export const USDC_NEAR_CONTRACT_ID =
+    "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1";
+export const NEP141_USDC_NEAR_ASSET_ID = `nep141:${USDC_NEAR_CONTRACT_ID}`;
+
+const USDC_ICON =
+    "https://s2.coinmarketcap.com/static/img/coins/128x128/3408.png";
+
 export const default_near_token = (isConfidential: boolean) => {
     return {
         symbol: "NEAR",
@@ -23,5 +31,25 @@ export const default_near_token = (isConfidential: boolean) => {
         name: "NEAR",
         chainIcons: NEAR_CHAIN_ICONS,
         residency: isConfidential ? "Intents" : "Near",
+    } satisfies Token;
+};
+
+/**
+ * Fallback when treasury assets aren't cached yet — USDC on NEAR (Intents).
+ * Same asset id/residency for confidential and public; matches the bridge
+ * token picker selection (nep141:17208628… / Intents / near).
+ */
+export const default_usdc_near_token = (_isConfidential?: boolean) => {
+    return {
+        symbol: "USDC",
+        address: NEP141_USDC_NEAR_ASSET_ID,
+        network: NEAR_NETWORK_ID,
+        decimals: 6,
+        icon: USDC_ICON,
+        name: "USD Coin",
+        chainIcons: NEAR_CHAIN_ICONS,
+        residency: "Intents",
+        minWithdrawalAmount: "1",
+        minDepositAmount: "1",
     } satisfies Token;
 };

--- a/nt-fe/constants/token.ts
+++ b/nt-fe/constants/token.ts
@@ -36,20 +36,18 @@ export const default_near_token = (isConfidential: boolean) => {
 
 /**
  * Fallback when treasury assets aren't cached yet — USDC on NEAR (Intents).
- * Same asset id/residency for confidential and public; matches the bridge
- * token picker selection (nep141:17208628… / Intents / near).
+ * Same for confidential and public; matches the bridge token picker
+ * (nep141:17208628… / Intents / near).
  */
-export const default_usdc_near_token = (_isConfidential?: boolean) => {
-    return {
-        symbol: "USDC",
-        address: NEP141_USDC_NEAR_ASSET_ID,
-        network: NEAR_NETWORK_ID,
-        decimals: 6,
-        icon: USDC_ICON,
-        name: "USD Coin",
-        chainIcons: NEAR_CHAIN_ICONS,
-        residency: "Intents",
-        minWithdrawalAmount: "1",
-        minDepositAmount: "1",
-    } satisfies Token;
-};
+export const default_usdc_near_token = (): Token => ({
+    symbol: "USDC",
+    address: NEP141_USDC_NEAR_ASSET_ID,
+    network: NEAR_NETWORK_ID,
+    decimals: 6,
+    icon: USDC_ICON,
+    name: "USD Coin",
+    chainIcons: NEAR_CHAIN_ICONS,
+    residency: "Intents",
+    minWithdrawalAmount: "1",
+    minDepositAmount: "1",
+});

--- a/nt-fe/hooks/use-assets.ts
+++ b/nt-fe/hooks/use-assets.ts
@@ -28,6 +28,16 @@ const isTokenValidByOptions = (
 };
 
 /**
+ * Shared options for payments / deposit / token pickers so every observer
+ * hits the same React Query cache entry (onlyPositiveBalance must not be
+ * omitted — `undefined` vs `false` used to split the key and refetch).
+ */
+export const DEFAULT_ASSETS_QUERY = {
+    onlyPositiveBalance: false,
+    onlySupportedTokens: true,
+} as const;
+
+/**
  * Query hook to get whitelisted tokens with balances and prices
  * Fetches from backend which aggregates data from Ref Finance and FastNear
  */
@@ -39,8 +49,12 @@ export function useAssets(
         enabled?: boolean;
     },
 ) {
+    // Normalize so callers that omit onlyPositiveBalance share cache with
+    // those that pass `false` explicitly.
+    const onlyPositiveBalance = options?.onlyPositiveBalance ?? false;
+
     return useQuery({
-        queryKey: ["treasuryAssets", treasuryId, options?.onlyPositiveBalance],
+        queryKey: ["treasuryAssets", treasuryId, onlyPositiveBalance],
         queryFn: () => getTreasuryAssets(treasuryId!),
         enabled: !!treasuryId && (options?.enabled ?? true),
         staleTime: 1000 * 5, // 5 seconds (assets change frequently)
@@ -48,7 +62,10 @@ export function useAssets(
             return {
                 ...data,
                 tokens: data.tokens.filter((token) =>
-                    isTokenValidByOptions(token, options),
+                    isTokenValidByOptions(token, {
+                        ...options,
+                        onlyPositiveBalance,
+                    }),
                 ),
             };
         },

--- a/nt-fe/hooks/use-intents-quote.ts
+++ b/nt-fe/hooks/use-intents-quote.ts
@@ -153,7 +153,8 @@ function isInvalidRecipientAddressError(message: string): boolean {
 
 interface UseIntentsQuoteParams {
     treasuryId: string | undefined;
-    token: Token;
+    /** Null while the page waits to seed a default token. */
+    token: Token | null;
     amount: string;
     destinationAmountDecimals?: number;
     address: string;
@@ -182,7 +183,7 @@ export function useIntentsQuote({
     enabled = true,
 }: UseIntentsQuoteParams) {
     const t = useTranslations("intentsQuote");
-    const isIntents = isIntentsToken(token);
+    const isIntents = !!token && isIntentsToken(token);
     const normalizedAddress = address.trim();
     const [debouncedAddress] = useDebounce(normalizedAddress, 300);
     const [debouncedAmount] = useDebounce(amount, 400);
@@ -193,13 +194,16 @@ export function useIntentsQuote({
         !isNearComNetwork(destinationNetwork);
     const requestAmountDecimals = requiresDestinationAmountDecimals
         ? destinationAmountDecimals
-        : token.decimals;
+        : token?.decimals;
 
     const isRecipientReady =
-        !!debouncedAddress && isAddressValidForToken(debouncedAddress, token);
+        !!token &&
+        !!debouncedAddress &&
+        isAddressValidForToken(debouncedAddress, token);
     const requiresDestinationSelectionForPayment = isPayment && isIntents;
     const isQuoteReady =
         enabled &&
+        !!token &&
         isIntents &&
         !!treasuryId &&
         isRecipientReady &&
@@ -231,7 +235,7 @@ export function useIntentsQuote({
         queryKey: [
             "paymentLiveQuote",
             treasuryId,
-            token.address,
+            token?.address,
             debouncedAmount,
             debouncedAddress,
             amountMode,
@@ -239,7 +243,7 @@ export function useIntentsQuote({
             isPayment,
         ],
         queryFn: async ({ signal }): Promise<IntentsQuoteResponse | null> => {
-            if (!isQuoteReady) return null;
+            if (!isQuoteReady || !token) return null;
             if (requestAmountDecimals === undefined) {
                 captureMissingDestinationDecimals(token.address);
                 throw new Error(t("fetchFailed"));
@@ -275,7 +279,7 @@ export function useIntentsQuote({
             return t("fetchFailed");
         }
 
-        if (!hasQueryError || !error) return null;
+        if (!hasQueryError || !error || !token) return null;
         const msg =
             error instanceof Error
                 ? error.message
@@ -291,7 +295,7 @@ export function useIntentsQuote({
         hasQueryError,
         error,
         requestAmountDecimals,
-        token.symbol,
+        token,
         t,
     ]);
 

--- a/nt-fe/hooks/use-merged-tokens.ts
+++ b/nt-fe/hooks/use-merged-tokens.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import {
     useAggregatedTokens,
+    DEFAULT_ASSETS_QUERY,
     useAssets,
     type AggregatedAsset,
 } from "@/hooks/use-assets";
@@ -301,10 +302,7 @@ export function useMergedTokens({
     const {
         data: { tokens: rawTokens = [] } = {},
         isPending: isAssetsPending,
-    } = useAssets(treasuryId, {
-        onlyPositiveBalance: false,
-        onlySupportedTokens: true,
-    });
+    } = useAssets(treasuryId, DEFAULT_ASSETS_QUERY);
 
     const aggregatedTokens = useAggregatedTokens(rawTokens);
 

--- a/nt-fe/hooks/use-merged-tokens.ts
+++ b/nt-fe/hooks/use-merged-tokens.ts
@@ -298,7 +298,10 @@ export function useMergedTokens({
 }: UseMergedTokensOptions = {}) {
     const { treasuryId, isConfidential } = useTreasury();
 
-    const { data: { tokens: rawTokens = [] } = {} } = useAssets(treasuryId, {
+    const {
+        data: { tokens: rawTokens = [] } = {},
+        isPending: isAssetsPending,
+    } = useAssets(treasuryId, {
         onlyPositiveBalance: false,
         onlySupportedTokens: true,
     });
@@ -340,5 +343,11 @@ export function useMergedTokens({
         ];
     }, [aggregatedTokens, bridgeAssets, showOnlyOwned]);
 
-    return { tokens, aggregatedTokens, isLoading };
+    return {
+        tokens,
+        aggregatedTokens,
+        isLoading,
+        /** False until treasury assets resolve from cache or network — use before defaulting tokens. */
+        isAssetsReady: !isAssetsPending,
+    };
 }

--- a/nt-fe/lib/match-treasury-asset.test.ts
+++ b/nt-fe/lib/match-treasury-asset.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import type { TreasuryAsset } from "@/lib/api";
+import { findMatchingTreasuryAsset } from "./match-treasury-asset";
+
+const btcAsset = {
+    id: "nep141:btc.omft.near",
+    contractId: "btc.omft.near",
+    residency: "Intents",
+    network: "bitcoin",
+    chainName: "Bitcoin",
+    symbol: "BTC",
+    balance: { Standard: { total: "544253", locked: "0" } },
+    decimals: 8,
+    price: 67540,
+    name: "Bitcoin",
+    icon: "",
+    balanceUSD: 367,
+    weight: 0,
+} as unknown as TreasuryAsset;
+
+describe("findMatchingTreasuryAsset", () => {
+    it("matches nep141 address to bare contractId", () => {
+        const matched = findMatchingTreasuryAsset([btcAsset], {
+            address: "nep141:btc.omft.near",
+            network: "bitcoin",
+        });
+        expect(matched?.symbol).toBe("BTC");
+    });
+
+    it("matches bare contractId address", () => {
+        const matched = findMatchingTreasuryAsset([btcAsset], {
+            address: "btc.omft.near",
+            network: "bitcoin",
+        });
+        expect(matched?.id).toBe("nep141:btc.omft.near");
+    });
+
+    it("requires network when both sides have one", () => {
+        expect(
+            findMatchingTreasuryAsset([btcAsset], {
+                address: "btc.omft.near",
+                network: "eth",
+            }),
+        ).toBeNull();
+    });
+
+    it("returns null when tokens or address are missing", () => {
+        expect(
+            findMatchingTreasuryAsset(undefined, { address: "x" }),
+        ).toBeNull();
+        expect(findMatchingTreasuryAsset([btcAsset], null)).toBeNull();
+        expect(
+            findMatchingTreasuryAsset([btcAsset], { address: "" }),
+        ).toBeNull();
+    });
+});

--- a/nt-fe/lib/match-treasury-asset.ts
+++ b/nt-fe/lib/match-treasury-asset.ts
@@ -1,0 +1,31 @@
+import type { TreasuryAsset } from "@/lib/api";
+import { canonicalizeTokenIdForMatch } from "@/lib/utils";
+
+/**
+ * Match a selected token (form / picker) to a treasury asset row for
+ * live balance and price. Accepts nep141: vs bare contract IDs.
+ */
+export function findMatchingTreasuryAsset(
+    tokens: readonly TreasuryAsset[] | undefined,
+    token: { address?: string | null; network?: string | null } | null,
+): TreasuryAsset | null {
+    if (!tokens?.length || !token?.address) return null;
+
+    const tokenId = canonicalizeTokenIdForMatch(token.address);
+    const tokenNetwork = token.network?.trim().toLowerCase();
+
+    return (
+        tokens.find((asset) => {
+            const assetId = canonicalizeTokenIdForMatch(
+                asset.contractId ?? asset.id,
+            );
+            const assetIdAlt = canonicalizeTokenIdForMatch(asset.id);
+            const idMatch = assetId === tokenId || assetIdAlt === tokenId;
+            const networkMatch =
+                !tokenNetwork ||
+                !asset.network ||
+                asset.network.trim().toLowerCase() === tokenNetwork;
+            return idMatch && networkMatch;
+        }) ?? null
+    );
+}

--- a/nt-fe/lib/pick-default-token.test.ts
+++ b/nt-fe/lib/pick-default-token.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import type { MergedToken } from "@/hooks/use-merged-tokens";
+import {
+    isDefaultUsdcNearSelection,
+    pickDefaultSelectedToken,
+    pickHighestUsdOwnedToken,
+} from "./pick-default-token";
+
+const nearUsdc: MergedToken = {
+    id: "usdc",
+    name: "USD Coin",
+    symbol: "USDC",
+    icon: "",
+    totalBalanceUSD: 50,
+    networks: [
+        {
+            id: "nep141:17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
+            name: "near",
+            symbol: "USDC",
+            chainIcons: null,
+            chainId: "near:mainnet",
+            decimals: 6,
+            residency: "Intents",
+            balance: "50000000",
+            balanceUSD: 50,
+        },
+    ],
+};
+
+const ethWeth: MergedToken = {
+    id: "weth",
+    name: "Wrapped Ether",
+    symbol: "WETH",
+    icon: "",
+    totalBalanceUSD: 200,
+    networks: [
+        {
+            id: "nep141:eth.omft.near",
+            name: "eth",
+            symbol: "WETH",
+            chainIcons: null,
+            chainId: "eth:1",
+            decimals: 18,
+            residency: "Intents",
+            balance: "100000000000000000",
+            balanceUSD: 200,
+        },
+    ],
+};
+
+describe("pickDefaultSelectedToken", () => {
+    it("picks the highest USD owned network when assets are cached", () => {
+        const picked = pickDefaultSelectedToken([nearUsdc, ethWeth], {
+            isConfidential: true,
+        });
+        expect(picked.symbol).toBe("WETH");
+        expect(picked.network).toBe("eth");
+        expect(picked.address).toBe(ethWeth.networks[0].id);
+        expect(pickHighestUsdOwnedToken([nearUsdc, ethWeth])?.address).toBe(
+            ethWeth.networks[0].id,
+        );
+    });
+
+    it("falls back to USDC on NEAR from the list when nothing is owned", () => {
+        const listedOnly: MergedToken = {
+            ...nearUsdc,
+            totalBalanceUSD: 0,
+            networks: nearUsdc.networks.map((n) => ({
+                ...n,
+                balance: undefined,
+                balanceUSD: undefined,
+            })),
+        };
+        const picked = pickDefaultSelectedToken([listedOnly], {
+            isConfidential: true,
+        });
+        expect(picked.symbol).toBe("USDC");
+        expect(picked.network).toBe("near");
+    });
+
+    it("falls back to static USDC on NEAR when the list is empty", () => {
+        const picked = pickDefaultSelectedToken([], { isConfidential: true });
+        expect(picked.symbol).toBe("USDC");
+        expect(picked.network).toBe("near");
+        expect(isDefaultUsdcNearSelection(picked, true)).toBe(true);
+    });
+
+    it("respects disableTokens when picking owned holdings", () => {
+        const picked = pickDefaultSelectedToken([nearUsdc, ethWeth], {
+            isConfidential: true,
+            disableTokens: (t) => t.symbol === "WETH",
+        });
+        expect(picked.symbol).toBe("USDC");
+        expect(picked.network).toBe("near");
+    });
+});

--- a/nt-fe/lib/pick-default-token.test.ts
+++ b/nt-fe/lib/pick-default-token.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { MergedToken } from "@/hooks/use-merged-tokens";
 import {
-    isDefaultUsdcNearSelection,
+    pickDefaultDepositAsset,
     pickDefaultSelectedToken,
     pickHighestUsdOwnedToken,
 } from "./pick-default-token";
@@ -50,12 +50,11 @@ const ethWeth: MergedToken = {
 
 describe("pickDefaultSelectedToken", () => {
     it("picks the highest USD owned network when assets are cached", () => {
-        const picked = pickDefaultSelectedToken([nearUsdc, ethWeth], {
-            isConfidential: true,
-        });
+        const picked = pickDefaultSelectedToken([nearUsdc, ethWeth]);
         expect(picked.symbol).toBe("WETH");
         expect(picked.network).toBe("eth");
         expect(picked.address).toBe(ethWeth.networks[0].id);
+        expect(picked.balance).toBe("100000000000000000");
         expect(pickHighestUsdOwnedToken([nearUsdc, ethWeth])?.address).toBe(
             ethWeth.networks[0].id,
         );
@@ -71,26 +70,41 @@ describe("pickDefaultSelectedToken", () => {
                 balanceUSD: undefined,
             })),
         };
-        const picked = pickDefaultSelectedToken([listedOnly], {
-            isConfidential: true,
-        });
+        const picked = pickDefaultSelectedToken([listedOnly]);
         expect(picked.symbol).toBe("USDC");
         expect(picked.network).toBe("near");
     });
 
     it("falls back to static USDC on NEAR when the list is empty", () => {
-        const picked = pickDefaultSelectedToken([], { isConfidential: true });
+        const picked = pickDefaultSelectedToken([]);
         expect(picked.symbol).toBe("USDC");
         expect(picked.network).toBe("near");
-        expect(isDefaultUsdcNearSelection(picked, true)).toBe(true);
+        expect(picked.address).toContain("17208628");
     });
 
     it("respects disableTokens when picking owned holdings", () => {
         const picked = pickDefaultSelectedToken([nearUsdc, ethWeth], {
-            isConfidential: true,
             disableTokens: (t) => t.symbol === "WETH",
         });
         expect(picked.symbol).toBe("USDC");
         expect(picked.network).toBe("near");
+    });
+});
+
+describe("pickDefaultDepositAsset", () => {
+    it("prefers the first owned asset (USD-sorted by caller)", () => {
+        const picked = pickDefaultDepositAsset(
+            [{ id: "btc" }, { id: "usdc" }],
+            [{ id: "btc" }, { id: "usdc" }, { id: "eth" }],
+        );
+        expect(picked?.id).toBe("btc");
+    });
+
+    it("falls back to USDC then first available when none owned", () => {
+        expect(
+            pickDefaultDepositAsset([], [{ id: "eth" }, { id: "usdc" }])?.id,
+        ).toBe("usdc");
+        expect(pickDefaultDepositAsset([], [{ id: "eth" }])?.id).toBe("eth");
+        expect(pickDefaultDepositAsset([], [])).toBeUndefined();
     });
 });

--- a/nt-fe/lib/pick-default-token.ts
+++ b/nt-fe/lib/pick-default-token.ts
@@ -1,0 +1,160 @@
+import type { SelectedTokenData } from "@/components/token-select";
+import { NEAR_NETWORK_ID } from "@/constants/network-ids";
+import {
+    default_usdc_near_token,
+    NEP141_USDC_NEAR_ASSET_ID,
+    USDC_NEAR_CONTRACT_ID,
+} from "@/constants/token";
+import type { MergedNetwork, MergedToken } from "@/hooks/use-merged-tokens";
+import Big from "@/lib/big";
+import { canonicalizeTokenIdForMatch } from "@/lib/utils";
+
+export type DefaultTokenFilter = (token: {
+    address: string;
+    symbol: string;
+    network: string;
+    residency?: string;
+}) => boolean;
+
+function networkHasBalance(network: MergedNetwork): boolean {
+    if (network.balance == null) return false;
+    try {
+        return Big(network.balance).gt(0);
+    } catch {
+        return false;
+    }
+}
+
+function toSelected(
+    token: MergedToken,
+    network: MergedNetwork,
+): SelectedTokenData {
+    return {
+        address: network.id,
+        symbol: network.symbol,
+        decimals: network.decimals,
+        name: token.name || network.symbol,
+        icon: token.icon || "",
+        network: network.name,
+        chainIcons: network.chainIcons || undefined,
+        residency: network.residency,
+        minWithdrawalAmount: network.minWithdrawalAmount,
+        minDepositAmount: network.minDepositAmount,
+    };
+}
+
+function isDisabled(
+    network: MergedNetwork,
+    disableTokens?: DefaultTokenFilter,
+): boolean {
+    return (
+        disableTokens?.({
+            address: network.id,
+            symbol: network.symbol,
+            network: network.name,
+            residency: network.residency,
+        }) ?? false
+    );
+}
+
+function isNearNetworkName(name: string): boolean {
+    return name.trim().toLowerCase() === NEAR_NETWORK_ID;
+}
+
+function isUsdcSymbol(symbol: string): boolean {
+    return symbol.trim().toUpperCase() === "USDC";
+}
+
+/**
+ * Highest USD-value owned network across cached treasury assets.
+ * Tokens should already be sorted by totalBalanceUSD desc when from useMergedTokens.
+ */
+export function pickHighestUsdOwnedToken(
+    tokens: MergedToken[],
+    disableTokens?: DefaultTokenFilter,
+): SelectedTokenData | null {
+    let best: {
+        token: MergedToken;
+        network: MergedNetwork;
+        usd: number;
+    } | null = null;
+
+    for (const token of tokens) {
+        for (const network of token.networks) {
+            if (
+                !networkHasBalance(network) ||
+                isDisabled(network, disableTokens)
+            ) {
+                continue;
+            }
+            const usd = network.balanceUSD ?? 0;
+            if (!best || usd > best.usd) {
+                best = { token, network, usd };
+            }
+        }
+    }
+
+    return best ? toSelected(best.token, best.network) : null;
+}
+
+/** Prefer USDC on the NEAR network from the merged token list. */
+export function pickUsdcNearFromTokens(
+    tokens: MergedToken[],
+    disableTokens?: DefaultTokenFilter,
+): SelectedTokenData | null {
+    for (const token of tokens) {
+        for (const network of token.networks) {
+            if (!isUsdcSymbol(network.symbol)) continue;
+            if (!isNearNetworkName(network.name)) continue;
+            if (isDisabled(network, disableTokens)) continue;
+            return toSelected(token, network);
+        }
+    }
+    return null;
+}
+
+/**
+ * Default token for Deposit / Payments / Bulk (not Exchange):
+ * 1) most USD-valuable owned network from cached assets
+ * 2) USDC on NEAR from the available list
+ * 3) static USDC-on-NEAR fallback
+ */
+export function pickDefaultSelectedToken(
+    tokens: MergedToken[],
+    options?: {
+        disableTokens?: DefaultTokenFilter;
+        isConfidential?: boolean;
+    },
+): SelectedTokenData {
+    const owned = pickHighestUsdOwnedToken(tokens, options?.disableTokens);
+    if (owned) return owned;
+
+    const usdcNear = pickUsdcNearFromTokens(tokens, options?.disableTokens);
+    if (usdcNear) return usdcNear;
+
+    return default_usdc_near_token(options?.isConfidential ?? false);
+}
+
+/** True when the selection matches the static USDC-on-NEAR fallback. */
+export function isDefaultUsdcNearSelection(
+    token:
+        | Pick<SelectedTokenData, "address" | "symbol" | "network">
+        | null
+        | undefined,
+    isConfidential: boolean,
+): boolean {
+    if (!token) return false;
+    if (!isUsdcSymbol(token.symbol) || !isNearNetworkName(token.network)) {
+        return false;
+    }
+    const fallback = default_usdc_near_token(isConfidential);
+    const a = canonicalizeTokenIdForMatch(token.address);
+    const b = canonicalizeTokenIdForMatch(fallback.address);
+    // Also accept either public or intents form of the same USDC contract.
+    const accepted = new Set([
+        b,
+        canonicalizeTokenIdForMatch(USDC_NEAR_CONTRACT_ID),
+        canonicalizeTokenIdForMatch(NEP141_USDC_NEAR_ASSET_ID),
+    ]);
+    return accepted.has(a);
+}

--- a/nt-fe/lib/pick-default-token.ts
+++ b/nt-fe/lib/pick-default-token.ts
@@ -1,13 +1,8 @@
 import type { SelectedTokenData } from "@/components/token-select";
 import { NEAR_NETWORK_ID } from "@/constants/network-ids";
-import {
-    default_usdc_near_token,
-    NEP141_USDC_NEAR_ASSET_ID,
-    USDC_NEAR_CONTRACT_ID,
-} from "@/constants/token";
+import { default_usdc_near_token } from "@/constants/token";
 import type { MergedNetwork, MergedToken } from "@/hooks/use-merged-tokens";
 import Big from "@/lib/big";
-import { canonicalizeTokenIdForMatch } from "@/lib/utils";
 
 export type DefaultTokenFilter = (token: {
     address: string;
@@ -40,6 +35,9 @@ function toSelected(
         residency: network.residency,
         minWithdrawalAmount: network.minWithdrawalAmount,
         minDepositAmount: network.minDepositAmount,
+        // Seed balance/price so TokenInput can show them immediately.
+        balance: network.balance,
+        price: network.price,
     };
 }
 
@@ -67,7 +65,6 @@ function isUsdcSymbol(symbol: string): boolean {
 
 /**
  * Highest USD-value owned network across cached treasury assets.
- * Tokens should already be sorted by totalBalanceUSD desc when from useMergedTokens.
  */
 export function pickHighestUsdOwnedToken(
     tokens: MergedToken[],
@@ -114,7 +111,7 @@ export function pickUsdcNearFromTokens(
 }
 
 /**
- * Default token for Deposit / Payments / Bulk (not Exchange):
+ * Default token for Payments / Bulk / TokenSelect (not Exchange, not Deposit):
  * 1) most USD-valuable owned network from cached assets
  * 2) USDC on NEAR from the available list
  * 3) static USDC-on-NEAR fallback
@@ -123,7 +120,6 @@ export function pickDefaultSelectedToken(
     tokens: MergedToken[],
     options?: {
         disableTokens?: DefaultTokenFilter;
-        isConfidential?: boolean;
     },
 ): SelectedTokenData {
     const owned = pickHighestUsdOwnedToken(tokens, options?.disableTokens);
@@ -132,29 +128,21 @@ export function pickDefaultSelectedToken(
     const usdcNear = pickUsdcNearFromTokens(tokens, options?.disableTokens);
     if (usdcNear) return usdcNear;
 
-    return default_usdc_near_token(options?.isConfidential ?? false);
+    return default_usdc_near_token();
 }
 
-/** True when the selection matches the static USDC-on-NEAR fallback. */
-export function isDefaultUsdcNearSelection(
-    token:
-        | Pick<SelectedTokenData, "address" | "symbol" | "network">
-        | null
-        | undefined,
-    isConfidential: boolean,
-): boolean {
-    if (!token) return false;
-    if (!isUsdcSymbol(token.symbol) || !isNearNetworkName(token.network)) {
-        return false;
-    }
-    const fallback = default_usdc_near_token(isConfidential);
-    const a = canonicalizeTokenIdForMatch(token.address);
-    const b = canonicalizeTokenIdForMatch(fallback.address);
-    // Also accept either public or intents form of the same USDC contract.
-    const accepted = new Set([
-        b,
-        canonicalizeTokenIdForMatch(USDC_NEAR_CONTRACT_ID),
-        canonicalizeTokenIdForMatch(NEP141_USDC_NEAR_ASSET_ID),
-    ]);
-    return accepted.has(a);
+/**
+ * Default deposit asset only (network stays empty for the user to pick):
+ * 1) first of yourAssets (caller must USD-sort)
+ * 2) USDC in allAssets
+ * 3) first available
+ */
+export function pickDefaultDepositAsset<T extends { id: string }>(
+    yourAssets: readonly T[],
+    allAssets: readonly T[],
+): T | undefined {
+    if (yourAssets[0]) return yourAssets[0];
+    const usdc = allAssets.find((asset) => asset.id.toLowerCase() === "usdc");
+    if (usdc) return usdc;
+    return allAssets[0];
 }


### PR DESCRIPTION
#1199 #1174
- Default token picker (payments, bulk, deposit): highest-USD owned asset from cache, else USDC on NEAR (Intents); skeleton while assets load
- Bulk review: network fee folded into amount with info tooltip instead of a per-recipient fee row
- Bulk recipient network: disabled until a recipient address is added
- Fix modal close icon cursor