### PR TITLE
fix: align quote deadlines with DAO proposal period

### DIFF
--- a/nt-be/src/handlers/intents/confidential/bulk_payment_prepare.rs
+++ b/nt-be/src/handlers/intents/confidential/bulk_payment_prepare.rs
@@ -23,12 +23,12 @@
 //! consume a batch-payment credit.
 
 use axum::{Json, extract::State, http::StatusCode};
-use chrono::Duration;
 use near_api::AccountId;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::sync::Arc;
 
+use crate::handlers::intents::quote::quote_deadline_for_dao;
 use crate::handlers::subscription::plans::get_account_plan_info;
 use crate::handlers::treasury::confidential_setup::derive_bulk_subaccount_id;
 use crate::{AppState, auth::AuthUser};
@@ -125,12 +125,6 @@ fn extract_leg_quote(quote_response: &Value, leg: &str) -> Result<LegQuote, (Sta
         amount_out: field("amountOut")?,
         amount_out_formatted: field("amountOutFormatted")?,
     })
-}
-
-/// Default deadline for confidential bulk quotes/intents — long enough that
-/// the proposal can wait through the DAO voting period.
-fn default_deadline() -> chrono::DateTime<chrono::Utc> {
-    chrono::Utc::now() + Duration::hours(24)
 }
 
 /// Build a 1Click quote body for a recipient leg (sub → recipient).
@@ -415,7 +409,8 @@ pub async fn bulk_payment_prepare(
         crate::handlers::intents::confidential::refresh_bulk_dao_jwt(&state, &request.dao_id)
             .await?;
 
-    let deadline = default_deadline()
+    let deadline = quote_deadline_for_dao(&state, &dao_account)
+        .await?
         .format("%Y-%m-%dT%H:%M:%S%.3fZ")
         .to_string();
     let slippage = request.slippage_tolerance.unwrap_or(100);

--- a/nt-be/src/handlers/intents/deposit_address.rs
+++ b/nt-be/src/handlers/intents/deposit_address.rs
@@ -36,13 +36,13 @@ async fn get_confidential_deposit_address(
     mut amount: u128,
 ) -> Result<DepositAddressResult, (StatusCode, String)> {
     let access_token = super::confidential::refresh_dao_jwt(state, account_id).await?;
+    let deadline = super::quote::quote_deadline_for_dao(state, account_id)
+        .await?
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string();
     let account_id = account_id.as_str();
 
     let url = format!("{}/v0/quote", state.env_vars.confidential_api_url);
-
-    let deadline = (chrono::Utc::now() + chrono::Duration::hours(24))
-        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
-        .to_string();
 
     // Try with the FE-provided amount, retrying with 10x increases if too low.
     // Max 5 retries (amount * 10^5) to avoid infinite loops.

--- a/nt-be/src/handlers/intents/quote.rs
+++ b/nt-be/src/handlers/intents/quote.rs
@@ -1,4 +1,5 @@
 use axum::{Json, extract::State, http::StatusCode};
+use near_account_id::AccountIdRef;
 use near_api::AccountId;
 use serde::Deserialize;
 use serde_json::Value;
@@ -7,6 +8,28 @@ use std::sync::Arc;
 
 use crate::AppState;
 use crate::auth::OptionalAuthUser;
+use crate::handlers::treasury::policy::fetch_treasury_policy_cached;
+
+/// Default DAO proposal period (7 days) used when policy is unavailable.
+const DEFAULT_PROPOSAL_PERIOD_NS: u64 = 604_800_000_000_000;
+
+/// Quote deadline aligned with the DAO's proposal voting period.
+pub async fn quote_deadline_for_dao(
+    state: &Arc<AppState>,
+    dao_id: &AccountIdRef,
+) -> Result<chrono::DateTime<chrono::Utc>, (StatusCode, String)> {
+    let policy = fetch_treasury_policy_cached(state, dao_id, None).await?;
+    let period_ns = policy
+        .get("proposal_period")
+        .and_then(|v| {
+            v.as_str()
+                .and_then(|s| s.parse::<u64>().ok())
+                .or_else(|| v.as_u64())
+        })
+        .unwrap_or(DEFAULT_PROPOSAL_PERIOD_NS);
+    let period_ms = (period_ns / 1_000_000) as i64;
+    Ok(chrono::Utc::now() + chrono::Duration::milliseconds(period_ms))
+}
 
 /// Quote request body - matches 1click API /v0/quote
 /// Client-provided appFees and referral are ignored and overridden by server config

--- a/nt-be/src/handlers/proposals/scraper.rs
+++ b/nt-be/src/handlers/proposals/scraper.rs
@@ -400,48 +400,25 @@ fn get_current_time_nanos() -> U64 {
     U64::from(nanos as u64)
 }
 
-fn is_short_expiry_exchange(proposal: &Proposal) -> bool {
-    // First, gate short-expiry logic to exchange proposals only.
-    if AssetExchangeInfo::from_proposal(proposal).is_none() {
-        return false;
-    }
-
-    let Some(function_call) = proposal.kind.get("FunctionCall") else {
-        return false;
+/// Effective expiry = min(voting period end, quoteDeadline from description).
+/// Legacy exchange quotes stored a 24h deadline in `quoteDeadline`; new quotes
+/// align with proposal_period, so this remains correct for both.
+fn get_effective_expiration_time_ns(proposal: &Proposal, submission_time: u64, period: u64) -> u64 {
+    let by_period = submission_time.saturating_add(period);
+    let Some(deadline_str) = extract_from_description(&proposal.description, "quoteDeadline")
+    else {
+        return by_period;
     };
 
-    let receiver_id = function_call
-        .get("receiver_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let actions = function_call
-        .get("actions")
-        .and_then(|a| a.as_array())
-        .map(|a| a.as_slice())
-        .unwrap_or(&[]);
+    let Ok(deadline) = chrono::DateTime::parse_from_rfc3339(deadline_str.trim()) else {
+        return by_period;
+    };
 
-    // Pure wrap/unwrap (single near_deposit/near_withdraw on wrap.near)
-    // follows normal proposal period, not short expiry.
-    if receiver_id == "wrap.near" && actions.len() == 1 {
-        let method_name = actions[0]
-            .get("method_name")
-            .and_then(|m| m.as_str())
-            .unwrap_or("");
-        if method_name == "near_deposit" || method_name == "near_withdraw" {
-            return false;
-        }
+    let deadline_ns = deadline.timestamp_nanos_opt().unwrap_or(0) as u64;
+    if deadline_ns == 0 {
+        return by_period;
     }
-
-    true
-}
-
-fn get_effective_expiration_period_ns(proposal: &Proposal, period: u64) -> u64 {
-    if !is_short_expiry_exchange(proposal) {
-        return period;
-    }
-
-    // Exchange custom deadline is 24h, capped by proposal period.
-    std::cmp::min(period, 24 * 60 * 60 * 1_000_000_000)
+    by_period.min(deadline_ns)
 }
 
 pub fn get_status_display(
@@ -455,14 +432,13 @@ pub fn get_status_display(
         ProposalStatus::InProgress => {
             let current_time = get_current_time_nanos().0;
 
-            // Exchange proposals use custom 24h expiration, capped by proposal period.
-            let expiration_period = if let Some(p) = proposal {
-                get_effective_expiration_period_ns(p, period)
+            let expiration_time = if let Some(p) = proposal {
+                get_effective_expiration_time_ns(p, submission_time, period)
             } else {
-                period
+                submission_time.saturating_add(period)
             };
 
-            if submission_time + expiration_period < current_time {
+            if expiration_time < current_time {
                 "Expired".to_string()
             } else {
                 pending_label.to_string()

--- a/nt-cli/src/payments/mod.rs
+++ b/nt-cli/src/payments/mod.rs
@@ -886,7 +886,7 @@ fn request_quote(
         .as_deref()
         .and_then(|p| p.parse::<u64>().ok())
         .map(|nanos| nanos / 1_000_000)
-        .unwrap_or(24 * 60 * 60 * 1000);
+        .unwrap_or(7 * 24 * 60 * 60 * 1000); // default DAO proposal period (7 days)
     let deadline = chrono::Utc::now() + chrono::Duration::milliseconds(deadline_ms as i64);
 
     let quote_request = serde_json::json!({

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/components/step2.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/components/step2.tsx
@@ -10,7 +10,6 @@ import { useFormatDate } from "@/components/formatted-date";
 import { InfoDisplay } from "@/components/info-display";
 import { ReviewStep, type StepProps } from "@/components/step-wizard";
 import { Skeleton } from "@/components/ui/skeleton";
-import { WarningAlert } from "@/components/warning-alert";
 import { useTreasury } from "@/hooks/use-treasury";
 import {
     calculateExchangeFeeAmount,
@@ -299,10 +298,6 @@ export function Step2({ handleBack }: StepProps) {
                         </div>
                     </>
                 ) : null}
-
-                <WarningAlert message={tEx("approveWithin24h")} />
-
-                <></>
             </ReviewStep>
 
             <div className="rounded-lg border bg-card p-0 overflow-hidden">

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/hooks/use-exchange-amount-quote.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/hooks/use-exchange-amount-quote.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useDebounce } from "use-debounce";
 import type { UseFormReturn } from "react-hook-form";
+import { useTreasuryPolicy } from "@/hooks/use-treasury-queries";
 import type { ExchangeFormValues } from "../exchange-form";
 import { type ExchangeSwapType, useExchangeQuote } from "./use-exchange-quote";
 import { useFormatQuoteAmount } from "./use-format-quote-amount";
@@ -28,6 +29,9 @@ export function useExchangeAmountQuote({
     isDryRun,
     refetchInterval,
 }: UseExchangeAmountQuoteParams) {
+    const { data: policy } = useTreasuryPolicy(selectedTreasury);
+    const proposalPeriod = policy?.proposal_period;
+
     const sellToken = form.watch("sellToken");
     const receiveToken = form.watch("receiveToken");
     const sellAmount = form.watch("sellAmount");
@@ -70,6 +74,7 @@ export function useExchangeAmountQuote({
         slippageTolerance,
         enabled: Boolean(
             selectedTreasury &&
+                proposalPeriod &&
                 hasValidAmount &&
                 !areSameTokens &&
                 !exchangeSlotBlocked,
@@ -77,6 +82,7 @@ export function useExchangeAmountQuote({
         isDryRun,
         refetchInterval,
         isConfidential,
+        proposalPeriod,
     });
 
     const isDebouncingSource =

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/hooks/use-exchange-quote.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/hooks/use-exchange-quote.ts
@@ -16,6 +16,7 @@ import {
 } from "../utils";
 import { formatQuoteErrorMessage, isAbortError } from "../quote-errors";
 import { NEAR_NETWORK_ID, WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
+import { nanosToMs } from "@/lib/utils";
 
 export type ExchangeSwapType = "EXACT_INPUT" | "EXACT_OUTPUT";
 
@@ -31,6 +32,8 @@ interface UseExchangeQuoteParams {
     isDryRun: boolean;
     refetchInterval: number;
     isConfidential?: boolean;
+    /** DAO proposal_period in nanoseconds — used as the quote deadline. */
+    proposalPeriod?: string;
 }
 
 /**
@@ -48,6 +51,7 @@ export function useExchangeQuote({
     isDryRun,
     refetchInterval,
     isConfidential,
+    proposalPeriod,
 }: UseExchangeQuoteParams) {
     const tEx = useTranslations("exchangeErrors");
     const amountToken = swapType === "EXACT_INPUT" ? sellToken : receiveToken;
@@ -62,9 +66,14 @@ export function useExchangeQuote({
             swapType,
             slippageTolerance,
             isConfidential,
+            proposalPeriod,
         ],
         queryFn: async ({ signal }): Promise<IntentsQuoteResponse | null> => {
-            if (!selectedTreasury) return null;
+            if (!selectedTreasury || !proposalPeriod) return null;
+
+            const deadline = new Date(
+                Date.now() + nanosToMs(proposalPeriod),
+            ).toISOString();
 
             try {
                 const isDeposit = isNEARDeposit(sellToken, receiveToken);
@@ -95,12 +104,8 @@ export function useExchangeQuote({
                             minAmountOut: amountInRaw,
                             timeEstimate: 0,
                             depositAddress: selectedTreasury,
-                            deadline: new Date(
-                                Date.now() + 24 * 60 * 60 * 1000,
-                            ).toISOString(),
-                            timeWhenInactive: new Date(
-                                Date.now() + 24 * 60 * 60 * 1000,
-                            ).toISOString(),
+                            deadline,
+                            timeWhenInactive: deadline,
                         },
                         quoteRequest: {
                             swapType,
@@ -117,9 +122,7 @@ export function useExchangeQuote({
                             refundType: "DESTINATION_CHAIN",
                             recipient: selectedTreasury,
                             recipientType: "DESTINATION_CHAIN",
-                            deadline: new Date(
-                                Date.now() + 24 * 60 * 60 * 1000,
-                            ).toISOString(),
+                            deadline,
                         },
                         signature: "",
                         timestamp: new Date().toISOString(),
@@ -157,9 +160,7 @@ export function useExchangeQuote({
                         refundType: depositAndRefundType,
                         recipient: selectedTreasury,
                         recipientType: recipientType,
-                        deadline: new Date(
-                            Date.now() + 24 * 60 * 60 * 1000,
-                        ).toISOString(),
+                        deadline,
                         quoteWaitingTimeMs: isDryRun ? 0 : 3000,
                     },
                     isDryRun,
@@ -175,7 +176,7 @@ export function useExchangeQuote({
                 );
             }
         },
-        enabled,
+        enabled: enabled && !!proposalPeriod,
         refetchInterval,
         staleTime: refetchInterval,
         refetchIntervalInBackground: false,

--- a/nt-fe/app/(treasury)/[treasuryId]/exchange/utils/proposal-builder.ts
+++ b/nt-fe/app/(treasury)/[treasuryId]/exchange/utils/proposal-builder.ts
@@ -48,7 +48,9 @@ export function buildProposalDescription(
     receiveToken: Token,
     slippageTolerance: number,
 ): string {
-    const deadline = proposalData.quote.deadline;
+    // Use quoteRequest.deadline (voting-period aligned). quote.deadline from
+    // 1Click can be a longer deposit-address window and must not drive UI expiry.
+    const deadline = proposalData.quoteRequest.deadline;
     return encodeToMarkdown({
         proposal_action: "asset-exchange",
         notes: `**Must be executed before ${deadline}** for transferring tokens to 1Click's deposit address for swap execution.`,

--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -1089,6 +1089,10 @@ export default function PaymentsPage() {
             let proposalKind: FunctionCallKind | TransferKind;
 
             if (shouldUseIntents) {
+                const proposalPeriod = policy?.proposal_period;
+                if (!proposalPeriod) {
+                    throw new Error(tPay("failed1ClickQuote"));
+                }
                 const quoteAmountDecimals = getDestinationAmountDecimals(
                     tokenClassification.tokenForIntentsQuote,
                     data.destinationNetwork,
@@ -1123,7 +1127,7 @@ export default function PaymentsPage() {
                             trimmedAddress,
                             quoteAmount,
                             isConfidential,
-                            policy?.proposal_period,
+                            proposalPeriod,
                             undefined,
                             data.destinationNetwork,
                             true, // isPayment

--- a/nt-fe/features/proposals/components/expanded-view/batch-payment-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/batch-payment-expanded.tsx
@@ -204,9 +204,11 @@ interface BatchPaymentExpandedViewProps {
      */
     batchId?: string | null;
     /**
-     * Pre-computed total network fee in smallest units. Confidential bulk
-     * passes the sum of `(amountIn - minAmountOut)` from each recipient's
+     * Pre-computed total network fee in human-readable token units.
+     * Confidential bulk passes the sum of
+     * `(amountInFormatted - amountOutFormatted)` from each recipient's
      * stored 1Click quote — the actual fee the DAO already committed to.
+     * Formatted amounts are required when origin/destination decimals differ.
      * When provided, skips the live SDK estimate.
      */
     totalNetworkFeeOverride?: string | null;
@@ -282,14 +284,12 @@ export function BatchPaymentExpandedView({
         isIntentsCrossChainToken &&
         !hasFeeError &&
         !!dynamicFeeData?.networkFee;
-    // Confidential bulk passes a pre-summed override (smallest units, decoded
-    // to the token's display scale here). Public bulk falls back to the live
+    // Confidential bulk passes a pre-summed override already in token units
+    // (from formatted quote amounts). Public bulk falls back to the live
     // SDK estimate × recipient count.
     const totalNetworkFee = skipLiveFee
         ? Big(totalNetworkFeeOverride).gt(0)
-            ? Big(totalNetworkFeeOverride).div(
-                  Big(10).pow(tokenData?.decimals ?? 0),
-              )
+            ? Big(totalNetworkFeeOverride)
             : null
         : hasLiveFeeData
           ? Big(dynamicFeeData.networkFee).mul(payments.length)

--- a/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/common/proposal-sidebar.tsx
@@ -25,11 +25,11 @@ import type { PaymentRequestData } from "@/features/proposals/types/index";
 import { useProposalInsufficientBalance } from "@/features/proposals/hooks/use-proposal-insufficient-balance";
 import { extractProposalData } from "@/features/proposals/utils/proposal-extractors";
 import {
-    EXCHANGE_EXPIRY_MS,
+    getEffectiveExpiryMs,
     getProposalStatus,
     getProposalStatusDateInfo,
     getProposalUIKind,
-    isShortExpiryExchangeProposal,
+    isQuoteDeadlineBeforeVotingPeriod,
     type UIProposalStatus,
 } from "@/features/proposals/utils/proposal-utils";
 import {
@@ -45,10 +45,14 @@ import {
 import { useTreasury } from "@/hooks/use-treasury";
 import { useProposalApproveBlock } from "@/hooks/use-warnings";
 import { isNearComPaymentRoute } from "@/lib/intents-network";
-import Big from "@/lib/big";
 import { getApproversAndThreshold } from "@/lib/config-utils";
 import type { Proposal } from "@/lib/proposals-api";
-import { cn, getIntentsExplorerUrl, nanosToMs } from "@/lib/utils";
+import {
+    cn,
+    decodeProposalDescription,
+    getIntentsExplorerUrl,
+    nanosToMs,
+} from "@/lib/utils";
 import { useNear } from "@/stores/near-store";
 import type { Policy } from "@/types/policy";
 import { NotEnoughBalance } from "../../not-enough-balance";
@@ -440,17 +444,12 @@ export function ProposalSidebar({
             ? !isConfidential
             : isConfidentialRequestProposal || receiptProposalData !== null);
 
-    const expiresAt = new Date(
-        nanosToMs(
-            Big(proposal.submission_time)
-                .add(policy.proposal_period)
-                .toFixed(0),
-        ),
-    );
+    const expiresAt = new Date(getEffectiveExpiryMs(proposal, policy));
     const statusDateInfo = getProposalStatusDateInfo(proposal, policy);
-    const shortExpiryExchange =
-        isShortExpiryExchangeProposal(proposal) &&
-        nanosToMs(policy.proposal_period) > EXCHANGE_EXPIRY_MS;
+    const shortQuoteDeadline = isQuoteDeadlineBeforeVotingPeriod(
+        proposal,
+        policy,
+    );
 
     let timestamp;
     switch (status) {
@@ -639,8 +638,8 @@ export function ProposalSidebar({
                 </>
             )}
 
-            {/* Short-Expiry Warning (exchange proposals only) */}
-            {isPending && shortExpiryExchange && (
+            {/* Short quote deadline warning (legacy 24h quotes) */}
+            {isPending && shortQuoteDeadline && (
                 <InfoAlert
                     className="inline-flex"
                     message={

--- a/nt-fe/features/proposals/components/expanded-view/confidential-bulk-expanded.tsx
+++ b/nt-fe/features/proposals/components/expanded-view/confidential-bulk-expanded.tsx
@@ -1,8 +1,10 @@
 import { ConfidentialBulkData } from "../../types/index";
 import { BatchPayment, PaymentStatus } from "@/lib/api";
 import { BatchPaymentExpandedView } from "./batch-payment-expanded";
-import Big from "@/lib/big";
-import { mapConfidentialBulkRecipientPayment } from "../../utils/confidential-bulk-utils";
+import {
+    mapConfidentialBulkRecipientPayment,
+    sumConfidentialBulkNetworkFee,
+} from "../../utils/confidential-bulk-utils";
 import { useRequestDisplayContext } from "./common/request-display-context";
 
 interface ConfidentialBulkExpandedProps {
@@ -18,10 +20,11 @@ interface ConfidentialBulkExpandedProps {
  * Header total + token come from the parent extractor (header quote).
  * Recipient amount/recipient come from each leg's stored 1Click quote.
  *
- * Per-leg fee = `amountIn - amountOut` from the stored quote — the actual
- * withdrawal fee committed at prepare time. Summed across recipients and
- * passed as the override so the row reflects what the DAO is really paying,
- * not a fresh SDK estimate.
+ * Per-leg fee = `amountInFormatted - amountOutFormatted` from the stored
+ * quote (human-readable token units) — same as Review / single confidential
+ * payment. Raw smallest-unit diffs are wrong when origin and destination
+ * decimals differ. Summed across recipients and passed as the override so
+ * the row reflects what the DAO committed at prepare time.
  */
 export function ConfidentialBulkExpanded({
     data,
@@ -30,19 +33,15 @@ export function ConfidentialBulkExpanded({
     const requestDisplayContext = useRequestDisplayContext();
     const isExecuted = requestDisplayContext?.isExecuted ?? false;
 
-    let totalFeeRaw = Big(0);
+    const totalNetworkFee = sumConfidentialBulkNetworkFee(data.recipients);
     const payments: BatchPayment[] = data.recipients.map((r) => {
-        const { recipient, amountIn, amountOut } =
-            mapConfidentialBulkRecipientPayment(r.quoteMetadata);
+        const { recipient, amountOut } = mapConfidentialBulkRecipientPayment(
+            r.quoteMetadata,
+        );
         const isPaid = r.status === "submitted";
         const status: PaymentStatus = isPaid
             ? { Paid: { block_height: 0 } }
             : "Pending";
-
-        const legFee = Big(amountIn).minus(amountOut);
-        if (legFee.gt(0)) {
-            totalFeeRaw = totalFeeRaw.add(legFee);
-        }
 
         return { recipient, amount: amountOut, status };
     });
@@ -58,7 +57,7 @@ export function ConfidentialBulkExpanded({
             showReceiptButton={isExecuted}
             destinationAssetId={data.destinationAssetId}
             totalNetworkFeeOverride={
-                totalFeeRaw.gt(0) ? totalFeeRaw.toFixed(0) : null
+                totalNetworkFee.gt(0) ? totalNetworkFee.toFixed() : null
             }
         />
     );

--- a/nt-fe/features/proposals/components/voting-duration-impact-modal.tsx
+++ b/nt-fe/features/proposals/components/voting-duration-impact-modal.tsx
@@ -18,9 +18,8 @@ import { Alert, AlertDescription } from "@/components/alert";
 import { ProposalTypeIcon } from "@/features/proposals/components/proposal-type-icon";
 import { TransactionCell } from "@/features/proposals/components/transaction-cell";
 import {
-    EXCHANGE_EXPIRY_MS,
+    getQuoteDeadlineMs,
     getProposalUIKind,
-    isShortExpiryExchangeProposal,
 } from "@/features/proposals/utils/proposal-utils";
 import { useProposalKindLabel } from "@/features/proposals/hooks/use-proposal-kind-label";
 import { FormattedDate } from "@/components/formatted-date";
@@ -73,23 +72,15 @@ export function VotingDurationImpactModal({
         return activeProposals
             .map((proposal): ProposalImpact => {
                 const submissionTimeMs = nanosToMs(proposal.submission_time);
-                const isShortExpiryExchange =
-                    isShortExpiryExchangeProposal(proposal);
-
-                // Short-expiry exchanges are unaffected by
-                // voting-duration policy changes.
-                const oldExpiryDate = new Date(
-                    isShortExpiryExchange
-                        ? submissionTimeMs +
-                              Math.min(currentDurationMs, EXCHANGE_EXPIRY_MS)
-                        : submissionTimeMs + currentDurationMs,
-                );
-                const newExpiryDate = new Date(
-                    isShortExpiryExchange
-                        ? submissionTimeMs +
-                              Math.min(newDurationMs, EXCHANGE_EXPIRY_MS)
-                        : submissionTimeMs + newDurationMs,
-                );
+                const quoteDeadlineMs = getQuoteDeadlineMs(proposal);
+                const cappedExpiry = (periodMs: number) => {
+                    const byPeriod = submissionTimeMs + periodMs;
+                    return quoteDeadlineMs === undefined
+                        ? byPeriod
+                        : Math.min(byPeriod, quoteDeadlineMs);
+                };
+                const oldExpiryDate = new Date(cappedExpiry(currentDurationMs));
+                const newExpiryDate = new Date(cappedExpiry(newDurationMs));
 
                 const wasExpiredBefore = oldExpiryDate.getTime() <= now;
                 const willBeExpiredAfter = newExpiryDate.getTime() <= now;

--- a/nt-fe/features/proposals/utils/confidential-bulk-utils.ts
+++ b/nt-fe/features/proposals/utils/confidential-bulk-utils.ts
@@ -1,9 +1,12 @@
+import Big from "@/lib/big";
 import { NEAR_COM_NETWORK_ID } from "@/constants/network-ids";
 
 type BulkQuoteMetadata = {
     quote?: {
         amountIn?: string;
+        amountInFormatted?: string;
         amountOut?: string;
+        amountOutFormatted?: string;
     };
     quoteRequest?: {
         recipient?: string;
@@ -14,10 +17,14 @@ type BulkQuoteMetadata = {
 
 export interface ConfidentialBulkRecipientLeg {
     recipient: string;
-    /** Gross amount charged for this leg (quote amountIn). */
+    /** Gross amount charged for this leg (quote amountIn, smallest units). */
     amountIn: string;
     /** Recipient net amount in smallest units (quote amountOut). */
     amountOut: string;
+    /** Gross amount charged for this leg, human-readable token units. */
+    amountInFormatted: string;
+    /** Recipient net amount, human-readable token units. */
+    amountOutFormatted: string;
 }
 
 /**
@@ -30,8 +37,46 @@ export function mapConfidentialBulkRecipientPayment(
     const quote = (quoteMetadata ?? {}) as BulkQuoteMetadata;
     const amountIn = quote.quote?.amountIn ?? "0";
     const amountOut = quote.quote?.amountOut ?? amountIn;
+    const amountInFormatted = quote.quote?.amountInFormatted ?? "0";
+    const amountOutFormatted =
+        quote.quote?.amountOutFormatted ?? amountInFormatted;
     const recipient = quote.quoteRequest?.recipient ?? "";
-    return { recipient, amountIn, amountOut };
+    return {
+        recipient,
+        amountIn,
+        amountOut,
+        amountInFormatted,
+        amountOutFormatted,
+    };
+}
+
+/**
+ * Sum per-recipient network fees from stored 1Click quotes, in human-readable
+ * token units. Diffs `*Formatted` amounts (not raw smallest units) so origin
+ * and destination chain decimals cannot skew the fee — same approach as the
+ * Review-step `deriveQuoteFees` and single-payment `computeQuoteNetworkFee`.
+ */
+export function sumConfidentialBulkNetworkFee(
+    recipients: Array<{
+        quoteMetadata?: Record<string, unknown> | null;
+    }>,
+): Big {
+    let total = Big(0);
+    for (const recipient of recipients) {
+        const { amountInFormatted, amountOutFormatted } =
+            mapConfidentialBulkRecipientPayment(recipient.quoteMetadata);
+        try {
+            const legFee = Big(amountInFormatted || "0").minus(
+                Big(amountOutFormatted || "0"),
+            );
+            if (legFee.gt(0)) {
+                total = total.add(legFee);
+            }
+        } catch {
+            // Ignore malformed quote amounts for a single leg.
+        }
+    }
+    return total;
 }
 
 /**

--- a/nt-fe/features/proposals/utils/proposal-extractors.ts
+++ b/nt-fe/features/proposals/utils/proposal-extractors.ts
@@ -929,7 +929,7 @@ export function extractConfidentialRequestData(
                     slippage: (
                         (quoteRequest.slippageTolerance ?? 0) / 100
                     ).toString(),
-                    quoteDeadline: quote.deadline,
+                    quoteDeadline: quoteRequest.deadline,
                 } as SwapRequestData,
             };
             title = "Confidential Exchange";

--- a/nt-fe/features/proposals/utils/proposal-utils.ts
+++ b/nt-fe/features/proposals/utils/proposal-utils.ts
@@ -14,11 +14,6 @@ import { decodeArgs, decodeProposalDescription, nanosToMs } from "@/lib/utils";
 import { extractProposalData } from "./proposal-extractors";
 import { WRAP_NEAR_TOKEN_ID } from "@/constants/network-ids";
 
-// Exchange custom deadline (capped by proposal_period).
-// Pure wrap/unwrap (single wrap.near near_deposit/near_withdraw) uses normal proposal period.
-export const EXCHANGE_EXPIRY_HOURS = 24;
-export const EXCHANGE_EXPIRY_MS = EXCHANGE_EXPIRY_HOURS * 60 * 60 * 1000; // 24 hours in milliseconds
-
 const BULK_PAYMENT_CONTRACT_ID =
     process.env.NEXT_PUBLIC_BULK_PAYMENT_CONTRACT_ID || "bulkpayment.near";
 
@@ -316,43 +311,50 @@ export type UIProposalStatus =
     | "Removed"
     | "Moved";
 
-function isNormalPeriodWrapProposal(proposal: Proposal): boolean {
-    if (!("FunctionCall" in proposal.kind)) return false;
-
-    const functionCall = proposal.kind.FunctionCall;
-    const actions = functionCall.actions ?? [];
-
-    if (
-        functionCall.receiver_id !== WRAP_NEAR_TOKEN_ID ||
-        actions.length !== 1
-    ) {
-        return false;
-    }
-
-    const methodName = actions[0]?.method_name;
-    return methodName === "near_deposit" || methodName === "near_withdraw";
+/** ISO quote deadline from proposal description, when present. */
+export function getQuoteDeadlineMs(proposal: Proposal): number | undefined {
+    const raw = decodeProposalDescription(
+        "quoteDeadline",
+        proposal.description,
+    );
+    if (!raw || typeof raw !== "string") return undefined;
+    const ms = Date.parse(raw);
+    return Number.isFinite(ms) ? ms : undefined;
 }
 
-export function isShortExpiryExchangeProposal(proposal: Proposal): boolean {
-    const isExchangeProposal = getProposalUIKind(proposal) === "Exchange";
-    return isExchangeProposal && !isNormalPeriodWrapProposal(proposal);
-}
-
-function getEffectiveExpiryPeriodMs(
+/**
+ * Effective UI expiry: min(voting period end, quoteDeadline).
+ * Older quotes used a 24h deadline stored in the description; new quotes
+ * align with proposal_period, so this stays correct for both.
+ */
+export function getEffectiveExpiryMs(
     proposal: Proposal,
     policy: Policy,
 ): number {
-    const proposalPeriodMs = nanosToMs(policy.proposal_period);
-    if (!isShortExpiryExchangeProposal(proposal)) return proposalPeriodMs;
-    return Math.min(proposalPeriodMs, EXCHANGE_EXPIRY_MS);
+    const byPeriod =
+        nanosToMs(proposal.submission_time) + nanosToMs(policy.proposal_period);
+    const quoteDeadlineMs = getQuoteDeadlineMs(proposal);
+    if (quoteDeadlineMs === undefined) return byPeriod;
+    return Math.min(byPeriod, quoteDeadlineMs);
+}
+
+/** True when the quote expires meaningfully sooner than the voting period. */
+export function isQuoteDeadlineBeforeVotingPeriod(
+    proposal: Proposal,
+    policy: Policy,
+): boolean {
+    const quoteDeadlineMs = getQuoteDeadlineMs(proposal);
+    if (quoteDeadlineMs === undefined) return false;
+    const byPeriod =
+        nanosToMs(proposal.submission_time) + nanosToMs(policy.proposal_period);
+    // Ignore small gaps from quote-time → submit-time lag on new proposals.
+    return byPeriod - quoteDeadlineMs > 2 * 60 * 60 * 1000;
 }
 
 export function getProposalStatus(
     proposal: Proposal,
     policy: Policy,
 ): UIProposalStatus {
-    const submissionTimeMs = nanosToMs(proposal.submission_time);
-
     switch (proposal.status) {
         case "Approved":
             return "Executed";
@@ -361,11 +363,7 @@ export function getProposalStatus(
         case "Failed":
             return "Failed";
         case "InProgress":
-            if (
-                submissionTimeMs +
-                    getEffectiveExpiryPeriodMs(proposal, policy) <
-                Date.now()
-            ) {
+            if (getEffectiveExpiryMs(proposal, policy) < Date.now()) {
                 return "Expired";
             }
 
@@ -392,10 +390,11 @@ export function getProposalStatusDateInfo(
     const uiStatus = getProposalStatus(proposal, policy);
 
     if (uiStatus === "Pending") {
-        const expiryDate = new Date(
-            submissionTimeMs + getEffectiveExpiryPeriodMs(proposal, policy),
-        );
-        return { date: expiryDate, isFuture: true, labelKey: "expires" };
+        return {
+            date: new Date(getEffectiveExpiryMs(proposal, policy)),
+            isFuture: true,
+            labelKey: "expires",
+        };
     }
 
     // For all resolved statuses, use submission_time as a fallback since
@@ -422,11 +421,8 @@ export function getProposalStatusDateInfo(
                 labelKey: "created",
             };
         case "Expired": {
-            const expiredDate = new Date(
-                submissionTimeMs + getEffectiveExpiryPeriodMs(proposal, policy),
-            );
             return {
-                date: expiredDate,
+                date: new Date(getEffectiveExpiryMs(proposal, policy)),
                 isFuture: false,
                 labelKey: "expired",
             };

--- a/nt-fe/hooks/use-intents-quote.ts
+++ b/nt-fe/hooks/use-intents-quote.ts
@@ -37,14 +37,12 @@ export function buildIntentsQuoteRequest(
     address: string,
     parsedAmount: string,
     isConfidential: boolean,
-    proposalPeriod?: string,
+    proposalPeriod: string,
     amountMode: IntentsAmountMode = "recipient",
     destinationNetwork?: string,
     isPayment: boolean = false,
 ) {
-    const deadlineMs = proposalPeriod
-        ? nanosToMs(proposalPeriod)
-        : 24 * 60 * 60 * 1000;
+    const deadlineMs = nanosToMs(proposalPeriod);
 
     // ORIGIN_CHAIN for native-NEAR/NEAR-FT tokens (funds arrive via ft_transfer
     // on the NEAR blockchain).  INTENTS for Intents tokens (funds arrive via


### PR DESCRIPTION
#1193
- Quote requests (exchange, payments, confidential bulk, deposit) now set deadline from the DAO `proposal_period`
- Public exchange proposals store `quoteRequest.deadline` in the description (not 1Click’s longer `quote.deadline` deposit window)
- Remove hardcoded 24h exchange short-expiry; effective expiry is `min(voting period, quoteDeadline)` so legacy 24h proposals still expire correctly
- Aligned bulk Review step with single confidential payment: fee is now amountInFormatted - amountOutFormatted, summed across recipient legs, to avoid different decimals issue #1191