### PR TITLE
fix: restore EXACT_INPUT for payment MAX and floor displayed balances

### DIFF
--- a/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
+++ b/nt-fe/app/(treasury)/[treasuryId]/payments/page.tsx
@@ -66,19 +66,20 @@ import { Address } from "@/components/address";
 import {
     useIntentsQuote,
     buildIntentsQuoteRequest,
+    type IntentsAmountMode,
 } from "@/hooks/use-intents-quote";
 import { getNearComChainIcons, isNearComNetwork } from "@/lib/intents-network";
 import { parseTokenQueryParam } from "@/lib/token-query-param";
 import {
     cn,
     encodeToMarkdown,
-    formatBalance,
     formatCurrency,
     formatTokenDisplayAmount,
 } from "@/lib/utils";
 import { findBridgeAssetForToken } from "@/lib/bridge-asset-resolver";
 import {
     computeQuoteNetworkFee,
+    isIntentsCrossChainToken,
     isIntentsToken,
     isNearChainFtToken,
     isNearChainNativeToken,
@@ -126,6 +127,8 @@ interface Step1Props extends StepProps {
     quoteErrorMessage?: string | null;
     hasRestrictedRecipientError?: boolean;
     ensureQuoteBeforeReview?: () => Promise<boolean>;
+    onAmountInput?: () => void;
+    onMaxSet?: (maxAmount: string) => void;
     onAddressBookSelectionChange?: (isFromAddressBook: boolean) => void;
     bridgeAssets?: BridgeAsset[];
     isBridgeAssetsLoading?: boolean;
@@ -142,6 +145,8 @@ function Step1({
     quoteErrorMessage,
     hasRestrictedRecipientError,
     ensureQuoteBeforeReview,
+    onAmountInput,
+    onMaxSet,
     onAddressBookSelectionChange,
     bridgeAssets = [],
     isBridgeAssetsLoading = false,
@@ -242,11 +247,14 @@ function Step1({
                     destinationNetworkName="destinationNetwork"
                     destinationNetworkNameFieldName="destinationNetworkName"
                     feeErrorMessage={feeErrorMessage || quoteErrorMessage}
+                    networkFee={networkFee}
                     showRestrictedRecipientAlert={!!hasRestrictedRecipientError}
                     saveButtonText={saveButtonText}
                     slotBlocked={paymentsSlotBlocked}
                     onSave={handleSave}
                     isSubmitting={isFeeLoading}
+                    onAmountInput={onAmountInput}
+                    onMaxSet={onMaxSet}
                     onAddressBookSelectionChange={onAddressBookSelectionChange}
                     bridgeAssets={bridgeAssets}
                     isBridgeAssetsLoading={isBridgeAssetsLoading}
@@ -490,25 +498,25 @@ type PaymentTokenClassification = {
     tokenForIntentsQuote: Token;
 };
 
-// 1Click expects `amount` in destination-asset base units for EXACT_OUTPUT.
-// Some routes have mixed token decimals across networks (e.g. 18 vs 24), so
-// we resolve decimals from the selected destination network to avoid
-// under/over-scaling the quote request amount.
-function getDestinationAmountDecimals(
+/** Decimals for the quote `amount`: destination asset for EXACT_OUTPUT, origin for EXACT_INPUT. */
+function getQuoteAmountDecimals(
     token: Token,
     destinationNetwork: string | undefined,
+    amountMode: IntentsAmountMode,
     bridgeAssets: BridgeAsset[],
 ): number | undefined {
-    if (!destinationNetwork || isNearComNetwork(destinationNetwork)) {
+    // EXACT_INPUT (MAX) and near.com routes use the origin token's decimals.
+    if (
+        amountMode !== "recipient" ||
+        !destinationNetwork ||
+        isNearComNetwork(destinationNetwork)
+    ) {
         return token.decimals;
     }
 
     const bridgeAsset = findBridgeAssetForToken(bridgeAssets, token);
-    const destination = bridgeAsset?.networks.find(
-        (network) => network.id === destinationNetwork,
-    );
-
-    return destination?.decimals;
+    return bridgeAsset?.networks.find((n) => n.id === destinationNetwork)
+        ?.decimals;
 }
 
 function classifyPaymentToken(
@@ -642,12 +650,14 @@ function buildQuoteContextKey(params: {
     amount: string;
     address: string;
     destinationNetwork?: string;
+    amountMode: IntentsAmountMode;
 }) {
     return [
         params.tokenAddress,
         params.amount.trim(),
         params.address.trim().toLowerCase(),
         params.destinationNetwork ?? "",
+        params.amountMode,
     ].join("|");
 }
 
@@ -679,6 +689,9 @@ export default function PaymentsPage() {
     const autoSelectedTokenKeyRef = useRef<string | null>(null);
     // Cached quote + context key — avoids re-fetching while preventing stale reuse.
     const cachedQuoteRef = useRef<CachedQuote | null>(null);
+    /** `"recipient"` = EXACT_OUTPUT (typed); `"total"` = EXACT_INPUT (MAX, fees included). */
+    const [intentsAmountMode, setIntentsAmountMode] =
+        useState<IntentsAmountMode>("recipient");
     const [isAddressBookRecipientSelected, setIsAddressBookRecipientSelected] =
         useState(false);
 
@@ -835,23 +848,32 @@ export default function PaymentsPage() {
                 amount: watchedAmount ?? "",
                 address: watchedAddress ?? "",
                 destinationNetwork: watchedDestinationNetwork,
+                amountMode: intentsAmountMode,
             }),
         [
             quoteToken.address,
             watchedAmount,
             watchedAddress,
             watchedDestinationNetwork,
+            intentsAmountMode,
         ],
     );
 
-    const destinationAmountDecimals = useMemo(
+    const isCrossChainIntentsToken = isIntentsCrossChainToken(watchedToken);
+    const quoteAmountDecimals = useMemo(
         () =>
-            getDestinationAmountDecimals(
+            getQuoteAmountDecimals(
                 quoteToken,
                 watchedDestinationNetwork,
+                intentsAmountMode,
                 bridgeAssets,
             ),
-        [bridgeAssets, quoteToken, watchedDestinationNetwork],
+        [
+            bridgeAssets,
+            intentsAmountMode,
+            quoteToken,
+            watchedDestinationNetwork,
+        ],
     );
 
     // ── Live quote (drives step-1 fee preview & step-2 review) ───────────────
@@ -870,10 +892,11 @@ export default function PaymentsPage() {
         treasuryId,
         token: quoteToken,
         amount: watchedAmount,
-        destinationAmountDecimals,
+        destinationAmountDecimals: quoteAmountDecimals,
         address: watchedAddress,
         isConfidential,
         proposalPeriod: policy?.proposal_period,
+        amountMode: intentsAmountMode,
         destinationNetwork: watchedDestinationNetwork,
         isPayment: true,
         // Paused payment (critical warning on token/network or app-wide): don't
@@ -886,6 +909,10 @@ export default function PaymentsPage() {
         const fee = computeQuoteNetworkFee(liveQuote.quote);
         return fee ? fee.replaceAll(",", "") : null;
     }, [liveQuote]);
+
+    // Typed amounts treat fee as additive; MAX (EXACT_INPUT) already includes it.
+    const balanceCheckNetworkFee =
+        intentsAmountMode === "total" ? null : paymentNetworkFee;
 
     // Keep the quote ref in sync so onSubmit can use it without re-fetching.
     useEffect(() => {
@@ -903,6 +930,7 @@ export default function PaymentsPage() {
         watchedAmount,
         watchedAddress,
         watchedDestinationNetwork,
+        intentsAmountMode,
     ]);
 
     // Clear stale quote-related manual errors as soon as the user changes any
@@ -918,6 +946,7 @@ export default function PaymentsPage() {
         watchedAmount,
         watchedAddress,
         watchedDestinationNetwork,
+        intentsAmountMode,
     ]);
 
     const isQuoteBusy =
@@ -961,6 +990,7 @@ export default function PaymentsPage() {
             amount: formValues.amount ?? "",
             address: formValues.address ?? "",
             destinationNetwork: formValues.destinationNetwork,
+            amountMode: intentsAmountMode,
         });
         const result = await ensureBeforeReview({
             token: quoteToken,
@@ -988,7 +1018,17 @@ export default function PaymentsPage() {
             }
         }
         return false;
-    }, [ensureBeforeReview, form, quoteToken]);
+    }, [ensureBeforeReview, form, quoteToken, intentsAmountMode]);
+
+    const handleAmountInput = useCallback(() => {
+        setIntentsAmountMode("recipient");
+    }, []);
+
+    const handleMaxSet = useCallback(() => {
+        if (isCrossChainIntentsToken) {
+            setIntentsAmountMode("total");
+        }
+    }, [isCrossChainIntentsToken]);
 
     // ── Effects ───────────────────────────────────────────────────────────────
 
@@ -1022,6 +1062,12 @@ export default function PaymentsPage() {
             shouldValidate: true,
         });
     }, [defaultAddress, watchedDestinationNetwork, form]);
+
+    useEffect(() => {
+        if (!isCrossChainIntentsToken) {
+            setIntentsAmountMode("recipient");
+        }
+    }, [isCrossChainIntentsToken]);
 
     useEffect(() => {
         if (!compatibleDefaultToken || tokenParam) {
@@ -1089,16 +1135,17 @@ export default function PaymentsPage() {
             let proposalKind: FunctionCallKind | TransferKind;
 
             if (shouldUseIntents) {
-                const quoteAmountDecimals = getDestinationAmountDecimals(
+                const amountDecimals = getQuoteAmountDecimals(
                     tokenClassification.tokenForIntentsQuote,
                     data.destinationNetwork,
+                    intentsAmountMode,
                     bridgeAssets,
                 );
-                if (quoteAmountDecimals === undefined) {
+                if (amountDecimals === undefined) {
                     throw new Error(tPay("failed1ClickQuote"));
                 }
                 const quoteAmount = Big(data.amount)
-                    .mul(Big(10).pow(quoteAmountDecimals))
+                    .mul(Big(10).pow(amountDecimals))
                     .toFixed();
                 const tokenForQuote = tokenClassification.tokenForIntentsQuote;
 
@@ -1109,6 +1156,7 @@ export default function PaymentsPage() {
                     amount: data.amount ?? "",
                     address: trimmedAddress,
                     destinationNetwork: data.destinationNetwork,
+                    amountMode: intentsAmountMode,
                 });
                 const cachedQuote =
                     cachedQuoteRef.current?.key === submitQuoteKey
@@ -1124,7 +1172,7 @@ export default function PaymentsPage() {
                             quoteAmount,
                             isConfidential,
                             policy?.proposal_period,
-                            undefined,
+                            intentsAmountMode,
                             data.destinationNetwork,
                             true, // isPayment
                         ),
@@ -1208,6 +1256,7 @@ export default function PaymentsPage() {
                     });
                     form.reset();
                     cachedQuoteRef.current = null;
+                    setIntentsAmountMode("recipient");
                     setIsAddressBookRecipientSelected(false);
                     setStep(0);
                     triggerPendingTour();
@@ -1227,7 +1276,7 @@ export default function PaymentsPage() {
             {
                 component: Step1,
                 props: {
-                    networkFee: paymentNetworkFee,
+                    networkFee: balanceCheckNetworkFee,
                     isFeeLoading: isQuoteBusy,
                     quoteErrorMessage:
                         isViaIntents && hasLiveQuoteError
@@ -1238,6 +1287,8 @@ export default function PaymentsPage() {
                         hasLiveQuoteError &&
                         hasInvalidRecipientAddressError,
                     ensureQuoteBeforeReview,
+                    onAmountInput: handleAmountInput,
+                    onMaxSet: handleMaxSet,
                     onAddressBookSelectionChange:
                         setIsAddressBookRecipientSelected,
                     bridgeAssets,
@@ -1264,13 +1315,15 @@ export default function PaymentsPage() {
             },
         ],
         [
+            balanceCheckNetworkFee,
             isQuoteBusy,
             isViaIntents,
             hasLiveQuoteError,
             liveQuoteErrorMessage,
             hasInvalidRecipientAddressError,
             ensureQuoteBeforeReview,
-            paymentNetworkFee,
+            handleAmountInput,
+            handleMaxSet,
             liveQuote,
             isLoadingLiveQuote,
             isFetchingLiveQuote,

--- a/nt-fe/lib/utils.ts
+++ b/nt-fe/lib/utils.ts
@@ -449,9 +449,10 @@ export function formatBalance(
     } else {
         parsedBalance = balance;
     }
+    // Round down so the displayed balance never exceeds the true amount.
     return parsedBalance
         .div(Big(10).pow(decimals))
-        .toFixed(displayDecimals, 3)
+        .toFixed(displayDecimals, Big.roundDown)
         .replace(/\.?0+$/, "");
 }
 


### PR DESCRIPTION
- Restore `EXACT_INPUT` (`amountMode: "total"`) when clicking MAX on cross-chain intents payments so the full balance is the spend and fees are included, instead of failing as additive fee on top of MAX #1203 
- Floor (`ROUND_DOWN`) displayed available balances so the UI never overstates holdings; #979